### PR TITLE
docs(release): fix macOS Gatekeeper guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,8 +139,12 @@ jobs:
             | Linux (AppImage) | `*.AppImage` |
 
             ### First run on macOS
-            If macOS blocks the app, open **System Settings → Privacy & Security** and click **Open Anyway**.
-            For screen capture to work, grant **Screen Recording** permission in **Privacy & Security → Screen Recording**.
+            macOS may say the app is **"damaged and can't be opened."** It isn't — the app just isn't
+            Apple-notarized, so macOS quarantines the download. Fix it in one step: drag **GoodWebTools.app**
+            into **Applications**, then in **Terminal** run:
+            `xattr -cr /Applications/GoodWebTools.app`
+            and open it normally. (Right-click → Open does *not* work for the "damaged" message.)
+            For screen capture, grant **Screen Recording** in **System Settings → Privacy & Security → Screen Recording**.
           releaseDraft: true
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
           args: ${{ matrix.args }}

--- a/RELEASING-DESKTOP.md
+++ b/RELEASING-DESKTOP.md
@@ -90,8 +90,12 @@ usable release; the **Apple** secrets are optional but recommended for macOS
 | `APPLE_TEAM_ID` | macOS only | Apple Developer Team ID | Apple Developer → Membership |
 
 > **Minimum to ship a beta:** just the two `TAURI_SIGNING_*` secrets. Without the
-> Apple secrets the macOS `.app`/`.dmg` still builds, but users must right-click →
-> Open to bypass Gatekeeper. Windows/Linux need no additional secrets.
+> Apple secrets the macOS `.app`/`.dmg` still builds, but it's unsigned/un-notarized,
+> so macOS shows **"GoodWebTools is damaged and can't be opened"** (right-click → Open
+> does *not* bypass this variant). Users clear the download quarantine instead: drag the
+> app to **Applications**, then run `xattr -cr /Applications/GoodWebTools.app` in Terminal.
+> Set the Apple secrets to notarize and remove this friction entirely. Windows/Linux need
+> no additional secrets.
 
 **Verify a release built correctly:** after the tag build finishes, the GitHub
 Release should contain per-platform installers **and** a `latest.json` (the


### PR DESCRIPTION
The 'damaged and can't be opened' error needs xattr, not 'Open Anyway'. Update release.yml body + RELEASING-DESKTOP.md.