### PR TITLE
feat(desktop): bundle ffmpeg as a sidecar

### DIFF
--- a/.github/workflows/desktop-check.yml
+++ b/.github/workflows/desktop-check.yml
@@ -69,6 +69,16 @@ jobs:
           mkdir -p dist
           echo '<!doctype html><title>stub</title>' > dist/index.html
 
+      # externalBin ("bin/ffmpeg") is validated at compile time by tauri-build;
+      # an empty file is enough for `cargo check` — we never execute it here.
+      - name: Stub ffmpeg sidecar
+        shell: bash
+        run: |
+          mkdir -p src-tauri/bin
+          TRIPLE=$(rustc -vV | sed -n 's/host: //p')
+          EXT=""; [ "${{ runner.os }}" = "Windows" ] && EXT=".exe"
+          : > "src-tauri/bin/ffmpeg-${TRIPLE}${EXT}"
+
       - name: cargo check (all targets)
         working-directory: src-tauri
         run: cargo check --all-targets

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,8 @@
   "version": "1.0.0-beta.2",
   "identifier": "com.goodwebtools.app",
   "build": {
-    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run download:ffmpeg",
+    "beforeBuildCommand": "npm run download:ffmpeg && npm run build",
     "frontendDist": "../dist",
     "devUrl": "http://localhost:4321"
   },
@@ -78,6 +79,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
+    "externalBin": ["bin/ffmpeg"],
     "targets": ["nsis", "app", "dmg", "deb"],
     "resources": [],
     "category": "Utility",


### PR DESCRIPTION
Re-enables externalBin so the desktop app ships ffmpeg (no system dependency). desktop-check stubs the sidecar for cargo check; release.yml downloads the real per-target binary; local builds auto-download via beforeBuild/DevCommand.