### PR TITLE
feat(analytics): branch-based GA + noindex gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
+# These are auto-set by branch on Cloudflare Workers Builds (see astro.config.mjs):
+#   main branch  → Google Analytics ON,  indexable
+#   other branch → Google Analytics OFF, robots noindex
+# Only set them below to override that locally.
+
 # Google Analytics 4 measurement ID (e.g. G-XXXXXXXXXX). Leave empty to disable.
 # Analytics only loads after the visitor accepts cookies in the consent banner.
 PUBLIC_GA_ID=
 
-# Set to 1 on the STAGING build so pages emit robots noindex (keeps the staging
-# site out of search results). Leave empty/unset for production.
+# Set to 1 to emit robots noindex on every page. Auto-set to 1 for non-main
+# branch builds in CI; leave empty otherwise.
 PUBLIC_NOINDEX=

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,26 @@ import tailwind from '@astrojs/tailwind';
 import AstroPWA from '@vite-pwa/astro';
 import sitemap from '@astrojs/sitemap';
 
+// --- Deploy-context gating ---------------------------------------------------
+// Production and staging share one Cloudflare Worker, so we can't tell them apart
+// by build mode (both run `astro build`). Instead, use the branch that Cloudflare
+// Workers Builds injects (WORKERS_CI_BRANCH) to decide: only the production branch
+// (`main`) loads Google Analytics and is indexable; every other branch (develop /
+// preview builds) runs analytics-free and emits robots `noindex`.
+//
+// Only applied on Workers Builds (WORKERS_CI=1) so local/manual builds keep their
+// existing behavior. An explicitly-set PUBLIC_* env var always wins (overrides).
+const PROD_GA_ID = 'G-4Q9F8CL7FW';
+if (process.env.WORKERS_CI === '1') {
+  const isProductionBranch = (process.env.WORKERS_CI_BRANCH || '') === 'main';
+  if (process.env.PUBLIC_GA_ID === undefined) {
+    process.env.PUBLIC_GA_ID = isProductionBranch ? PROD_GA_ID : '';
+  }
+  if (process.env.PUBLIC_NOINDEX === undefined) {
+    process.env.PUBLIC_NOINDEX = isProductionBranch ? '' : '1';
+  }
+}
+
 export default defineConfig({
   output: 'static',
   // Canonical origin — powers <link rel="canonical">, OG URLs, and the sitemap.


### PR DESCRIPTION
Prod + staging share one Worker, so GA and robots-noindex are now derived from the Cloudflare build branch (`WORKERS_CI_BRANCH`): `main` → GA on + indexable; other branches → GA off + noindex. No per-environment dashboard variables needed. Verified both branches build correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)