### PR TITLE
fix(release): defer ffmpeg externalBin + fix deploy OOM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Build
+        env:
+          # The asset-heavy Astro build OOMs on the default ~2 GB Node heap.
+          NODE_OPTIONS: --max-old-space-size=8192
         run: npm run build
 
       - name: Deploy to Cloudflare Pages

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -79,7 +79,6 @@
     "active": true,
     "targets": "all",
     "resources": [],
-    "externalBin": ["bin/ffmpeg"],
     "category": "Utility",
     "shortDescription": "Privacy-first client-side tools",
     "longDescription": "GoodWebTools Desktop brings browser-based tools to your desktop with system-wide capture, global hotkeys, and native file access."


### PR DESCRIPTION
externalBin validates at compile time and broke release + desktop-check. Removed it (kept bundle.active:true); fixed Cloudflare deploy OOM with NODE_OPTIONS. 🤖 Generated with [Claude Code](https://claude.com/claude-code)