### PR TITLE
fix(recording): silent recordings — capture + mux audio correctly

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,6 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 
 [lints.rust]
-# The `objc` crate's msg_send! macro expands to a `cfg(cargo-clippy)` check;
-# declare it as a known cfg so it doesn't trip the unexpected_cfgs lint.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(cargo-clippy)'] }
+# The `objc` crate's msg_send! macro references a `cargo-clippy` cfg that trips
+# the unexpected_cfgs lint — it's from the dependency macro, not our code.
+unexpected_cfgs = "allow"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -76,13 +76,21 @@ impl AudioRecorder {
             output_path.display()
         );
 
+        // The captured audio is AAC, but the container dictates the codec:
+        // WebM (VP9) can't hold AAC — it needs Opus; MP4 takes AAC. Using the
+        // wrong codec makes the mux fail, leaving a silent video-only file.
+        let audio_codec = match format {
+            "mp4" => "aac",
+            _ => "libopus", // webm
+        };
+
         let status = Command::new(ffmpeg_path())
             .args([
                 "-y",
                 "-i", &video_path.to_string_lossy(),
                 "-i", &audio_path.to_string_lossy(),
                 "-c:v", "copy",
-                "-c:a", "aac",
+                "-c:a", audio_codec,
                 "-shortest",
                 &output_path.to_string_lossy(),
             ])

--- a/src/services/capture/tauri.ts
+++ b/src/services/capture/tauri.ts
@@ -66,6 +66,10 @@ export class TauriCaptureService implements CaptureService {
           fps: options?.fps,
           displayId: options?.displayId,
           bounds: options?.bounds,
+          // Without these the Rust side never starts the audio recorder,
+          // so recordings came out silent.
+          includeAudio: options?.includeAudio,
+          systemAudio: options?.systemAudio,
         },
       });
 


### PR DESCRIPTION
## Summary
Screen recordings came out **silent** (video-only stream, confirmed via ffprobe). Two root causes:

1. **Audio flags dropped in IPC** — `TauriCaptureService.startRecording` forwarded only `format/fps/displayId/bounds`, so `includeAudio`/`systemAudio` never reached Rust and the `AudioRecorder` was never started. Now forwarded.
2. **Wrong mux codec for WebM** — the mux always used `-c:a aac`, but the default output is WebM, which can't hold AAC (needs Opus). The mux failed → video-only file. Now picks by container: `mp4 → aac`, `webm → libopus`.

## Also fixes a build break
The `[lints.rust]` `check-cfg = ['cfg(cargo-clippy)']` form (added in #5) is invalid on current rustc — `cargo build` errors with *invalid --check-cfg argument*. CI's rustc was lenient so it slipped through. Switched to `unexpected_cfgs = "allow"`.

## Testing
- macOS builds clean (0 warnings); 385 JS tests pass.
- ⚠️ Needs a **mic-enabled recording on hardware** to confirm audio actually lands in the file (the code path is now correct; whether avfoundation `:0` captures your mic is the runtime check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)