### PR TITLE
fix(release): contents:write permission + drop AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    # tauri-action creates the GitHub Release + uploads assets, which needs write.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -77,7 +77,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "app", "dmg", "deb", "appimage"],
+    "targets": ["nsis", "app", "dmg", "deb"],
     "resources": [],
     "category": "Utility",
     "shortDescription": "Privacy-first client-side tools",


### PR DESCRIPTION
Builds succeed but publish failed on missing contents:write; Linux AppImage crashed on icon. Grant permission + drop appimage (deb stays). 🤖 Generated with [Claude Code](https://claude.com/claude-code)