### PR TITLE
fix(build): add .npmrc legacy-peer-deps to unblock Cloudflare deploy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# upscaler/@upscalerjs pin @tensorflow/tfjs to ~4.11 as a peer, but the root uses
+# tfjs ^4.22 (the two are compatible in practice). npm ci enforces peer deps
+# strictly and fails without this — Cloudflare's `npm clean-install` needs it, as
+# do local installs (previously passed via the --legacy-peer-deps flag).
+legacy-peer-deps=true


### PR DESCRIPTION
Cloudflare Workers Builds runs `npm clean-install` (npm ci) with no `--legacy-peer-deps`, so it fails on the pre-existing tfjs/@upscalerjs peer conflict. Adds a committed `.npmrc` (`legacy-peer-deps=true`) so ci resolves it. Verified locally: `npm clean-install` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)