### PR TITLE
chore(desktop): clean up all Rust compiler warnings (12 → 0)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,3 +37,8 @@ ashpd = "0.7"
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+[lints.rust]
+# The `objc` crate's msg_send! macro expands to a `cfg(cargo-clippy)` check;
+# declare it as a known cfg so it doesn't trip the unexpected_cfgs lint.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(cargo-clippy)'] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,9 @@ use tauri::{Emitter, Manager};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+// include_audio/system_audio are part of the frontend wire contract but only
+// used by the recording path, not by still capture — keep them, don't warn.
+#[allow(dead_code)]
 pub struct CaptureOptions {
     pub format: Option<String>,
     pub quality: Option<f32>,
@@ -35,6 +38,9 @@ pub struct Rectangle {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+// video_bitrate/audio_bitrate are accepted from the frontend but not yet
+// threaded into the encoder — reserved config, keep without warning.
+#[allow(dead_code)]
 pub struct RecordOptions {
     pub format: Option<String>,
     pub video_bitrate: Option<u32>,
@@ -82,8 +88,8 @@ pub fn capture_screen_fast(display_id: Option<i32>, fps: u32, bounds: Option<Rec
         // Determine capture region (full screen or bounded region)
         let (region_x, region_y, width, height) = if let Some(rect) = bounds {
             // Scale logical bounds to physical pixels for HiDPI displays
-            let x = ((rect.x as f64 * scale_x).max(0.0) as u32);
-            let y = ((rect.y as f64 * scale_y).max(0.0) as u32);
+            let x = (rect.x as f64 * scale_x).max(0.0) as u32;
+            let y = (rect.y as f64 * scale_y).max(0.0) as u32;
             let w = ((rect.width as f64 * scale_x) as u32).min(full_width - x);
             let h = ((rect.height as f64 * scale_y) as u32).min(full_height - y);
             println!("[Capture] Logical bounds: ({}, {}) {}x{} → Physical: ({}, {}) {}x{}",
@@ -160,7 +166,9 @@ pub fn capture_screen_fast(display_id: Option<i32>, fps: u32, bounds: Option<Rec
     return Err("Platform not supported".to_string());
 }
 
-// Internal helper for recording (not exposed as command)
+// Internal helper for recording (not exposed as command).
+// Kept as a reference PNG-capture path; recording uses capture_screen_fast.
+#[allow(dead_code)]
 pub fn capture_screen_internal(display_id: Option<i32>) -> Result<Vec<u8>, String> {
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1,14 +1,5 @@
 // src-tauri/src/overlay.rs
 use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewUrl, WebviewWindowBuilder};
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Rectangle {
-    pub x: i32,
-    pub y: i32,
-    pub width: u32,
-    pub height: u32,
-}
 
 /// Pre-create the region-selector overlay window, hidden, at app startup.
 ///

--- a/src-tauri/src/recording.rs
+++ b/src-tauri/src/recording.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 use std::process::Command;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +28,9 @@ pub struct RecordingHandle {
     pub format: Option<String>,
 }
 
+// Several fields snapshot the request for diagnostics/future use; the live
+// recording thread reads the Arc-shared ones. Keep them without warning.
+#[allow(dead_code)]
 struct RecordingState {
     handle: RecordingHandle,
     fps: u32,


### PR DESCRIPTION
## Summary
Zero-warning Rust build for the desktop app. Independent of the in-flight capture PRs (#3, #4) — touches only pre-existing dead code and lint config.

## Changes
- Remove unnecessary parens in `capture_screen_fast`.
- Drop unused `std::path::PathBuf` import.
- Remove the genuinely-dead `overlay::Rectangle` struct (+ its serde import).
- `#[allow(dead_code)]` on frontend-contract fields not yet read in Rust (bitrate + audio flags), `RecordingState` snapshot fields, and the reference `capture_screen_internal` helper.
- Declare `cfg(cargo-clippy)` via `[lints.rust]` check-cfg so the `objc` `msg_send!` macro stops tripping `unexpected_cfgs`.

## Testing
- `cargo build` → 0 warnings; audio unit tests pass. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)