### PR TITLE
feat(shell): Settings nav link desktop-only

### DIFF
--- a/src/components/shell/ShellIsland.tsx
+++ b/src/components/shell/ShellIsland.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from './ThemeToggle';
 import { CommandPalette } from './CommandPalette';
 import { Modal } from '@/components/ui/Modal';
 import { initTheme } from '@/stores/theme.store';
+import { isTauri } from '@/services/platform';
 import { REPO_URL } from '@/config';
 
 /** Opens the command palette from a click (works without a keyboard). */
@@ -17,10 +18,15 @@ const iconBtn =
 export function ShellIsland() {
   const [modal, setModal] = useState<null | 'github' | 'bookmark'>(null);
   const [isMac, setIsMac] = useState(true);
+  // Settings only apply to the desktop app; hide the nav link on the web.
+  // Starts false so SSR and the first client render match, then reveals on
+  // desktop after mount (avoids a hydration mismatch).
+  const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
     initTheme();
     setIsMac(/Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent));
+    setIsDesktop(isTauri());
   }, []);
 
   const bookmarkKey = isMac ? '⌘ D' : 'Ctrl + D';
@@ -48,9 +54,11 @@ export function ShellIsland() {
                   <kbd className="border-2 border-border bg-background px-1.5 py-0.5 text-xs">⌘K</kbd> to search
                 </span>
               </button>
-              <a href="/settings" aria-label="Settings" title="Settings" className={iconBtn}>
-                <Settings className="h-4 w-4" />
-              </a>
+              {isDesktop && (
+                <a href="/settings" aria-label="Settings" title="Settings" className={iconBtn}>
+                  <Settings className="h-4 w-4" />
+                </a>
+              )}
               <a href="/about" aria-label="About" title="About" className={iconBtn}>
                 <Info className="h-4 w-4" />
               </a>


### PR DESCRIPTION
Hide the Settings navbar link on the web (it only applies to the desktop app); keep it in the Tauri build. Gated on isTauri, revealed after mount.