### PR TITLE
feat: hide desktop-only tools (Hotkey Test) from web

### DIFF
--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -22,7 +22,7 @@ export function ToolGrid() {
               />
               <h2 className="text-xl font-bold uppercase tracking-tight">{category}</h2>
               <span className="text-sm font-bold text-muted-foreground">
-                ({categoryTools.length})
+                ({categoryTools.filter(tool => !tool.desktopOnly).length})
               </span>
             </div>
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -32,6 +32,7 @@ export function ToolGrid() {
                   <a
                     key={tool.id}
                     href={tool.route}
+                    {...(tool.desktopOnly ? { 'data-desktop-only': '' } : {})}
                     className="group flex items-start gap-3 border-2 border-border bg-muted p-4 shadow-brutal press-brutal"
                   >
                     <span

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect, useRef } from 'react';
 import { Command } from 'cmdk';
 import { searchTools } from '@/registry/tools';
 import { categories } from '@/registry/categories';
+import { isTauri } from '@/services/platform';
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const [isDesktop, setIsDesktop] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const results = searchTools(search);
+  // Desktop-only tools (e.g. Hotkey Test) are excluded from web search results.
+  const results = searchTools(search).filter(tool => isDesktop || !tool.desktopOnly);
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -19,6 +22,7 @@ export function CommandPalette() {
     // Let any element open search by clicking (dispatch 'gwt:open-search'),
     // so it works without a keyboard.
     const openSearch = () => setOpen(true);
+    setIsDesktop(isTauri());
     document.addEventListener('keydown', down);
     window.addEventListener('gwt:open-search', openSearch);
     return () => {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -102,18 +102,18 @@ const jsonLdBlocks = [siteJsonLd, ...(Array.isArray(jsonLd) ? jsonLd : jsonLd ? 
 
     <ViewTransitions />
     <script is:inline>
-      // Apply the saved theme before paint — on the initial load AND after every
-      // View Transitions navigation. Without the astro:after-swap re-apply, the
-      // runtime `dark` class is lost when the incoming (light) page swaps in, so
-      // dark mode "resets" when navigating between pages.
-      function applyStoredTheme() {
-        document.documentElement.classList.toggle(
-          'dark',
-          localStorage.getItem('theme') === 'dark',
-        );
+      // Apply environment classes before paint — on initial load AND after every
+      // View Transitions navigation (otherwise the class is lost when the incoming
+      // static page swaps in). `dark` = saved theme; `tauri` = running in the
+      // desktop app (reveals desktop-only tools that are hidden on the web).
+      var __isTauri = '__TAURI__' in window && window.__TAURI__ !== undefined;
+      function applyEnvClasses() {
+        var root = document.documentElement;
+        root.classList.toggle('dark', localStorage.getItem('theme') === 'dark');
+        root.classList.toggle('tauri', __isTauri);
       }
-      applyStoredTheme();
-      document.addEventListener('astro:after-swap', applyStoredTheme);
+      applyEnvClasses();
+      document.addEventListener('astro:after-swap', applyEnvClasses);
     </script>
 
     <!-- Google Analytics (GDPR): loads only when configured AND consent granted. -->

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -99,7 +99,8 @@ export const tools: ToolDef[] = [
     icon: Keyboard,
     summary: 'Test global hotkey registration (desktop only)',
     load: () => import('@/islands/dev/HotkeyTest'),
-    status: 'beta'
+    status: 'beta',
+    desktopOnly: true
   },
   {
     id: 'csv-json',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -179,3 +179,12 @@ body {
   background-size: 20px 20px;
   background-position: 0 0, 0 10px, 10px -10px, -10px 0;
 }
+
+/* Desktop-only tools (e.g. Hotkey Test) are hidden on the web and revealed only
+   in the Tauri desktop app, where an inline script sets `.tauri` on <html>. */
+[data-desktop-only] {
+  display: none;
+}
+html.tauri [data-desktop-only] {
+  display: flex;
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -19,6 +19,8 @@ export interface ToolDef {
   summary: string;
   load: () => Promise<{ default: React.ComponentType }>;
   needsIsolation?: boolean;
+  /** Hidden from web listings (grid + search); only shown in the Tauri desktop app. */
+  desktopOnly?: boolean;
   assets?: AssetRef[];
   status: 'stable' | 'beta' | 'experimental';
 }


### PR DESCRIPTION
Hotkey Test is now hidden from the web tool grid + search (desktopOnly flag), but its page still generates and it shows in the Tauri desktop app.