### PR TITLE
Promote to production: Image OCR + Receipt Scanner

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -109,6 +109,8 @@ export default defineConfig({
           '**/html.worker-*.js',
           '**/monaco-setup*.js',
           '**/DbDiagram*.js',
+          '**/ppu-paddle-ocr*.js',
+          '**/ort-*.wasm',
         ],
         runtimeCaching: [
           {

--- a/docs/superpowers/plans/2026-07-30-image-ocr.md
+++ b/docs/superpowers/plans/2026-07-30-image-ocr.md
@@ -1,0 +1,895 @@
+# Image → Text (OCR) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a client-side "Image → Text (OCR)" tool that extracts raw text from an image or PDF page entirely on-device using a PP-OCR pipeline on ONNX Runtime Web.
+
+**Architecture:** Three small, isolated, unit-tested libs (`ocr-preprocess.lib`, `ocr-pdf.lib`, `ocr.lib`) plus a thin orchestrator island (`ImageOcr.tsx`). The OCR SDK is quarantined to one tiny file (`ocr.engine.ts`) so the exact package is swappable behind a stable interface. The tool is registered in the existing registry and served by the existing dynamic `[tool].astro` route.
+
+**Tech Stack:** Astro + React island; `ppu-paddle-ocr` (PP-OCRv5 on ONNX Runtime Web, WebGPU→WASM); existing `mono.lib` (grayscale/threshold), `render.lib` (`pdfjs-dist` rasterization), `downloadService`, `usePasteImage`, `Dropzone`/`TextArea`/`CopyButton`/`Alert`/`ProgressBar`.
+
+## Global Constraints
+
+- **Branch:** `feat/image-ocr` (already created off `main`). Do NOT work on `main`/`develop`.
+- **Scope:** Phase 1, **English only**. No structured receipt parsing, no multi-language picker, no batch. (Spec §"Out of Scope").
+- **Privacy:** the image never leaves the browser; only model files are fetched from a CDN and cached. UI must disclose the one-time model download. (Spec §Constraints).
+- **Preprocessing default:** "Clean up image" is **OFF by default**. (Spec §Locked Decision 5).
+- **Errors are reason-specific:** every surfaced failure names its cause via `OcrError.reason` + message. (Spec §Error Handling).
+- **Test style:** Vitest. Pure transforms tested with plain `ImageData` objects in jsdom (no real canvas), mirroring `src/tools/image/mono.lib.test.ts`. Heavy deps (SDK, pdf renderer) are mocked with `vi.mock`, mirroring `src/services/capture/tauri.test.ts`.
+- **Lint:** must pass `npm run lint` (no `any` in new source; use real types).
+- **Tool naming:** display name **"Image to Text (OCR)"**, id `image-ocr`, category `Image`, status `beta`.
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/tools/image/ocr-preprocess.lib.ts` (create) | Pure `ImageData` transforms: `applyCleanup`, `rotate90`, `crop`. |
+| `src/tools/image/ocr-preprocess.lib.test.ts` (create) | Deterministic pixel tests for the above. |
+| `src/tools/image/ocr-pdf.lib.ts` (create) | `getPdfPageCount(file)`, `renderPdfPage(file, page, scale)` — wraps `openPdfRenderer`. |
+| `src/tools/image/ocr-pdf.lib.test.ts` (create) | Tests mocking `@/tools/pdf/render.lib`. |
+| `src/tools/image/ocr.engine.ts` (create) | The ONLY file importing the OCR SDK. Exports `createEngine()` → `{ backend, recognize }`. Smoke-tested only. |
+| `src/tools/image/ocr.lib.ts` (create) | `recognize(canvas)`, engine caching, `OcrError`, reading-order sort/join, error mapping. |
+| `src/tools/image/ocr.lib.test.ts` (create) | Tests mocking `./ocr.engine`. |
+| `src/islands/image/ImageOcr.tsx` (create) | Thin UI orchestrator. |
+| `src/registry/tools.ts` (modify) | Register the tool. |
+| `astro.config.mjs` (modify) | Keep OCR SDK chunk out of the PWA precache. |
+
+---
+
+### Task 1: Preprocessing transforms (`ocr-preprocess.lib.ts`)
+
+Pure, canvas-free `ImageData` transforms reused by the review-&-adjust step. No heavy deps — pure functions, fully unit-tested.
+
+**Files:**
+- Create: `src/tools/image/ocr-preprocess.lib.ts`
+- Test: `src/tools/image/ocr-preprocess.lib.test.ts`
+
+**Interfaces:**
+- Consumes: `toGrayscale`, `toBlackWhite` from `src/tools/image/mono.lib.ts` — signatures: `toGrayscale(src: ImageData): ImageData`, `toBlackWhite(src: ImageData, threshold: number): ImageData`.
+- Produces:
+  - `interface OcrBox { x: number; y: number; width: number; height: number }`
+  - `applyCleanup(src: ImageData, opts?: { threshold?: number }): ImageData` — grayscale; if `threshold` given, then hard black/white.
+  - `rotate90(src: ImageData): ImageData` — one 90° clockwise turn.
+  - `crop(src: ImageData, region: OcrBox): ImageData` — copy a clamped sub-rectangle.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tools/image/ocr-preprocess.lib.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { applyCleanup, rotate90, crop } from './ocr-preprocess.lib';
+
+// Plain ImageData is enough in jsdom — transforms only read width/height/data.
+function makeImageData(width: number, height: number, px: number[][]): ImageData {
+  const data = new Uint8ClampedArray(px.length * 4);
+  px.forEach(([r, g, b, a], i) => {
+    data[i * 4] = r; data[i * 4 + 1] = g; data[i * 4 + 2] = b; data[i * 4 + 3] = a ?? 255;
+  });
+  return { width, height, data, colorSpace: 'srgb' } as ImageData;
+}
+
+describe('applyCleanup', () => {
+  it('grayscales when no threshold (R=G=B, alpha kept)', () => {
+    const out = applyCleanup(makeImageData(2, 1, [[255, 0, 0, 255], [0, 0, 255, 128]]));
+    expect(out.data[0]).toBe(out.data[1]);
+    expect(out.data[1]).toBe(out.data[2]);
+    expect(out.data[3]).toBe(255);
+    expect(out.data[7]).toBe(128); // alpha preserved
+  });
+
+  it('binarizes to 0/255 when a threshold is given', () => {
+    const out = applyCleanup(makeImageData(2, 1, [[100, 100, 100, 255], [200, 200, 200, 255]]), { threshold: 128 });
+    expect(out.data[0]).toBe(0);   // lum 100 < 128
+    expect(out.data[4]).toBe(255); // lum 200 >= 128
+  });
+});
+
+describe('rotate90', () => {
+  it('turns a 2x1 into a 1x2 and moves pixels clockwise', () => {
+    // source row: [A=red, B=green]; 90° CW -> column top=A, bottom=B
+    const src = makeImageData(2, 1, [[255, 0, 0, 255], [0, 255, 0, 255]]);
+    const out = rotate90(src);
+    expect(out.width).toBe(1);
+    expect(out.height).toBe(2);
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([255, 0, 0]); // top = A
+    expect([out.data[4], out.data[5], out.data[6]]).toEqual([0, 255, 0]); // bottom = B
+  });
+
+  it('applied four times returns the original', () => {
+    const src = makeImageData(2, 1, [[1, 2, 3, 255], [4, 5, 6, 255]]);
+    let out = src;
+    for (let i = 0; i < 4; i++) out = rotate90(out);
+    expect(out.width).toBe(2);
+    expect(out.height).toBe(1);
+    expect(Array.from(out.data)).toEqual(Array.from(src.data));
+  });
+});
+
+describe('crop', () => {
+  it('copies the requested sub-rectangle', () => {
+    // 2x2: TL=1,TR=2,BL=3,BR=4 (red channel encodes id)
+    const src = makeImageData(2, 2, [[1, 0, 0, 255], [2, 0, 0, 255], [3, 0, 0, 255], [4, 0, 0, 255]]);
+    const out = crop(src, { x: 1, y: 0, width: 1, height: 2 }); // right column
+    expect(out.width).toBe(1);
+    expect(out.height).toBe(2);
+    expect(out.data[0]).toBe(2); // TR
+    expect(out.data[4]).toBe(4); // BR
+  });
+
+  it('clamps a region that exceeds bounds', () => {
+    const src = makeImageData(2, 1, [[1, 0, 0, 255], [2, 0, 0, 255]]);
+    const out = crop(src, { x: 0, y: 0, width: 99, height: 99 });
+    expect(out.width).toBe(2);
+    expect(out.height).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tools/image/ocr-preprocess.lib.test.ts`
+Expected: FAIL — `applyCleanup`/`rotate90`/`crop` are not defined (module not found).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/tools/image/ocr-preprocess.lib.ts`:
+
+```ts
+import { toGrayscale, toBlackWhite } from './mono.lib';
+
+export interface OcrBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function emptyLike(width: number, height: number): ImageData {
+  return { width, height, data: new Uint8ClampedArray(width * height * 4), colorSpace: 'srgb' } as ImageData;
+}
+
+/** Grayscale; if a threshold is supplied, hard-binarize to black/white. */
+export function applyCleanup(src: ImageData, opts: { threshold?: number } = {}): ImageData {
+  const gray = toGrayscale(src);
+  return opts.threshold === undefined ? gray : toBlackWhite(gray, opts.threshold);
+}
+
+/** One 90° clockwise rotation. dest[x'=h-1-y, y'=x]. */
+export function rotate90(src: ImageData): ImageData {
+  const { width: w, height: h } = src;
+  const out = emptyLike(h, w); // dimensions swap
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const si = (y * w + x) * 4;
+      const dx = h - 1 - y;
+      const dy = x;
+      const di = (dy * h + dx) * 4;
+      out.data[di] = src.data[si];
+      out.data[di + 1] = src.data[si + 1];
+      out.data[di + 2] = src.data[si + 2];
+      out.data[di + 3] = src.data[si + 3];
+    }
+  }
+  return out;
+}
+
+/** Copy a sub-rectangle, clamped to the source bounds. */
+export function crop(src: ImageData, region: OcrBox): ImageData {
+  const x0 = Math.max(0, Math.min(region.x, src.width));
+  const y0 = Math.max(0, Math.min(region.y, src.height));
+  const x1 = Math.max(x0, Math.min(region.x + region.width, src.width));
+  const y1 = Math.max(y0, Math.min(region.y + region.height, src.height));
+  const w = x1 - x0;
+  const h = y1 - y0;
+  const out = emptyLike(w, h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const si = ((y0 + y) * src.width + (x0 + x)) * 4;
+      const di = (y * w + x) * 4;
+      out.data[di] = src.data[si];
+      out.data[di + 1] = src.data[si + 1];
+      out.data[di + 2] = src.data[si + 2];
+      out.data[di + 3] = src.data[si + 3];
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/tools/image/ocr-preprocess.lib.test.ts`
+Expected: PASS (3 describes, 6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/image/ocr-preprocess.lib.ts src/tools/image/ocr-preprocess.lib.test.ts
+git commit -m "feat(ocr): pure image preprocessing transforms (cleanup/rotate/crop)"
+```
+
+---
+
+### Task 2: PDF page rasterization adapter (`ocr-pdf.lib.ts`)
+
+Wraps the existing `openPdfRenderer` so the island can turn a PDF page into an image blob, reusing the same `pdfjs-dist` path the `pdf-to-image` tool uses.
+
+**Files:**
+- Create: `src/tools/image/ocr-pdf.lib.ts`
+- Test: `src/tools/image/ocr-pdf.lib.test.ts`
+
+**Interfaces:**
+- Consumes: `openPdfRenderer` from `src/tools/pdf/render.lib.ts` — `openPdfRenderer(data: ArrayBuffer | Uint8Array): Promise<PdfRenderer>` where `PdfRenderer = { pageCount: number; renderPage(pageNumber: number, scale: number, mimeType?: string, quality?: number): Promise<{ blob: Blob; width: number; height: number }>; destroy(): void }`.
+- Produces:
+  - `getPdfPageCount(file: File): Promise<number>`
+  - `renderPdfPage(file: File, page: number, scale?: number): Promise<Blob>` — 1-indexed `page`, default `scale = 2`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tools/image/ocr-pdf.lib.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const renderPage = vi.fn();
+const destroy = vi.fn();
+const openPdfRenderer = vi.fn();
+
+vi.mock('@/tools/pdf/render.lib', () => ({
+  openPdfRenderer: (...args: unknown[]) => openPdfRenderer(...args),
+}));
+
+import { getPdfPageCount, renderPdfPage } from './ocr-pdf.lib';
+
+function fakeFile(): File {
+  // arrayBuffer() is what the lib calls; jsdom File supports it.
+  return new File([new Uint8Array([1, 2, 3])], 'r.pdf', { type: 'application/pdf' });
+}
+
+beforeEach(() => {
+  renderPage.mockReset();
+  destroy.mockReset();
+  openPdfRenderer.mockReset();
+  openPdfRenderer.mockResolvedValue({ pageCount: 3, renderPage, destroy });
+});
+
+describe('getPdfPageCount', () => {
+  it('returns the renderer page count and tears down', async () => {
+    expect(await getPdfPageCount(fakeFile())).toBe(3);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('renderPdfPage', () => {
+  it('renders the given 1-indexed page at default scale 2 and returns the blob', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    renderPage.mockResolvedValue({ blob, width: 10, height: 20 });
+    const out = await renderPdfPage(fakeFile(), 2);
+    expect(out).toBe(blob);
+    expect(renderPage).toHaveBeenCalledWith(2, 2, 'image/png');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('tears down even if rendering throws', async () => {
+    renderPage.mockRejectedValue(new Error('boom'));
+    await expect(renderPdfPage(fakeFile(), 1)).rejects.toThrow('boom');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tools/image/ocr-pdf.lib.test.ts`
+Expected: FAIL — module `./ocr-pdf.lib` / its exports not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/tools/image/ocr-pdf.lib.ts`:
+
+```ts
+import { openPdfRenderer } from '@/tools/pdf/render.lib';
+
+/** Number of pages in a PDF file. */
+export async function getPdfPageCount(file: File): Promise<number> {
+  const renderer = await openPdfRenderer(await file.arrayBuffer());
+  try {
+    return renderer.pageCount;
+  } finally {
+    renderer.destroy();
+  }
+}
+
+/** Rasterize one 1-indexed PDF page to a PNG blob. */
+export async function renderPdfPage(file: File, page: number, scale = 2): Promise<Blob> {
+  const renderer = await openPdfRenderer(await file.arrayBuffer());
+  try {
+    const { blob } = await renderer.renderPage(page, scale, 'image/png');
+    return blob;
+  } finally {
+    renderer.destroy();
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/tools/image/ocr-pdf.lib.test.ts`
+Expected: PASS (2 describes, 3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/image/ocr-pdf.lib.ts src/tools/image/ocr-pdf.lib.test.ts
+git commit -m "feat(ocr): PDF page rasterization adapter over openPdfRenderer"
+```
+
+---
+
+### Task 3: OCR engine wrapper + result/error logic (`ocr.engine.ts` + `ocr.lib.ts`)
+
+`ocr.engine.ts` is the sole SDK boundary (smoke-tested). `ocr.lib.ts` holds all testable logic: engine caching, reading-order assembly, and reason-specific `OcrError`s.
+
+**Files:**
+- Create: `src/tools/image/ocr.engine.ts`
+- Create: `src/tools/image/ocr.lib.ts`
+- Test: `src/tools/image/ocr.lib.test.ts`
+- Modify: `package.json` (add `ppu-paddle-ocr` dependency)
+
+**Interfaces:**
+- Consumes: `OcrBox` from `./ocr-preprocess.lib`.
+- Produces (from `ocr.engine.ts`):
+  - `type OcrBackend = 'webgpu' | 'wasm'`
+  - `interface RawLine { text: string; box: OcrBox; confidence: number }`
+  - `interface OcrEngine { backend: OcrBackend; recognize(canvas: HTMLCanvasElement): Promise<RawLine[]> }`
+  - `createEngine(): Promise<OcrEngine>`
+- Produces (from `ocr.lib.ts`):
+  - `type OcrReason = 'engine-unsupported' | 'model-download' | 'inference' | 'no-text' | 'input'`
+  - `class OcrError extends Error { reason: OcrReason }`
+  - `interface OcrLine extends RawLine {}` and `interface OcrResult { text: string; lines: OcrLine[]; backend: OcrBackend }`
+  - `getEngine(): Promise<OcrEngine>` (cached; failure clears the cache so Retry can re-init)
+  - `recognize(canvas: HTMLCanvasElement): Promise<OcrResult>`
+
+- [ ] **Step 1: Vertical-slice eval — pin the SDK and confirm its output shape**
+
+Install the engine and confirm it loads in the browser build before writing the adapter:
+
+```bash
+npm i ppu-paddle-ocr --legacy-peer-deps
+```
+
+Then, in `ocr.engine.ts` (next step), the adapter maps the SDK's per-line output to `RawLine`. Verify the real shape once with a scratch check in the browser (or the package's README/types): the SDK returns detected regions with a `text` string, a quadrilateral/box, and a `score`. Map: `text` → `text`; bounding box of the region → `{x,y,width,height}`; `score` (0..1) → `confidence`. If the field names differ, adjust ONLY the mapping inside `createEngine` — nothing else in the plan depends on the SDK's native shape.
+
+> Note: `ppu-paddle-ocr` pulls `onnxruntime-web`, which is already a dependency. If install surfaces a peer conflict, the repo's committed `.npmrc` (`legacy-peer-deps=true`) already covers it.
+
+- [ ] **Step 2: Write `ocr.engine.ts` (SDK boundary, no unit test)**
+
+Create `src/tools/image/ocr.engine.ts`:
+
+```ts
+import type { OcrBox } from './ocr-preprocess.lib';
+
+export type OcrBackend = 'webgpu' | 'wasm';
+
+export interface RawLine {
+  text: string;
+  box: OcrBox;
+  confidence: number;
+}
+
+export interface OcrEngine {
+  backend: OcrBackend;
+  recognize(canvas: HTMLCanvasElement): Promise<RawLine[]>;
+}
+
+// Convert a PP-OCR quadrilateral ([[x,y]... ] ) to an axis-aligned box.
+function quadToBox(points: number[][]): OcrBox {
+  const xs = points.map((p) => p[0]);
+  const ys = points.map((p) => p[1]);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+}
+
+/**
+ * Create the on-device OCR engine (English). This is the only file that touches
+ * the OCR SDK; keep it thin so the SDK stays swappable. WebGPU is used when the
+ * browser exposes it, otherwise the SDK falls back to WASM.
+ */
+export async function createEngine(): Promise<OcrEngine> {
+  const backend: OcrBackend = typeof navigator !== 'undefined' && 'gpu' in navigator ? 'webgpu' : 'wasm';
+  const { default: PaddleOcr } = await import('ppu-paddle-ocr/web');
+  const ocr = await PaddleOcr.initialize();
+
+  return {
+    backend,
+    async recognize(canvas: HTMLCanvasElement): Promise<RawLine[]> {
+      const result = await ocr.recognize(canvas);
+      // result.lines: Array<{ text: string; points: number[][]; score: number }>
+      return (result.lines ?? []).map((l: { text: string; points: number[][]; score: number }) => ({
+        text: l.text,
+        box: quadToBox(l.points),
+        confidence: l.score,
+      }));
+    },
+  };
+}
+```
+
+> If Step 1's eval showed different SDK field names (`box` instead of `points`, `confidence` instead of `score`, a top-level array instead of `.lines`), adjust the mapping above accordingly. This is the single reconciliation point.
+
+- [ ] **Step 3: Write the failing test for `ocr.lib.ts`**
+
+Create `src/tools/image/ocr.lib.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createEngine = vi.fn();
+vi.mock('./ocr.engine', () => ({ createEngine: () => createEngine() }));
+
+import { recognize, getEngine, OcrError } from './ocr.lib';
+
+function line(text: string, x: number, y: number, confidence = 0.9) {
+  return { text, box: { x, y, width: 40, height: 10 }, confidence };
+}
+
+beforeEach(() => {
+  createEngine.mockReset();
+});
+
+describe('recognize', () => {
+  it('joins lines in reading order (top-to-bottom, then left-to-right)', async () => {
+    const engineRecognize = vi.fn().mockResolvedValue([
+      line('world', 60, 0),
+      line('hello', 0, 0),
+      line('again', 0, 40),
+    ]);
+    createEngine.mockResolvedValue({ backend: 'webgpu', recognize: engineRecognize });
+    const res = await recognize({} as HTMLCanvasElement);
+    expect(res.text).toBe('hello world\nagain');
+    expect(res.backend).toBe('webgpu');
+    expect(res.lines).toHaveLength(3);
+  });
+
+  it('throws OcrError(no-text) when nothing is detected', async () => {
+    createEngine.mockResolvedValue({ backend: 'wasm', recognize: vi.fn().mockResolvedValue([]) });
+    await expect(recognize({} as HTMLCanvasElement)).rejects.toMatchObject({ reason: 'no-text' });
+  });
+
+  it('wraps an inference failure as OcrError(inference) with the cause', async () => {
+    createEngine.mockResolvedValue({ backend: 'wasm', recognize: vi.fn().mockRejectedValue(new Error('kernel died')) });
+    await expect(recognize({} as HTMLCanvasElement)).rejects.toMatchObject({
+      reason: 'inference',
+      message: expect.stringContaining('kernel died'),
+    });
+  });
+});
+
+describe('getEngine init errors', () => {
+  it('maps a network/fetch failure to model-download', async () => {
+    createEngine.mockRejectedValueOnce(new Error('Failed to fetch model'));
+    await expect(getEngine()).rejects.toMatchObject({ reason: 'model-download' });
+  });
+
+  it('maps other init failures to engine-unsupported and clears the cache for retry', async () => {
+    createEngine.mockRejectedValueOnce(new Error('no wasm SIMD'));
+    await expect(getEngine()).rejects.toMatchObject({ reason: 'engine-unsupported' });
+    // cache cleared: a second call re-invokes createEngine (now succeeding)
+    createEngine.mockResolvedValueOnce({ backend: 'wasm', recognize: vi.fn() });
+    await expect(getEngine()).resolves.toMatchObject({ backend: 'wasm' });
+    expect(createEngine).toHaveBeenCalledTimes(2);
+  });
+});
+
+it('OcrError carries name and reason', () => {
+  const e = new OcrError('input', 'bad file');
+  expect(e).toBeInstanceOf(Error);
+  expect(e.name).toBe('OcrError');
+  expect(e.reason).toBe('input');
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `npx vitest run src/tools/image/ocr.lib.test.ts`
+Expected: FAIL — `./ocr.lib` exports not found.
+
+- [ ] **Step 5: Write the implementation**
+
+Create `src/tools/image/ocr.lib.ts`:
+
+```ts
+import { createEngine, type OcrEngine, type RawLine, type OcrBackend } from './ocr.engine';
+
+export type OcrReason = 'engine-unsupported' | 'model-download' | 'inference' | 'no-text' | 'input';
+
+export class OcrError extends Error {
+  reason: OcrReason;
+  constructor(reason: OcrReason, message: string) {
+    super(message);
+    this.name = 'OcrError';
+    this.reason = reason;
+  }
+}
+
+export type OcrLine = RawLine;
+export interface OcrResult {
+  text: string;
+  lines: OcrLine[];
+  backend: OcrBackend;
+}
+
+const NO_TEXT_MSG = 'No text detected — try turning on Clean up image, or use a clearer/tighter crop.';
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Init failures: a network/fetch problem means the model download failed;
+// anything else means the engine can't run in this browser.
+function toInitError(err: unknown): OcrError {
+  const msg = messageOf(err).toLowerCase();
+  if (msg.includes('fetch') || msg.includes('network') || msg.includes('download')) {
+    return new OcrError(
+      'model-download',
+      'Couldn’t download the OCR model (network error or blocked). First use needs a connection — check it and retry.',
+    );
+  }
+  return new OcrError(
+    'engine-unsupported',
+    'On-device OCR couldn’t start: this browser can’t run the OCR engine (missing WebAssembly SIMD support).',
+  );
+}
+
+let enginePromise: Promise<OcrEngine> | null = null;
+
+/** Lazily create the engine once. On failure, clear the cache so a retry re-inits. */
+export function getEngine(): Promise<OcrEngine> {
+  if (!enginePromise) {
+    enginePromise = createEngine().catch((err) => {
+      enginePromise = null;
+      throw toInitError(err);
+    });
+  }
+  return enginePromise;
+}
+
+// Reading order: group into rows by vertical overlap, then left-to-right within a row.
+function sortReadingOrder(lines: RawLine[]): RawLine[] {
+  return [...lines].sort((a, b) => {
+    const rowTol = Math.min(a.box.height, b.box.height) * 0.5;
+    if (Math.abs(a.box.y - b.box.y) > rowTol) return a.box.y - b.box.y;
+    return a.box.x - b.box.x;
+  });
+}
+
+/** Recognize text in a prepared canvas. Throws OcrError with a specific reason. */
+export async function recognize(canvas: HTMLCanvasElement): Promise<OcrResult> {
+  const engine = await getEngine();
+  let raw: RawLine[];
+  try {
+    raw = await engine.recognize(canvas);
+  } catch (err) {
+    throw new OcrError('inference', `OCR failed: ${messageOf(err)}`);
+  }
+  const lines = sortReadingOrder(raw);
+  if (lines.length === 0) throw new OcrError('no-text', NO_TEXT_MSG);
+  return { text: lines.map((l) => l.text).join('\n'), lines, backend: engine.backend };
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npx vitest run src/tools/image/ocr.lib.test.ts`
+Expected: PASS (3 describes + standalone test, 6 tests).
+
+> Note: `ocr.engine.ts` has no unit test (it is the SDK boundary); it is exercised by the manual smoke checklist in Task 4.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json src/tools/image/ocr.engine.ts src/tools/image/ocr.lib.ts src/tools/image/ocr.lib.test.ts
+git commit -m "feat(ocr): engine wrapper, reading-order assembly, reason-specific errors"
+```
+
+---
+
+### Task 4: Orchestrator island + registry + PWA config (`ImageOcr.tsx`)
+
+Wires input (image or PDF) → review-&-adjust (rotate + optional cleanup/threshold) → run → results (editable text, copy, download). Registers the tool and keeps the OCR chunk out of the PWA precache. Deliverable: a working, reachable tool.
+
+**Files:**
+- Create: `src/islands/image/ImageOcr.tsx`
+- Modify: `src/registry/tools.ts`
+- Modify: `astro.config.mjs`
+
+**Interfaces:**
+- Consumes: `recognize`, `OcrError`, `type OcrResult` from `@/tools/image/ocr.lib`; `applyCleanup`, `rotate90` from `@/tools/image/ocr-preprocess.lib`; `getPdfPageCount`, `renderPdfPage` from `@/tools/image/ocr-pdf.lib`; `downloadService.download(blob, filename)`; `usePasteImage`; UI: `Dropzone`, `Button`, `Alert`, `TextArea`, `CopyButton`. (No `ProgressBar` — it is determinate-only; OCR uses an indeterminate busy indicator.)
+- Produces: default-exported React component `ImageOcr`.
+
+- [ ] **Step 1: Register the tool (make the route resolvable)**
+
+In `src/registry/tools.ts`, add this entry to the tools array near the other `image-*` entries (e.g. after `image-face-blur`). Import the icon `ScanText` from `lucide-react` in the existing icon import block:
+
+```ts
+  {
+    id: 'image-ocr',
+    name: 'Image to Text (OCR)',
+    category: 'Image',
+    route: '/tools/image-ocr',
+    keywords: ['ocr', 'receipt', 'scan', 'text', 'extract', 'recognize', 'read', 'document'],
+    icon: ScanText,
+    summary: 'Extract text from an image or PDF with on-device AI',
+    load: () => import('@/islands/image/ImageOcr'),
+    status: 'beta'
+  },
+```
+
+- [ ] **Step 2: Keep the OCR SDK chunk out of the PWA precache**
+
+In `astro.config.mjs`, add the OCR SDK chunk glob to the existing `workbox.globIgnores` array (same list that already ignores the Monaco/DbDiagram chunks):
+
+```js
+          '**/ppu-paddle-ocr*.js',
+          '**/ort-*.wasm',
+```
+
+- [ ] **Step 3: Implement the island**
+
+Create `src/islands/image/ImageOcr.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { TextArea } from '@/components/ui/TextArea';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { downloadService } from '@/services/download';
+import { applyCleanup, rotate90 } from '@/tools/image/ocr-preprocess.lib';
+import { recognize, OcrError } from '@/tools/image/ocr.lib';
+import { getPdfPageCount, renderPdfPage } from '@/tools/image/ocr-pdf.lib';
+
+// Oversized inputs are downscaled before inference (memory/perf guard; Spec §Error Handling).
+const MAX_DIM = 2000;
+
+// Draw a blob to an offscreen canvas (downscaled if huge) and return its ImageData (the "base").
+async function blobToImageData(blob: Blob): Promise<ImageData> {
+  const bitmap = await createImageBitmap(blob);
+  const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+  return ctx.getImageData(0, 0, w, h);
+}
+
+// Apply rotation + optional cleanup, returning a canvas ready for OCR/preview.
+function buildAdjusted(
+  base: ImageData,
+  opts: { quarters: number; cleanup: boolean; threshold: number },
+): HTMLCanvasElement {
+  let img = base;
+  for (let i = 0; i < opts.quarters; i++) img = rotate90(img);
+  if (opts.cleanup) img = applyCleanup(img, { threshold: opts.threshold });
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  const sink = ctx.createImageData(img.width, img.height);
+  sink.data.set(img.data);
+  ctx.putImageData(sink, 0, 0);
+  return canvas;
+}
+
+export default function ImageOcr() {
+  const [file, setFile] = useState<File | null>(null);
+  const [isPdf, setIsPdf] = useState(false);
+  const [pageCount, setPageCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [base, setBase] = useState<ImageData | null>(null);
+
+  const [quarters, setQuarters] = useState(0);
+  const [cleanup, setCleanup] = useState(false); // OFF by default (Global Constraints)
+  const [threshold, setThreshold] = useState(140);
+
+  const [busy, setBusy] = useState(false);
+  const [text, setText] = useState('');
+  const [backendNote, setBackendNote] = useState('');
+  const [error, setError] = useState('');
+  const [retryable, setRetryable] = useState(false);
+
+  const previewRef = useRef<HTMLCanvasElement | null>(null);
+
+  const reset = () => {
+    setBase(null); setText(''); setError(''); setRetryable(false);
+    setQuarters(0); setCleanup(false); setPage(1); setPageCount(0);
+  };
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find((x) => x.type.startsWith('image/') || x.type === 'application/pdf') ?? null;
+    reset();
+    setFile(f);
+    if (!f) return;
+    const pdf = f.type === 'application/pdf';
+    setIsPdf(pdf);
+    try {
+      if (pdf) {
+        const count = await getPdfPageCount(f);
+        setPageCount(count);
+        setBase(await blobToImageData(await renderPdfPage(f, 1)));
+      } else {
+        setBase(await blobToImageData(f));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load that file.');
+    }
+  };
+  usePasteImage((f) => onDrop([f]));
+
+  // Load a different PDF page.
+  useEffect(() => {
+    if (!file || !isPdf || pageCount === 0) return;
+    let alive = true;
+    renderPdfPage(file, page)
+      .then(blobToImageData)
+      .then((d) => alive && setBase(d))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : 'Could not render that page.'));
+    return () => { alive = false; };
+  }, [file, isPdf, page, pageCount]);
+
+  // Live preview of the adjusted image.
+  useEffect(() => {
+    if (!base || !previewRef.current) return;
+    const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+    const el = previewRef.current;
+    el.width = canvas.width;
+    el.height = canvas.height;
+    el.getContext('2d')?.drawImage(canvas, 0, 0);
+  }, [base, quarters, cleanup, threshold]);
+
+  const runOcr = async () => {
+    if (!base) return;
+    setBusy(true); setError(''); setRetryable(false); setText('');
+    try {
+      const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+      const result = await recognize(canvas);
+      setText(result.text);
+      setBackendNote(
+        result.backend === 'wasm'
+          ? 'Ran in slower CPU (WASM) mode — WebGPU isn’t available in this browser.'
+          : '',
+      );
+    } catch (e) {
+      if (e instanceof OcrError) {
+        setError(e.message);
+        setRetryable(e.reason === 'model-download');
+      } else {
+        setError(e instanceof Error ? e.message : 'OCR failed.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const outName = (file?.name.replace(/\.[^.]+$/, '') || 'ocr') + '.txt';
+  const download = () => downloadService.download(new Blob([text], { type: 'text/plain' }), outName);
+
+  return (
+    <div className="space-y-4">
+      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">Drop an image or PDF, or click to browse</p>
+          <p className="text-sm text-muted-foreground">Runs on-device · or paste (⌘V). First use downloads the OCR model once.</p>
+        </div>
+      </Dropzone>
+
+      {file && <p className="text-sm font-bold text-foreground">{file.name}</p>}
+
+      {isPdf && pageCount > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
+          <span>Page {page} / {pageCount}</span>
+          <Button variant="secondary" disabled={page >= pageCount} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      )}
+
+      {base && (
+        <div className="space-y-3">
+          <canvas ref={previewRef} className="max-h-96 w-auto border-2 border-border" />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="secondary" onClick={() => setQuarters((q) => (q + 1) % 4)}>Rotate 90°</Button>
+            <label className="flex items-center gap-2 text-sm font-bold">
+              <input type="checkbox" checked={cleanup} onChange={(e) => setCleanup(e.target.checked)} />
+              Clean up image
+            </label>
+            {cleanup && (
+              <label className="flex items-center gap-2 text-sm">
+                <span className="uppercase tracking-wide text-muted-foreground">Threshold {threshold}</span>
+                <input type="range" min={0} max={255} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} className="accent-accent" />
+              </label>
+            )}
+            <Button onClick={runOcr} disabled={busy}>{busy ? 'Reading…' : 'Run OCR'}</Button>
+          </div>
+
+          {busy && (
+            <p className="animate-pulse text-sm text-muted-foreground">
+              Extracting text… (first run downloads the OCR model once)
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error">
+          {error}
+          {retryable && <> <button className="underline" onClick={runOcr}>Retry</button></>}
+        </Alert>
+      )}
+
+      {text && (
+        <div className="space-y-2">
+          {backendNote && <p className="text-xs text-muted-foreground">{backendNote}</p>}
+          <TextArea label="Recognized text" value={text} onChange={(e) => setText(e.target.value)} rows={12} />
+          <div className="flex gap-2">
+            <CopyButton value={text} />
+            <Button variant="secondary" onClick={download}>Download .txt</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Verify the full test suite still passes**
+
+Run: `npx vitest run`
+Expected: PASS — all prior tests plus the three new lib test files; total count increases by the new tests. No failures.
+
+- [ ] **Step 5: Verify lint and build**
+
+Run: `npm run lint`
+Expected: 0 errors (warnings tolerated per repo config, but no `any` in the new files).
+
+Run: `npm run build`
+Expected: build completes; check the console for a workbox precache warning naming a large `ppu-paddle-ocr`/`ort` chunk. If one appears, add its exact glob to `astro.config.mjs` `globIgnores` and rebuild until the warning is gone.
+
+- [ ] **Step 6: Manual smoke checklist (real inference — not automated)**
+
+Run `npm run dev`, open `/tools/image-ocr`, and confirm:
+- An English receipt photo → recognized text appears; Copy and Download .txt work.
+- A screenshot with clear text → accurate text.
+- A multi-page PDF → page nav works; OCR runs on the selected page.
+- Rotate 90° on a sideways photo improves the result.
+- "Clean up image" toggle + threshold slider change the preview.
+- In a browser without WebGPU (or with it disabled), OCR still works and shows the WASM note.
+- Simulate offline for the first run → the model-download error with a working Retry.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/islands/image/ImageOcr.tsx src/registry/tools.ts astro.config.mjs
+git commit -m "feat(ocr): Image to Text (OCR) tool — island, registry, PWA config"
+```
+
+---
+
+## Deviations from the spec (deliberate MVP trims — flag for the user)
+
+- **Crop UI deferred.** `crop()` is implemented and tested in `ocr-preprocess.lib` (the structured-receipt phase and a future crop UI will use it), but the MVP island wires only **rotate + cleanup + threshold**. Users needing a tight crop can pre-crop with the existing **Image Crop** tool. Interactive drag-crop is a fast-follow. (Spec §Locked Decision 5 listed crop; this trims the UI, not the capability.)
+- **Bounding-box overlay** remains the optional stretch it was in the spec — not implemented in the MVP island. `OcrResult.lines[].box` is available when it's added.
+
+## Post-completion
+
+After Task 4, follow **superpowers:finishing-a-development-branch**: confirm the full suite + lint + build are green, then open a PR from `feat/image-ocr` to `develop` (matching the repo's develop→main flow).

--- a/docs/superpowers/plans/2026-07-30-receipt-parsing.md
+++ b/docs/superpowers/plans/2026-07-30-receipt-parsing.md
@@ -1,0 +1,853 @@
+# Structured Receipt Parsing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract editable summary fields (merchant, date, currency, subtotal, tax, total) from OCR output via a pure heuristic parser, surfaced as a "Parse as receipt" toggle in the OCR tool and a dedicated "Receipt Scanner" tool, with JSON/CSV export.
+
+**Architecture:** Two pure libs (`receipt.lib`, `receipt-export.lib`). The OCR input→preprocess→run UI is extracted from `ImageOcr` into a shared `OcrWorkbench` component reused by both tools. A shared `ReceiptFields` component renders editable fields + export.
+
+**Tech Stack:** React islands (Astro); existing `OcrResult` from `@/tools/image/ocr.lib`; `downloadService`; `Button`/`Alert`/`TextArea`/`CopyButton`/`Dropzone`; Vitest.
+
+## Global Constraints
+
+- **Branch:** `feat/image-ocr` (continues the OCR feature; the MVP is committed here).
+- **Scope:** summary fields only. No line items, no batch, no locale picker. (Spec §Out of Scope).
+- **Parser is pure & deterministic:** no network, no DOM — operates only on `OcrResult`. (Spec §Approach).
+- **Language-pluggable keywords:** anchors live in a `ReceiptKeywords` set; ship `EN_KEYWORDS`; `parseReceipt(ocr, keywords = EN_KEYWORDS)`. (Spec §Locked Decision 5).
+- **Date convention:** ambiguous numeric dates are **day-first (DD/MM/YYYY)**; fields are editable. (Spec §Heuristics).
+- **Refactor is behavior-preserving:** extracting `OcrWorkbench` must not change the OCR tool's existing UX. (Spec §Constraints).
+- **Test style:** Vitest, table-driven with fixture `OcrResult`s (plain objects), mirroring `src/tools/image/mono.lib.test.ts`.
+- **Lint:** `npm run lint` 0 errors; no `any` in new source.
+- **No commits until the user orders them** (per the user's standing instruction for this feature).
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/tools/image/receipt.lib.ts` (create) | `parseReceipt`, finders, `parseAmount`, `parseDate`, `ReceiptData`, `ReceiptKeywords`, `EN_KEYWORDS`. |
+| `src/tools/image/receipt.lib.test.ts` (create) | Table-driven parser tests. |
+| `src/tools/image/receipt-export.lib.ts` (create) | `receiptToJson`, `receiptToCsv`. |
+| `src/tools/image/receipt-export.lib.test.ts` (create) | Export format/escaping tests. |
+| `src/islands/image/OcrWorkbench.tsx` (create; refactor from `ImageOcr`) | Shared input→preprocess→run UI; `onResult`/`onReset` callbacks. |
+| `src/islands/image/ImageOcr.tsx` (modify ×2) | Task 3: use `OcrWorkbench`. Task 4: add "Parse as receipt" toggle. |
+| `src/islands/image/ReceiptFields.tsx` (create) | Editable fields form + JSON/CSV/copy export. |
+| `src/islands/image/ReceiptScanner.tsx` (create) | Dedicated tool: `OcrWorkbench` + `ReceiptFields` primary + raw text collapsible. |
+| `src/registry/tools.ts` (modify) | Register `image-receipt-scanner`. |
+
+---
+
+### Task 1: Receipt parser (`receipt.lib.ts`)
+
+Pure heuristic parser over `OcrResult`. The logic core — build it test-first.
+
+**Files:**
+- Create: `src/tools/image/receipt.lib.ts`
+- Test: `src/tools/image/receipt.lib.test.ts`
+
+**Interfaces:**
+- Consumes: `OcrResult`, `OcrLine` from `@/tools/image/ocr.lib`. `OcrLine = { text: string; box: { x:number; y:number; width:number; height:number }; confidence: number }`. `OcrResult = { text: string; lines: OcrLine[]; backend: 'webgpu'|'wasm' }`.
+- Produces:
+  - `interface ReceiptData { merchant: string|null; dateRaw: string|null; dateIso: string|null; currency: string|null; subtotal: number|null; tax: number|null; total: number|null }`
+  - `interface ReceiptKeywords { total: string[]; totalExclude: string[]; subtotal: string[]; tax: string[] }`
+  - `const EN_KEYWORDS: ReceiptKeywords`
+  - `parseAmount(text: string): number | null`
+  - `parseDate(text: string): { raw: string; iso: string } | null`
+  - `parseReceipt(ocr: OcrResult, keywords?: ReceiptKeywords): ReceiptData`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tools/image/receipt.lib.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseAmount, parseDate, parseReceipt, EN_KEYWORDS, type ReceiptData } from './receipt.lib';
+import type { OcrResult, OcrLine } from './ocr.lib';
+
+// Build an OcrResult from [text, y] pairs (x=0, fixed size). y drives layout.
+function ocr(rows: [string, number][]): OcrResult {
+  const lines: OcrLine[] = rows.map(([text, y]) => ({
+    text,
+    box: { x: 0, y, width: 100, height: 12 },
+    confidence: 0.9,
+  }));
+  return { text: rows.map((r) => r[0]).join('\n'), lines, backend: 'wasm' };
+}
+
+describe('parseAmount', () => {
+  const cases: [string, number | null][] = [
+    ['$12.34', 12.34],
+    ['TOTAL 1,234.56', 1234.56],
+    ['1.234,56', 1234.56],
+    ['12,50', 12.5],
+    ['1,234', 1234],
+    ['no digits here', null],
+  ];
+  it.each(cases)('parses %s', (input, expected) => {
+    expect(parseAmount(input)).toBe(expected);
+  });
+});
+
+describe('parseDate', () => {
+  it('parses ISO YYYY-MM-DD', () => {
+    expect(parseDate('Date: 2026-02-01')).toEqual({ raw: '2026-02-01', iso: '2026-02-01' });
+  });
+  it('parses numeric dates day-first', () => {
+    expect(parseDate('01/02/2026')).toEqual({ raw: '01/02/2026', iso: '2026-02-01' });
+  });
+  it('parses "5 Jan 2026"', () => {
+    expect(parseDate('5 Jan 2026')?.iso).toBe('2026-01-05');
+  });
+  it('parses "Jan 5, 2026"', () => {
+    expect(parseDate('Jan 5, 2026')?.iso).toBe('2026-01-05');
+  });
+  it('returns null when no date', () => {
+    expect(parseDate('THANK YOU')).toBeNull();
+  });
+});
+
+describe('parseReceipt', () => {
+  it('extracts all summary fields and disambiguates total from subtotal/tax', () => {
+    const result = parseReceipt(
+      ocr([
+        ['BLUE BOTTLE COFFEE', 0],
+        ['123 Main St', 10],
+        ['Date: 02/03/2026', 20],
+        ['Latte $4.50', 40],
+        ['Subtotal $9.00', 60],
+        ['Tax $0.90', 70],
+        ['TOTAL $9.90', 80],
+        ['VISA ****1234', 100],
+      ]),
+    );
+    const expected: ReceiptData = {
+      merchant: 'BLUE BOTTLE COFFEE',
+      dateRaw: '02/03/2026',
+      dateIso: '2026-03-02',
+      currency: '$',
+      subtotal: 9.0,
+      tax: 0.9,
+      total: 9.9,
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it('prefers "Grand Total" and handles "Amount Due" keyword variants', () => {
+    const r = parseReceipt(ocr([['Amount Due USD 42.00', 50], ['Grand Total USD 42.00', 60]]));
+    expect(r.total).toBe(42);
+    expect(r.currency).toBe('USD');
+  });
+
+  it('returns all-null when nothing matches', () => {
+    expect(parseReceipt(ocr([['xxxxx', 0], ['yyyyy', 10]]))).toEqual({
+      merchant: 'xxxxx', dateRaw: null, dateIso: null, currency: null, subtotal: null, tax: null, total: null,
+    });
+  });
+
+  it('accepts a custom keyword set', () => {
+    const idKeywords = { ...EN_KEYWORDS, total: ['jumlah'], totalExclude: ['pajak'] };
+    const r = parseReceipt(ocr([['Jumlah 15.00', 50]]), idKeywords);
+    expect(r.total).toBe(15);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tools/image/receipt.lib.test.ts`
+Expected: FAIL — `./receipt.lib` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/tools/image/receipt.lib.ts`:
+
+```ts
+import type { OcrResult, OcrLine } from './ocr.lib';
+
+export interface ReceiptData {
+  merchant: string | null;
+  dateRaw: string | null;
+  dateIso: string | null;
+  currency: string | null;
+  subtotal: number | null;
+  tax: number | null;
+  total: number | null;
+}
+
+export interface ReceiptKeywords {
+  total: string[];
+  totalExclude: string[];
+  subtotal: string[];
+  tax: string[];
+}
+
+export const EN_KEYWORDS: ReceiptKeywords = {
+  total: ['grand total', 'amount due', 'balance due', 'total'],
+  totalExclude: ['subtotal', 'sub total', 'tax', 'vat', 'gst'],
+  subtotal: ['subtotal', 'sub total'],
+  tax: ['tax', 'vat', 'gst'],
+};
+
+const NUMBER_RE = /\d{1,3}(?:[.,]\d{3})*[.,]\d{2}|\d+[.,]\d{2}|\d{1,3}(?:[.,]\d{3})+|\d+/g;
+
+// Normalize a single numeric token (handles 1,234.56 / 1.234,56 / 12,50 / 1,234 / 12).
+function normalizeNumber(tok: string): number | null {
+  let s = tok;
+  if (s.includes(',') && s.includes('.')) {
+    s = s.lastIndexOf(',') > s.lastIndexOf('.') ? s.replace(/\./g, '').replace(',', '.') : s.replace(/,/g, '');
+  } else if (s.includes(',')) {
+    s = /,\d{2}$/.test(s) ? s.replace(',', '.') : s.replace(/,/g, '');
+  } else if (s.includes('.')) {
+    if (!/\.\d{2}$/.test(s)) s = s.replace(/\./g, ''); // dots are thousands unless 2 trailing digits
+  }
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Extract a monetary amount from a line: prefer a 2-decimal (money) token, else the largest number. */
+export function parseAmount(text: string): number | null {
+  const tokens = text.match(NUMBER_RE);
+  if (!tokens) return null;
+  const money = tokens.filter((t) => /[.,]\d{2}$/.test(t));
+  if (money.length) return normalizeNumber(money[money.length - 1]);
+  const nums = tokens.map(normalizeNumber).filter((n): n is number => n !== null);
+  return nums.length ? Math.max(...nums) : null;
+}
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+const pad = (n: number) => String(n).padStart(2, '0');
+const normYear = (y: string) => (Number(y) < 100 ? 2000 + Number(y) : Number(y));
+
+/** Detect a date; ambiguous numeric dates are read day-first (DD/MM/YYYY). */
+export function parseDate(text: string): { raw: string; iso: string } | null {
+  let m: RegExpMatchArray | null;
+  if ((m = text.match(/\b(\d{4})-(\d{1,2})-(\d{1,2})\b/))) {
+    return { raw: m[0], iso: `${m[1]}-${pad(+m[2])}-${pad(+m[3])}` };
+  }
+  if ((m = text.match(/\b(\d{1,2})[/.-](\d{1,2})[/.-](\d{2,4})\b/))) {
+    return { raw: m[0], iso: `${normYear(m[3])}-${pad(+m[2])}-${pad(+m[1])}` };
+  }
+  if ((m = text.match(/\b(\d{1,2})\s+([A-Za-z]{3,})\.?\s+(\d{4})\b/))) {
+    const mo = MONTHS[m[2].slice(0, 3).toLowerCase()];
+    if (mo) return { raw: m[0], iso: `${m[3]}-${pad(mo)}-${pad(+m[1])}` };
+  }
+  if ((m = text.match(/\b([A-Za-z]{3,})\.?\s+(\d{1,2}),?\s+(\d{4})\b/))) {
+    const mo = MONTHS[m[1].slice(0, 3).toLowerCase()];
+    if (mo) return { raw: m[0], iso: `${m[3]}-${pad(mo)}-${pad(+m[2])}` };
+  }
+  return null;
+}
+
+function hasAny(text: string, kws: string[]): boolean {
+  const t = text.toLowerCase();
+  return kws.some((k) => t.includes(k));
+}
+
+function amountOnKeywordLine(lines: OcrLine[], kws: string[], exclude: string[] = []): OcrLine[] {
+  return lines.filter((l) => hasAny(l.text, kws) && !hasAny(l.text, exclude) && parseAmount(l.text) !== null);
+}
+
+function findTotal(lines: OcrLine[], kw: ReceiptKeywords): number | null {
+  const cands = amountOnKeywordLine(lines, kw.total, kw.totalExclude);
+  if (!cands.length) return null;
+  cands.sort((a, b) => b.box.y - a.box.y || (parseAmount(b.text)! - parseAmount(a.text)!));
+  return parseAmount(cands[0].text);
+}
+
+function firstAmount(lines: OcrLine[], kws: string[]): number | null {
+  const c = amountOnKeywordLine(lines, kws);
+  return c.length ? parseAmount(c[0].text) : null;
+}
+
+const CURRENCY_RE = /([$€£¥₹])|\b(USD|EUR|GBP|JPY|IDR|Rp)\b/i;
+function findCurrency(lines: OcrLine[]): string | null {
+  for (const l of lines) {
+    const m = l.text.match(CURRENCY_RE);
+    if (m) return m[1] ?? m[2];
+  }
+  return null;
+}
+
+function isAmountOnly(text: string): boolean {
+  return /^[\s$€£¥₹]*[\d.,\s]+$/.test(text.trim());
+}
+function findMerchant(lines: OcrLine[], kw: ReceiptKeywords): string | null {
+  const sorted = [...lines].sort((a, b) => a.box.y - b.box.y);
+  const skip = [...kw.total, ...kw.subtotal, ...kw.tax];
+  for (const l of sorted) {
+    const t = l.text.trim();
+    if (!t || parseDate(t) || isAmountOnly(t) || hasAny(t, skip)) continue;
+    return t;
+  }
+  return null;
+}
+
+export function parseReceipt(ocr: OcrResult, keywords: ReceiptKeywords = EN_KEYWORDS): ReceiptData {
+  const { lines } = ocr;
+  const date = parseDate(lines.map((l) => l.text).join('\n'));
+  return {
+    merchant: findMerchant(lines, keywords),
+    dateRaw: date?.raw ?? null,
+    dateIso: date?.iso ?? null,
+    currency: findCurrency(lines),
+    subtotal: firstAmount(lines, keywords.subtotal),
+    tax: firstAmount(lines, keywords.tax),
+    total: findTotal(lines, keywords),
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/tools/image/receipt.lib.test.ts`
+Expected: PASS (parseAmount 6 cases, parseDate 5, parseReceipt 4).
+
+> If a case fails, fix the implementation (not the test) — the tests encode the spec's required behavior.
+
+- [ ] **Step 5: (Hold commit per user instruction.)**
+
+---
+
+### Task 2: Export helpers (`receipt-export.lib.ts`)
+
+**Files:**
+- Create: `src/tools/image/receipt-export.lib.ts`
+- Test: `src/tools/image/receipt-export.lib.test.ts`
+
+**Interfaces:**
+- Consumes: `ReceiptData` from `./receipt.lib`.
+- Produces: `receiptToJson(d: ReceiptData): string`, `receiptToCsv(d: ReceiptData): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tools/image/receipt-export.lib.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { receiptToJson, receiptToCsv } from './receipt-export.lib';
+import type { ReceiptData } from './receipt.lib';
+
+const sample: ReceiptData = {
+  merchant: 'Blue Bottle', dateRaw: '02/03/2026', dateIso: '2026-03-02',
+  currency: '$', subtotal: 9, tax: 0.9, total: 9.9,
+};
+
+describe('receiptToJson', () => {
+  it('round-trips to the same object', () => {
+    expect(JSON.parse(receiptToJson(sample))).toEqual(sample);
+  });
+});
+
+describe('receiptToCsv', () => {
+  it('emits a header and one row', () => {
+    const csv = receiptToCsv(sample);
+    const [header, row] = csv.split('\n');
+    expect(header).toBe('merchant,dateRaw,dateIso,currency,subtotal,tax,total');
+    expect(row).toBe('Blue Bottle,02/03/2026,2026-03-02,$,9,0.9,9.9');
+  });
+  it('quotes and escapes fields containing commas or quotes', () => {
+    const row = receiptToCsv({ ...sample, merchant: 'A, "B" Store' }).split('\n')[1];
+    expect(row.startsWith('"A, ""B"" Store",')).toBe(true);
+  });
+  it('renders null fields as empty cells', () => {
+    const row = receiptToCsv({ ...sample, tax: null, dateRaw: null }).split('\n')[1];
+    expect(row).toBe('Blue Bottle,,2026-03-02,$,9,,9.9');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tools/image/receipt-export.lib.test.ts`
+Expected: FAIL — `./receipt-export.lib` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/tools/image/receipt-export.lib.ts`:
+
+```ts
+import type { ReceiptData } from './receipt.lib';
+
+const FIELDS: (keyof ReceiptData)[] = ['merchant', 'dateRaw', 'dateIso', 'currency', 'subtotal', 'tax', 'total'];
+
+export function receiptToJson(d: ReceiptData): string {
+  return JSON.stringify(d, null, 2);
+}
+
+function csvCell(v: string | number | null): string {
+  if (v === null) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function receiptToCsv(d: ReceiptData): string {
+  const header = FIELDS.join(',');
+  const row = FIELDS.map((f) => csvCell(d[f])).join(',');
+  return `${header}\n${row}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/tools/image/receipt-export.lib.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: (Hold commit.)**
+
+---
+
+### Task 3: Extract `OcrWorkbench` (behavior-preserving refactor)
+
+Pull the input→preprocess→run UI out of `ImageOcr` into a shared component. `ImageOcr` keeps its exact current behavior (raw-text output, backend note, copy, download) but delegates the pipeline to `OcrWorkbench`.
+
+**Files:**
+- Create: `src/islands/image/OcrWorkbench.tsx`
+- Modify: `src/islands/image/ImageOcr.tsx` (replace pipeline internals with `<OcrWorkbench>`)
+
+**Interfaces:**
+- Consumes: `recognize`, `OcrError`, `type OcrResult` from `@/tools/image/ocr.lib`; `applyCleanup`, `rotate90` from `@/tools/image/ocr-preprocess.lib`; `getPdfPageCount`, `renderPdfPage` from `@/tools/image/ocr-pdf.lib`; `usePasteImage`; `Dropzone`/`Button`/`Alert`.
+- Produces: `OcrWorkbench` — `export default function OcrWorkbench(props: { onResult: (result: OcrResult) => void; onReset: () => void })`.
+
+- [ ] **Step 1: Create `OcrWorkbench.tsx`**
+
+Create `src/islands/image/OcrWorkbench.tsx` (this is the pipeline lifted verbatim from the current `ImageOcr`, minus the results rendering, ending in `onResult(result)`):
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { applyCleanup, rotate90 } from '@/tools/image/ocr-preprocess.lib';
+import { recognize, OcrError, type OcrResult } from '@/tools/image/ocr.lib';
+import { getPdfPageCount, renderPdfPage } from '@/tools/image/ocr-pdf.lib';
+
+const MAX_DIM = 2000;
+
+async function blobToImageData(blob: Blob): Promise<ImageData> {
+  const bitmap = await createImageBitmap(blob);
+  const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+  return ctx.getImageData(0, 0, w, h);
+}
+
+function buildAdjusted(
+  base: ImageData,
+  opts: { quarters: number; cleanup: boolean; threshold: number },
+): HTMLCanvasElement {
+  let img = base;
+  for (let i = 0; i < opts.quarters; i++) img = rotate90(img);
+  if (opts.cleanup) img = applyCleanup(img, { threshold: opts.threshold });
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  const sink = ctx.createImageData(img.width, img.height);
+  sink.data.set(img.data);
+  ctx.putImageData(sink, 0, 0);
+  return canvas;
+}
+
+export default function OcrWorkbench({ onResult, onReset }: { onResult: (result: OcrResult) => void; onReset: () => void }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isPdf, setIsPdf] = useState(false);
+  const [pageCount, setPageCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [base, setBase] = useState<ImageData | null>(null);
+  const [quarters, setQuarters] = useState(0);
+  const [cleanup, setCleanup] = useState(false);
+  const [threshold, setThreshold] = useState(140);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [retryable, setRetryable] = useState(false);
+  const previewRef = useRef<HTMLCanvasElement | null>(null);
+
+  const reset = () => {
+    setBase(null); setError(''); setRetryable(false);
+    setQuarters(0); setCleanup(false); setPage(1); setPageCount(0);
+    onReset();
+  };
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find((x) => x.type.startsWith('image/') || x.type === 'application/pdf') ?? null;
+    reset();
+    setFile(f);
+    if (!f) return;
+    const pdf = f.type === 'application/pdf';
+    setIsPdf(pdf);
+    try {
+      if (pdf) {
+        setPageCount(await getPdfPageCount(f));
+        setBase(await blobToImageData(await renderPdfPage(f, 1)));
+      } else {
+        setBase(await blobToImageData(f));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load that file.');
+    }
+  };
+  usePasteImage((f) => onDrop([f]));
+
+  useEffect(() => {
+    if (!file || !isPdf || pageCount === 0) return;
+    let alive = true;
+    renderPdfPage(file, page)
+      .then(blobToImageData)
+      .then((d) => alive && setBase(d))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : 'Could not render that page.'));
+    return () => { alive = false; };
+  }, [file, isPdf, page, pageCount]);
+
+  useEffect(() => {
+    if (!base || !previewRef.current) return;
+    const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+    const el = previewRef.current;
+    el.width = canvas.width;
+    el.height = canvas.height;
+    el.getContext('2d')?.drawImage(canvas, 0, 0);
+  }, [base, quarters, cleanup, threshold]);
+
+  const runOcr = async () => {
+    if (!base) return;
+    setBusy(true); setError(''); setRetryable(false);
+    try {
+      const result = await recognize(buildAdjusted(base, { quarters, cleanup, threshold }));
+      onResult(result);
+    } catch (e) {
+      if (e instanceof OcrError) {
+        setError(e.message);
+        setRetryable(e.reason === 'model-download');
+      } else {
+        setError(e instanceof Error ? e.message : 'OCR failed.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">Drop an image or PDF, or click to browse</p>
+          <p className="text-sm text-muted-foreground">Runs on-device · or paste (⌘V). First use downloads the OCR model once.</p>
+        </div>
+      </Dropzone>
+
+      {file && <p className="text-sm font-bold text-foreground">{file.name}</p>}
+
+      {isPdf && pageCount > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
+          <span>Page {page} / {pageCount}</span>
+          <Button variant="secondary" disabled={page >= pageCount} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      )}
+
+      {base && (
+        <div className="space-y-3">
+          <canvas ref={previewRef} className="max-h-96 w-auto border-2 border-border" />
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="secondary" onClick={() => setQuarters((q) => (q + 1) % 4)}>Rotate 90°</Button>
+            <label className="flex items-center gap-2 text-sm font-bold">
+              <input type="checkbox" checked={cleanup} onChange={(e) => setCleanup(e.target.checked)} />
+              Clean up image
+            </label>
+            {cleanup && (
+              <label className="flex items-center gap-2 text-sm">
+                <span className="uppercase tracking-wide text-muted-foreground">Threshold {threshold}</span>
+                <input type="range" min={0} max={255} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} className="accent-accent" />
+              </label>
+            )}
+            <Button onClick={runOcr} disabled={busy}>{busy ? 'Reading…' : 'Run OCR'}</Button>
+          </div>
+          {busy && (
+            <p className="animate-pulse text-sm text-muted-foreground">
+              Extracting text… (first run downloads the OCR model once)
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error">
+          {error}
+          {retryable && <> <button className="underline" onClick={runOcr}>Retry</button></>}
+        </Alert>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Rewrite `ImageOcr.tsx` to use `OcrWorkbench`**
+
+Replace the entire contents of `src/islands/image/ImageOcr.tsx` with:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { TextArea } from '@/components/ui/TextArea';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
+import { type OcrResult } from '@/tools/image/ocr.lib';
+import OcrWorkbench from './OcrWorkbench';
+
+export default function ImageOcr() {
+  const [result, setResult] = useState<OcrResult | null>(null);
+  const [text, setText] = useState('');
+
+  useEffect(() => { setText(result?.text ?? ''); }, [result]);
+
+  const download = () => downloadService.download(new Blob([text], { type: 'text/plain' }), 'ocr.txt');
+
+  return (
+    <div className="space-y-4">
+      <OcrWorkbench onResult={setResult} onReset={() => setResult(null)} />
+
+      {result && (
+        <div className="space-y-2">
+          {result.backend === 'wasm' && (
+            <p className="text-xs text-muted-foreground">
+              Ran in slower CPU (WASM) mode — WebGPU isn’t available in this browser.
+            </p>
+          )}
+          <TextArea label="Recognized text" value={text} onChange={(e) => setText(e.target.value)} rows={12} />
+          <div className="flex gap-2">
+            <CopyButton value={text} />
+            <Button variant="secondary" onClick={download}>Download .txt</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify the OCR tool still builds and behaves**
+
+Run: `npx vitest run` — Expected: all existing tests still pass (no test imported the old `ImageOcr` internals).
+Run: `npm run build` — Expected: succeeds; `/tools/image-ocr` page builds.
+Manual: `npm run dev` → `/tools/image-ocr` still works exactly as before (drop image → Run OCR → text + copy + download).
+
+- [ ] **Step 4: (Hold commit.)**
+
+---
+
+### Task 4: `ReceiptFields` + "Parse as receipt" toggle in the OCR tool
+
+**Files:**
+- Create: `src/islands/image/ReceiptFields.tsx`
+- Modify: `src/islands/image/ImageOcr.tsx` (add toggle)
+
+**Interfaces:**
+- Consumes: `type ReceiptData` from `@/tools/image/receipt.lib`; `receiptToJson`, `receiptToCsv` from `@/tools/image/receipt-export.lib`; `downloadService`; `Button`/`CopyButton`.
+- Produces: `ReceiptFields` — `export default function ReceiptFields({ data }: { data: ReceiptData })`.
+
+- [ ] **Step 1: Create `ReceiptFields.tsx`**
+
+Create `src/islands/image/ReceiptFields.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
+import type { ReceiptData } from '@/tools/image/receipt.lib';
+import { receiptToJson, receiptToCsv } from '@/tools/image/receipt-export.lib';
+
+const FIELDS: { key: keyof ReceiptData; label: string }[] = [
+  { key: 'merchant', label: 'Merchant' },
+  { key: 'dateRaw', label: 'Date (as printed)' },
+  { key: 'dateIso', label: 'Date (ISO)' },
+  { key: 'currency', label: 'Currency' },
+  { key: 'subtotal', label: 'Subtotal' },
+  { key: 'tax', label: 'Tax' },
+  { key: 'total', label: 'Total' },
+];
+
+// Editable string form of ReceiptData.
+type Form = Record<keyof ReceiptData, string>;
+
+function toForm(d: ReceiptData): Form {
+  return {
+    merchant: d.merchant ?? '', dateRaw: d.dateRaw ?? '', dateIso: d.dateIso ?? '',
+    currency: d.currency ?? '', subtotal: d.subtotal?.toString() ?? '',
+    tax: d.tax?.toString() ?? '', total: d.total?.toString() ?? '',
+  };
+}
+
+function toData(f: Form): ReceiptData {
+  const num = (s: string) => (s.trim() === '' || Number.isNaN(Number(s)) ? null : Number(s));
+  const str = (s: string) => (s.trim() === '' ? null : s);
+  return {
+    merchant: str(f.merchant), dateRaw: str(f.dateRaw), dateIso: str(f.dateIso),
+    currency: str(f.currency), subtotal: num(f.subtotal), tax: num(f.tax), total: num(f.total),
+  };
+}
+
+export default function ReceiptFields({ data }: { data: ReceiptData }) {
+  const [form, setForm] = useState<Form>(() => toForm(data));
+  useEffect(() => { setForm(toForm(data)); }, [data]);
+
+  const set = (key: keyof ReceiptData, value: string) => setForm((f) => ({ ...f, [key]: value }));
+  const current = toData(form);
+  const someMissing = Object.values(current).some((v) => v === null);
+
+  const downloadJson = () => downloadService.download(new Blob([receiptToJson(current)], { type: 'application/json' }), 'receipt.json');
+  const downloadCsv = () => downloadService.download(new Blob([receiptToCsv(current)], { type: 'text/csv' }), 'receipt.csv');
+
+  return (
+    <div className="space-y-3 border-2 border-border p-3">
+      <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Receipt fields</p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {FIELDS.map(({ key, label }) => (
+          <label key={key} className="space-y-1 text-sm">
+            <span className="block font-bold text-muted-foreground">{label}</span>
+            <input
+              value={form[key]}
+              onChange={(e) => set(key, e.target.value)}
+              className="w-full border-2 border-border bg-muted px-2 py-1.5 outline-none focus:shadow-brutal-sm"
+            />
+          </label>
+        ))}
+      </div>
+      {someMissing && (
+        <p className="text-xs text-muted-foreground">Some fields couldn’t be detected — fill them in above.</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <Button variant="secondary" onClick={downloadJson}>Download JSON</Button>
+        <Button variant="secondary" onClick={downloadCsv}>Download CSV</Button>
+        <CopyButton value={receiptToJson(current)} label="Copy JSON" />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add the "Parse as receipt" toggle to `ImageOcr.tsx`**
+
+In `src/islands/image/ImageOcr.tsx`, add the imports:
+
+```tsx
+import { parseReceipt } from '@/tools/image/receipt.lib';
+import ReceiptFields from './ReceiptFields';
+```
+
+Add a state hook next to the others:
+
+```tsx
+  const [asReceipt, setAsReceipt] = useState(false);
+```
+
+Then, inside the `{result && (...)}` block, after the copy/download `<div>`, add:
+
+```tsx
+          <label className="flex items-center gap-2 text-sm font-bold">
+            <input type="checkbox" checked={asReceipt} onChange={(e) => setAsReceipt(e.target.checked)} />
+            Parse as receipt
+          </label>
+          {asReceipt && <ReceiptFields data={parseReceipt(result)} />}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npx vitest run` — Expected: all pass (unchanged).
+Run: `npm run lint` — Expected: 0 errors.
+Manual: `/tools/image-ocr` → run OCR on a receipt → tick "Parse as receipt" → fields populate and are editable; JSON/CSV download work.
+
+- [ ] **Step 4: (Hold commit.)**
+
+---
+
+### Task 5: `ReceiptScanner` tool + registry
+
+**Files:**
+- Create: `src/islands/image/ReceiptScanner.tsx`
+- Modify: `src/registry/tools.ts`
+
+**Interfaces:**
+- Consumes: `OcrWorkbench`, `ReceiptFields`, `parseReceipt`, `type OcrResult`.
+- Produces: default-exported `ReceiptScanner` island; a registry entry `image-receipt-scanner`.
+
+- [ ] **Step 1: Create `ReceiptScanner.tsx`**
+
+Create `src/islands/image/ReceiptScanner.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { type OcrResult } from '@/tools/image/ocr.lib';
+import { parseReceipt } from '@/tools/image/receipt.lib';
+import OcrWorkbench from './OcrWorkbench';
+import ReceiptFields from './ReceiptFields';
+
+export default function ReceiptScanner() {
+  const [result, setResult] = useState<OcrResult | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <OcrWorkbench onResult={setResult} onReset={() => setResult(null)} />
+
+      {result && (
+        <>
+          <ReceiptFields data={parseReceipt(result)} />
+          <details className="border-2 border-border p-3">
+            <summary className="cursor-pointer text-sm font-bold text-muted-foreground">Raw recognized text</summary>
+            <pre className="mt-2 whitespace-pre-wrap break-words text-sm">{result.text}</pre>
+          </details>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Register the tool**
+
+In `src/registry/tools.ts`, add `Receipt` to the `lucide-react` import (append to the existing import list), then add this entry right after the `image-ocr` entry:
+
+```ts
+  {
+    id: 'image-receipt-scanner',
+    name: 'Receipt Scanner',
+    category: 'Image',
+    route: '/tools/image-receipt-scanner',
+    keywords: ['receipt', 'scanner', 'expense', 'invoice', 'ocr', 'extract', 'total', 'merchant'],
+    icon: Receipt,
+    summary: 'Pull merchant, date, and totals from a receipt on-device',
+    load: () => import('@/islands/image/ReceiptScanner'),
+    status: 'beta'
+  },
+```
+
+- [ ] **Step 3: Verify build + full suite + lint**
+
+Run: `npx vitest run` — Expected: all pass (receipt.lib + receipt-export.lib added).
+Run: `npm run lint` — Expected: 0 errors.
+Run: `npm run build` — Expected: succeeds; both `/tools/image-ocr` and `/tools/image-receipt-scanner` pages build.
+Manual smoke: `/tools/image-receipt-scanner` → drop a receipt → Run OCR → fields populate; raw text in the collapsible; JSON/CSV export work.
+
+- [ ] **Step 4: (Hold commit.)**
+
+---
+
+## Post-completion
+
+All five tasks leave the tree uncommitted per the user's standing instruction. When the user orders it, commit as five logical commits (one per task) and then follow **superpowers:finishing-a-development-branch** to open the PR to `develop`.
+
+## Notes / deliberate limits
+
+- **English keywords only** (`EN_KEYWORDS`); the `ReceiptKeywords` seam makes more languages a data addition later.
+- **Amount heuristic** prefers a 2-decimal "money" token, else the largest number on the keyword line — good for typical receipts, not guaranteed on exotic layouts (fields are editable).
+- **Date** is day-first for ambiguous numeric dates, editable.
+- No new island unit tests (islands stay thin; logic is in the tested libs) — consistent with the OCR MVP.

--- a/docs/superpowers/specs/2026-07-30-image-ocr-design.md
+++ b/docs/superpowers/specs/2026-07-30-image-ocr-design.md
@@ -1,0 +1,128 @@
+# Image → Text (OCR) — Design Spec
+
+**Status:** Approved (brainstorming complete)
+**Date:** 2026-07-30
+**Author:** brainstormed with Kresna
+**Scope:** Phase 1 (English-only MVP). Structured receipt parsing, multi-language, and batch input are explicitly deferred to later phases.
+
+## Goal
+
+Add a client-side **Image → Text (OCR)** tool to GoodWebTools that extracts raw text from an uploaded image or PDF entirely on-device. Receipts are the motivating use case, but the tool is a general OCR utility. The uploaded document never leaves the browser; only the OCR model files are fetched (from a CDN, cached thereafter).
+
+## Motivation & Context
+
+Users want to pull text out of receipts, screenshots, and scanned documents without uploading them to a third-party service. GWT already ships heavy on-device WASM/ML tools (`onnxruntime-web`, `mupdf`, `upscaler`, `@tensorflow/tfjs`), so the infrastructure patterns for lazy-loaded WASM, worker inference, and PWA-precache exclusion already exist and will be reused.
+
+## Locked Decisions
+
+These were settled during brainstorming and are not open questions:
+
+1. **Output:** raw recognized text (copy + download `.txt`). Structured field extraction (merchant/date/total/line items) is a **future phase**, not this spec.
+2. **Language:** **English only** for the MVP. The architecture must leave a clean seam for a curated (~10-language) picker later.
+3. **Engine:** the **PP-OCR pipeline (detection + angle-classification + recognition) running on ONNX Runtime Web**, via a maintained browser SDK (see Engine section). Chosen over Tesseract.js for higher accuracy on messy/real-world images ("the most powerful one").
+4. **Input:** a **single image** (PNG/JPG/WebP, via upload / drag-drop / paste) **or a PDF** (rasterized via the existing mupdf pipeline; multi-page PDFs get page selection).
+5. **Preprocessing:** a **"review & adjust" step** before OCR. Light auto-cleanup is available but **off by default** (PP-OCR is trained on natural images; aggressive binarizing can *reduce* accuracy). Manual overrides: rotate, crop, threshold slider.
+6. **Model hosting:** language/model files are **fetched from a CDN on demand** and cached. The image itself never leaves the browser; the UI discloses the one-time model download.
+7. **Error messages:** every failure/degradation surfaces its **specific reason** (see Error Handling).
+
+## Engine
+
+The OCR engine is a PP-OCR (PaddleOCR) pipeline running on **ONNX Runtime Web** (already a project dependency), with **WebGPU acceleration and automatic WASM fallback**. The full pipeline — image normalization, text **detection**, per-box crop/rectify, angle **classification**, text **recognition**, and CTC **decoding** — plus all post-processing is provided by the SDK; we do **not** hand-roll contour finding / polygon-unclip / perspective warp.
+
+**Lead candidate:** [`ppu-paddle-ocr`](https://www.npmjs.com/package/ppu-paddle-ocr) (`/web` entry) — PP-OCRv5, ONNX Runtime Web, WebGPU→WASM auto-fallback, on-demand + cached model download, `initialize()/recognize()/destroy()` API.
+**Alternatives with the same shape:** official [`@paddleocr/paddleocr-js`](https://www.npmjs.com/package/@paddleocr/paddleocr-js), [`@gutenye/ocr`](https://github.com/gutenye/ocr).
+
+**Engine-agnostic design:** all candidates share the `init → recognize(canvas) → { text, boxes }` shape. The exact package + version is pinned in the **first implementation task** via a thin vertical-slice eval (recognize text on one canvas, confirm bundle/model sizes, WebGPU + WASM paths). If the lead candidate fails the eval, an alternative is substituted behind the same `ocr.lib` wrapper with no other code changes.
+
+## Architecture
+
+A new **Image**-category tool `image-ocr` ("Image to Text (OCR)"), lazy-loaded through the registry `load()` like other heavy tools. Business logic lives in small, isolated, unit-tested libs; the island is a thin orchestrator.
+
+```
+File/paste ─┐
+PDF ────────┤→ [source → canvas]* → [Review & Adjust] → [ocr.lib.recognize] → [Results]
+            │      *PDF rasterized      preprocess        SDK on ORT-web        text + copy
+            │       via mupdf           (optional)        WebGPU/WASM           + download
+```
+
+### Components
+
+| File | Responsibility | Depends on | Tested by |
+|------|----------------|------------|-----------|
+| `src/tools/image/ocr.lib.ts` | Sole contact point with the OCR SDK. Lazy cached `initEngine()`; `recognize(source) → { text, lines: [{ text, box, confidence }] }`; maps SDK/runtime failures to reason-specific `OcrError`s. | the OCR SDK (mocked in tests) | mock SDK: output mapping + each error path |
+| `src/tools/image/ocr-preprocess.lib.ts` | Pure canvas transforms for the review step: grayscale, contrast/threshold (reuse `mono.lib` `toGrayscale`/`toBlackWhite`), rotate, crop. Input canvas → output canvas. | `mono.lib`, `canvas.lib` | deterministic pixel assertions (mirrors `mono.lib.test`) |
+| `src/tools/image/ocr-pdf.lib.ts` | Thin adapter: PDF `File` + page index → canvas, using the same mupdf rasterization the `pdf-to-image` tool uses. Exposes page count for the picker. | existing mupdf client/worker (mocked) | mock mupdf: page count + rasterize call |
+| `src/islands/image/ImageOcr.tsx` | Thin UI orchestrator: input (dropzone + `usePasteImage`), PDF page selection, review-&-adjust panel, run + progress, results (editable text, copy, download, optional overlay). | the three libs above | light island test / manual smoke |
+| `src/registry/tools.ts` (edit) | Register `id: 'image-ocr'`, `category: 'Image'`, `route: '/tools/image-ocr'`, `status: 'beta'`, `keywords: ['ocr','receipt','scan','text','extract','recognize','read']`, `load: () => import('@/islands/image/ImageOcr')`. | — | build / registry render |
+| `astro.config.mjs` (edit) | Add the ORT-wasm + OCR SDK chunk globs to workbox `globIgnores` so they are not PWA-precached (same treatment as DbDiagram/Monaco). | — | build (precache manifest) |
+| route page `src/pages/tools/image-ocr.astro` | Standard tool route wrapper hosting the island (follow existing tool pages). | — | build |
+
+### Data Model
+
+```ts
+interface OcrLine {
+  text: string;
+  box: { x: number; y: number; width: number; height: number }; // for optional overlay
+  confidence: number; // 0..1
+}
+interface OcrResult {
+  text: string;        // all lines joined in reading order (sorted top-to-bottom, then left-to-right)
+  lines: OcrLine[];
+}
+class OcrError extends Error {
+  reason: 'engine-unsupported' | 'model-download' | 'inference' | 'no-text' | 'input';
+  // message is the user-facing, reason-specific string
+}
+```
+
+## UX / Data Flow
+
+1. **Input:** drag-drop / file-pick / paste (`usePasteImage`) an image, or pick a PDF. A PDF renders a page to canvas via `ocr-pdf.lib`; multi-page PDFs show a page selector.
+2. **Review & Adjust panel:** live canvas preview with controls —
+   - **"Clean up image" toggle** (grayscale + contrast/threshold), **off by default**.
+   - **Rotate** (90° steps + fine).
+   - **Crop** to the region of interest.
+   - **Threshold slider** (only meaningful when cleanup is on).
+3. **Run OCR:** button runs `ocr.lib.recognize()` on the adjusted canvas. A progress/indeterminate indicator shows while the engine initializes (first-run model download) and infers. Disclose on first run that models download once from a CDN and are then cached.
+4. **Results:** recognized text in an **editable/selectable textarea**, with **Copy** and **Download .txt**. Empty result → "no text detected" guidance.
+5. **Optional stretch (flagged, not MVP-blocking):** a bounding-box overlay on the preview using `lines[].box`.
+
+## Error Handling (reason-specific)
+
+A `reason → user message` map lives in `ocr.lib`. Every surfaced state states *why*:
+
+- **WebGPU unavailable** → informational, not an error: *"Running in slower CPU (WASM) mode — WebGPU isn't available in this browser."* (OCR still works.)
+- **Engine can't initialize at all** (e.g. no WASM SIMD) → *"On-device OCR couldn't start: this browser lacks WebAssembly SIMD, which the OCR engine requires."* (`reason: 'engine-unsupported'`)
+- **Model download fails** (offline / CDN blocked) → *"Couldn't download the OCR model (network error or blocked). First use needs a connection — check it and Retry."* + Retry button. (`reason: 'model-download'`)
+- **Inference throws** → surface the underlying reason text: *"OCR failed: &lt;engine message&gt;."* (`reason: 'inference'`)
+- **Oversized image** → auto-downscaled to a max dimension before inference; note *"Large image downscaled to N px for processing."* (guard, not a hard error)
+- **No text found** → *"No text detected — try turning on Clean up image, or use a clearer/tighter crop."* (`reason: 'no-text'`)
+- **Unsupported file / broken PDF** → validation message naming the problem. (`reason: 'input'`)
+
+## Testing
+
+- **Unit (Vitest, following existing patterns):**
+  - `ocr-preprocess.lib` — deterministic pixel assertions for grayscale/threshold/rotate/crop (mirrors `mono.lib.test`).
+  - `ocr.lib` — mock the SDK; assert SDK output → `OcrResult` mapping, reading-order join, and each `OcrError` reason/message.
+  - `ocr-pdf.lib` — mock mupdf; assert page-count read and rasterize invocation.
+- **Not unit-tested:** real model inference (large, nondeterministic) — covered by a **manual smoke checklist** (English receipt, screenshot, multi-page PDF, WebGPU path, WASM-fallback path, offline model-download error). This mirrors how capture/hotkey/WASM services mock their heavy dependency in unit tests.
+- Keep the island thin so coverage concentrates in the libs.
+
+## Constraints & Non-Functional
+
+- **Privacy:** the document never leaves the browser. Only model files are fetched (CDN, cached). UI discloses this.
+- **Bundle/PWA:** ORT-wasm + SDK chunks excluded from workbox precache via `globIgnores`; models are runtime-fetched (optionally runtime-cached by the service worker for repeat/offline use).
+- **Performance:** inference off the main thread (ORT-web workers); oversized inputs downscaled; progress surfaced.
+- **Follows existing patterns:** registry `ToolDef` shape, `usePasteImage`, `mono.lib`/`canvas.lib`, mupdf rasterization, lazy `load()`.
+
+## Out of Scope (future phases)
+
+- Structured receipt fields (merchant, date, total, tax, line items).
+- Multi-language picker (~10 curated languages + per-language rec models/dicts).
+- Batch / multi-file OCR.
+- Auto-deskew of the whole image (PP-OCR per-box rectification largely covers rotation).
+- Self-hosting models for fully-offline first use.
+
+## Open Implementation Detail (resolved in the plan, not blocking)
+
+- Exact SDK package + version, and its model-hosting URLs, are pinned in the first implementation task's vertical-slice eval. The `ocr.lib` wrapper isolates this choice so a substitution touches one file.

--- a/docs/superpowers/specs/2026-07-30-receipt-parsing-design.md
+++ b/docs/superpowers/specs/2026-07-30-receipt-parsing-design.md
@@ -1,0 +1,123 @@
+# Structured Receipt Parsing — Design Spec
+
+**Status:** Approved (brainstorming complete)
+**Date:** 2026-07-30
+**Author:** brainstormed with Kresna
+**Builds on:** the Image → Text (OCR) MVP (`docs/superpowers/specs/2026-07-30-image-ocr-design.md`). Consumes its `OcrResult`.
+**Scope:** Summary fields only. Line items, multi-language keyword sets, batch, and a locale/date picker are deferred.
+
+## Goal
+
+Extract structured **summary fields** from a receipt — merchant, date, currency, subtotal, tax, total — from the OCR output, entirely client-side. Surface it two ways: a **"Parse as receipt"** toggle inside the existing Image → Text (OCR) tool, and a dedicated **"Receipt Scanner"** tool. Fields are editable and exportable as JSON and CSV.
+
+## Locked Decisions
+
+1. **Fields:** `merchant`, `date` (raw + best-effort ISO), `currency`, `subtotal`, `tax`, `total`. No line items.
+2. **Approach:** heuristic parser over the OCR `lines[]` (text + `box` + `confidence`) — Approach A. No ML model, no API. Deterministic, private, unit-testable.
+3. **Surfaces (both):** a "Parse as receipt" toggle in the OCR tool, and a dedicated "Receipt Scanner" tool. Powered by one shared pure parser.
+4. **Editable + export:** all fields editable; export **JSON** and **CSV** (single row).
+5. **Keywords English-only for the MVP**, but the parser is **built for language extension**: keyword anchors live in a pluggable `ReceiptKeywords` set (English shipped now), so adding a language later is a data addition, not a rewrite. Currency/date detection is largely locale-agnostic already.
+6. **Date ambiguity:** keep the raw printed string plus a best-effort ISO guess the user can correct. No locale/date-format picker.
+7. **Refactor approved:** extract the OCR input→preprocess→run pipeline out of `ImageOcr.tsx` into a shared `OcrWorkbench` component (behavior-preserving) so both tools reuse it.
+
+## Architecture
+
+The OCR MVP's input→preprocess→run UI currently lives inside `ImageOcr.tsx`. Extract it into a shared **`OcrWorkbench`** component that renders the dropzone, PDF page nav, preview, adjust controls (rotate / cleanup / threshold), and Run button, and reports results via callbacks. Both islands embed `OcrWorkbench` and render their own result section. Parsing and export are **pure libs** with no UI.
+
+```
+File/PDF ─▶ OcrWorkbench ─(OcrResult)─▶ parseReceipt ─(ReceiptData)─▶ ReceiptFields (editable) ─▶ JSON / CSV
+                                         (receipt.lib)                  (shared component)      (receipt-export.lib)
+```
+
+### Components
+
+| File | Responsibility | Tested by |
+|------|----------------|-----------|
+| `src/tools/image/receipt.lib.ts` (create) | Pure `parseReceipt(ocr: OcrResult): ReceiptData` + field finders. | Fixture `OcrResult`s → assert fields |
+| `src/tools/image/receipt-export.lib.ts` (create) | Pure `receiptToJson(d)` / `receiptToCsv(d)`. | Format + CSV escaping |
+| `src/islands/image/OcrWorkbench.tsx` (create; refactor from `ImageOcr`) | Shared input→preprocess→run UI. Props: `onResult(result: OcrResult): void`, `onReset(): void`. | Behavior-preserving; build + manual |
+| `src/islands/image/ReceiptFields.tsx` (create) | Shared editable-fields form + JSON/CSV export buttons. Props: `data: ReceiptData`. | Thin UI; manual |
+| `src/islands/image/ImageOcr.tsx` (modify) | Embed `OcrWorkbench`; keep raw-text output; add "Parse as receipt" toggle → `ReceiptFields`. | build + manual |
+| `src/islands/image/ReceiptScanner.tsx` (create) | Embed `OcrWorkbench`; `ReceiptFields` primary + raw text collapsible. | build + manual |
+| `src/registry/tools.ts` (modify) | Register `image-receipt-scanner`. | build |
+
+### Data Model
+
+```ts
+export interface ReceiptData {
+  merchant: string | null;
+  dateRaw: string | null;   // as printed, e.g. "01/02/2026"
+  dateIso: string | null;   // best-effort "2026-02-01" (may be wrong on ambiguous dates)
+  currency: string | null;  // "USD" | "$" | "Rp" | "€" …
+  subtotal: number | null;
+  tax: number | null;
+  total: number | null;
+}
+```
+
+`ReceiptFields` holds editable string copies of these; export serializes the current (possibly user-corrected) values. A number field that the user blanks or that never parsed exports as empty/null.
+
+## Heuristics (`receipt.lib`)
+
+Operates on `OcrResult.lines` (each `{ text, box: {x,y,width,height}, confidence }`), already in reading order.
+
+**Language-pluggable keywords.** Anchor words are not hardcoded in the finders — they come from a `ReceiptKeywords` set, so new languages are added as data, not code:
+
+```ts
+export interface ReceiptKeywords {
+  total: string[];      // e.g. ['grand total', 'amount due', 'balance due', 'total']
+  totalExclude: string[]; // e.g. ['subtotal', 'sub total', 'tax', 'vat', 'gst']
+  subtotal: string[];   // e.g. ['subtotal', 'sub total']
+  tax: string[];        // e.g. ['tax', 'vat', 'gst']
+}
+export const EN_KEYWORDS: ReceiptKeywords = { /* the English lists above */ };
+```
+
+`parseReceipt(ocr: OcrResult, keywords: ReceiptKeywords = EN_KEYWORDS): ReceiptData`. Each finder builds its matcher from the provided set. The multi-language OCR phase later adds more `ReceiptKeywords` (e.g. `ID_KEYWORDS` with `total`/`pajak`/`ppn`) and a language selector — no finder changes.
+
+- **`findMerchant`** → the text of the top-most line(s) by `box.y` (skip lines that are only a date/amount/keyword). Returns the first substantive top line.
+- **`findCurrency`** → first currency symbol (`$ € £ ¥ ₹`) or 3-letter code (`USD`, `IDR`, `Rp`…) found on any amount-bearing line.
+- **amount regex** → matches money like `1,234.56` / `1.234,56` / `12.00` with optional symbol; normalized to a JS number.
+- **`findTotal`** → amount on a line that contains one of `keywords.total` AND none of `keywords.totalExclude`; among candidates prefer the **bottom-most** (largest `box.y`), tie-break on largest amount.
+- **`findSubtotal`** → amount on a line containing one of `keywords.subtotal`.
+- **`findTax`** → amount on a line containing one of `keywords.tax`.
+- **`findDate`** → first line matching a multi-format date regex (`DD/MM/YYYY`, `YYYY-MM-DD`, `DD Mon YYYY`, `Mon DD, YYYY`); returns `{ raw, iso }`. For ambiguous numeric dates the documented convention is **DD/MM/YYYY** (day-first); `iso` is the best-effort normalization under that rule, and the user can correct it since the field is editable.
+
+Each finder returns `null` when nothing matches. `parseReceipt` assembles them into `ReceiptData`.
+
+## UX / Data Flow
+
+**Image → Text (OCR) tool:** unchanged raw-text output, plus a **"Parse as receipt"** checkbox. When on (and OCR has produced a result), render `ReceiptFields` below the text with the parsed values.
+
+**Receipt Scanner tool:** `OcrWorkbench` on top; after Run, `ReceiptFields` is the primary output (merchant, date, currency, subtotal, tax, total — each an editable input), with the raw recognized text in a collapsible `<details>`. Export buttons: **Download JSON**, **Download CSV**, plus copy.
+
+## Error Handling
+
+- OCR failures are owned by `OcrWorkbench` (existing reason-specific `OcrError` messages + retry).
+- Parsing never throws: unmatched fields are `null` → empty editable inputs. A short hint ("some fields couldn't be detected — fill them in") shows when ≥1 field is null.
+- No OCR text → the existing `no-text` error path covers it; parsing isn't invoked.
+
+## Testing
+
+- **`receipt.lib` (Vitest, table-driven):** fixture `OcrResult`s (synthetic `lines` with `box` coords) covering:
+  - total vs subtotal/tax disambiguation (a receipt with all three);
+  - keyword variants (`Grand Total`, `Amount Due`, `Balance Due`);
+  - several date formats → correct `raw` + `iso`;
+  - currency symbol and 3-letter code;
+  - merchant taken from the top line;
+  - all-null when nothing matches.
+- **`receipt-export.lib`:** `ReceiptData` → JSON object shape; CSV header + one row with proper quoting/escaping of commas in merchant names.
+- **`OcrWorkbench` refactor:** behavior-preserving — the OCR tool's existing flow keeps working (verified by build + the OCR manual smoke). Islands stay thin; no new island unit tests (consistent with the OCR MVP).
+
+## Constraints & Non-Functional
+
+- **Privacy:** no new network calls; parsing is pure local computation on the OCR result.
+- **Follows existing patterns:** pure-lib + thin-island split, registry `ToolDef`, existing `downloadService` for exports, Vitest fixtures.
+- **Behavior-preserving refactor:** extracting `OcrWorkbench` must not change the OCR tool's current UX.
+
+## Out of Scope (future phases)
+
+- Line-item extraction (description / qty / unit price).
+- Multi-language keyword *values* and a language selector (needs the multi-language OCR phase first) — but the pluggable `ReceiptKeywords` mechanism ships now, so this is additive.
+- Batch / multi-receipt aggregate export.
+- Locale/date-format picker and currency-locale configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "onnxruntime-web": "^1.27.0",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^6.1.200",
+        "ppu-paddle-ocr": "^6.2.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3915,7 +3916,6 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
       "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
       "license": "MIT",
-      "optional": true,
       "workspaces": [
         "e2e/*"
       ],
@@ -6169,6 +6169,12 @@
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
       }
+    },
+    "node_modules/@techstark/opencv-js": {
+      "version": "5.0.0-release.1",
+      "resolved": "https://registry.npmjs.org/@techstark/opencv-js/-/opencv-js-5.0.0-release.1.tgz",
+      "integrity": "sha512-PIm+eB0MFtieXoNC2GRao0dv/02sehG+Nv2nSW5D6pQm6J/4WqvDHm0RyoqOmGYQm67jdGiaOdIeTShCY3PIUg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@tensorflow/tfjs": {
       "version": "4.22.0",
@@ -15812,6 +15818,56 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/ppu-ocv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ppu-ocv/-/ppu-ocv-4.0.0.tgz",
+      "integrity": "sha512-ol+S9/KLZ0aTV0xbC8+ZB0iM+FYux8ujoULeQoYY2IDBZj4LAuujJUkzHzUA2O3KzHs17KuuIzV/w4/htPdn3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/canvas": "^1.0.0",
+        "@techstark/opencv-js": "^5.0.0-release.1"
+      },
+      "peerDependencies": {
+        "@shopify/react-native-skia": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@shopify/react-native-skia": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ppu-paddle-ocr": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ppu-paddle-ocr/-/ppu-paddle-ocr-6.2.0.tgz",
+      "integrity": "sha512-8YI6uI/IdhK5Jsi7Tb2job2k+Z5NgLdxh/4xkXVV5RJ+Qxeqq1FnThCRyigb9wy7baOzGKjrMAUBzAm+r2q5sw==",
+      "license": "MIT",
+      "dependencies": {
+        "ppu-ocv": "^4.0.0"
+      },
+      "bin": {
+        "ppu-paddle-ocr": "cli/index.js"
+      },
+      "peerDependencies": {
+        "@shopify/react-native-skia": ">=1.0.0",
+        "onnxruntime-node": "^1.23.2",
+        "onnxruntime-react-native": "^1.23.2",
+        "onnxruntime-web": "^1.23.2"
+      },
+      "peerDependenciesMeta": {
+        "@shopify/react-native-skia": {
+          "optional": true
+        },
+        "onnxruntime-node": {
+          "optional": true
+        },
+        "onnxruntime-react-native": {
+          "optional": true
+        },
+        "onnxruntime-web": {
+          "optional": true
+        }
+      }
     },
     "node_modules/preferred-pm": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "onnxruntime-web": "^1.27.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^6.1.200",
+    "ppu-paddle-ocr": "^6.2.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/islands/image/ImageOcr.tsx
+++ b/src/islands/image/ImageOcr.tsx
@@ -1,207 +1,46 @@
-import { useEffect, useRef, useState } from 'react';
-import { Dropzone } from '@/components/ui/Dropzone';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/Button';
-import { Alert } from '@/components/ui/Alert';
 import { TextArea } from '@/components/ui/TextArea';
 import { CopyButton } from '@/components/ui/CopyButton';
-import { usePasteImage } from '@/hooks/usePasteImage';
 import { downloadService } from '@/services/download';
-import { applyCleanup, rotate90 } from '@/tools/image/ocr-preprocess.lib';
-import { recognize, OcrError } from '@/tools/image/ocr.lib';
-import { getPdfPageCount, renderPdfPage } from '@/tools/image/ocr-pdf.lib';
-
-// Oversized inputs are downscaled before inference (memory/perf guard).
-const MAX_DIM = 2000;
-
-// Draw a blob to an offscreen canvas (downscaled if huge) and return its ImageData (the "base").
-async function blobToImageData(blob: Blob): Promise<ImageData> {
-  const bitmap = await createImageBitmap(blob);
-  const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
-  const w = Math.max(1, Math.round(bitmap.width * scale));
-  const h = Math.max(1, Math.round(bitmap.height * scale));
-  const canvas = document.createElement('canvas');
-  canvas.width = w;
-  canvas.height = h;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Canvas is not supported in this browser');
-  ctx.drawImage(bitmap, 0, 0, w, h);
-  bitmap.close?.();
-  return ctx.getImageData(0, 0, w, h);
-}
-
-// Apply rotation + optional cleanup, returning a canvas ready for OCR/preview.
-function buildAdjusted(
-  base: ImageData,
-  opts: { quarters: number; cleanup: boolean; threshold: number },
-): HTMLCanvasElement {
-  let img = base;
-  for (let i = 0; i < opts.quarters; i++) img = rotate90(img);
-  if (opts.cleanup) img = applyCleanup(img, { threshold: opts.threshold });
-  const canvas = document.createElement('canvas');
-  canvas.width = img.width;
-  canvas.height = img.height;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Canvas is not supported in this browser');
-  const sink = ctx.createImageData(img.width, img.height);
-  sink.data.set(img.data);
-  ctx.putImageData(sink, 0, 0);
-  return canvas;
-}
+import { type OcrResult } from '@/tools/image/ocr.lib';
+import { parseReceipt } from '@/tools/image/receipt.lib';
+import OcrWorkbench from './OcrWorkbench';
+import ReceiptFields from './ReceiptFields';
 
 export default function ImageOcr() {
-  const [file, setFile] = useState<File | null>(null);
-  const [isPdf, setIsPdf] = useState(false);
-  const [pageCount, setPageCount] = useState(0);
-  const [page, setPage] = useState(1);
-  const [base, setBase] = useState<ImageData | null>(null);
-
-  const [quarters, setQuarters] = useState(0);
-  const [cleanup, setCleanup] = useState(false); // OFF by default
-  const [threshold, setThreshold] = useState(140);
-
-  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<OcrResult | null>(null);
   const [text, setText] = useState('');
-  const [backendNote, setBackendNote] = useState('');
-  const [error, setError] = useState('');
-  const [retryable, setRetryable] = useState(false);
+  const [asReceipt, setAsReceipt] = useState(false);
 
-  const previewRef = useRef<HTMLCanvasElement | null>(null);
+  useEffect(() => { setText(result?.text ?? ''); }, [result]);
+  // Stable per OCR result so editing elsewhere doesn't reset the receipt form.
+  const receipt = useMemo(() => (result ? parseReceipt(result) : null), [result]);
 
-  const reset = () => {
-    setBase(null); setText(''); setError(''); setRetryable(false);
-    setQuarters(0); setCleanup(false); setPage(1); setPageCount(0);
-  };
-
-  const onDrop = async (files: File[]) => {
-    const f = files.find((x) => x.type.startsWith('image/') || x.type === 'application/pdf') ?? null;
-    reset();
-    setFile(f);
-    if (!f) return;
-    const pdf = f.type === 'application/pdf';
-    setIsPdf(pdf);
-    try {
-      if (pdf) {
-        const count = await getPdfPageCount(f);
-        setPageCount(count);
-        setBase(await blobToImageData(await renderPdfPage(f, 1)));
-      } else {
-        setBase(await blobToImageData(f));
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not load that file.');
-    }
-  };
-  usePasteImage((f) => onDrop([f]));
-
-  // Load a different PDF page.
-  useEffect(() => {
-    if (!file || !isPdf || pageCount === 0) return;
-    let alive = true;
-    renderPdfPage(file, page)
-      .then(blobToImageData)
-      .then((d) => alive && setBase(d))
-      .catch((e) => alive && setError(e instanceof Error ? e.message : 'Could not render that page.'));
-    return () => { alive = false; };
-  }, [file, isPdf, page, pageCount]);
-
-  // Live preview of the adjusted image.
-  useEffect(() => {
-    if (!base || !previewRef.current) return;
-    const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
-    const el = previewRef.current;
-    el.width = canvas.width;
-    el.height = canvas.height;
-    el.getContext('2d')?.drawImage(canvas, 0, 0);
-  }, [base, quarters, cleanup, threshold]);
-
-  const runOcr = async () => {
-    if (!base) return;
-    setBusy(true); setError(''); setRetryable(false); setText('');
-    try {
-      const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
-      const result = await recognize(canvas);
-      setText(result.text);
-      setBackendNote(
-        result.backend === 'wasm'
-          ? 'Ran in slower CPU (WASM) mode — WebGPU isn’t available in this browser.'
-          : '',
-      );
-    } catch (e) {
-      if (e instanceof OcrError) {
-        setError(e.message);
-        setRetryable(e.reason === 'model-download');
-      } else {
-        setError(e instanceof Error ? e.message : 'OCR failed.');
-      }
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const outName = (file?.name.replace(/\.[^.]+$/, '') || 'ocr') + '.txt';
-  const download = () => downloadService.download(new Blob([text], { type: 'text/plain' }), outName);
+  const download = () => downloadService.download(new Blob([text], { type: 'text/plain' }), 'ocr.txt');
 
   return (
     <div className="space-y-4">
-      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
-        <div className="space-y-1">
-          <p className="text-lg font-bold">Drop an image or PDF, or click to browse</p>
-          <p className="text-sm text-muted-foreground">Runs on-device · or paste (⌘V). First use downloads the OCR model once.</p>
-        </div>
-      </Dropzone>
+      <OcrWorkbench onResult={setResult} onReset={() => setResult(null)} />
 
-      {file && <p className="text-sm font-bold text-foreground">{file.name}</p>}
-
-      {isPdf && pageCount > 1 && (
-        <div className="flex items-center gap-2 text-sm">
-          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
-          <span>Page {page} / {pageCount}</span>
-          <Button variant="secondary" disabled={page >= pageCount} onClick={() => setPage((p) => p + 1)}>Next</Button>
-        </div>
-      )}
-
-      {base && (
-        <div className="space-y-3">
-          <canvas ref={previewRef} className="max-h-96 w-auto border-2 border-border" />
-
-          <div className="flex flex-wrap items-center gap-3">
-            <Button variant="secondary" onClick={() => setQuarters((q) => (q + 1) % 4)}>Rotate 90°</Button>
-            <label className="flex items-center gap-2 text-sm font-bold">
-              <input type="checkbox" checked={cleanup} onChange={(e) => setCleanup(e.target.checked)} />
-              Clean up image
-            </label>
-            {cleanup && (
-              <label className="flex items-center gap-2 text-sm">
-                <span className="uppercase tracking-wide text-muted-foreground">Threshold {threshold}</span>
-                <input type="range" min={0} max={255} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} className="accent-accent" />
-              </label>
-            )}
-            <Button onClick={runOcr} disabled={busy}>{busy ? 'Reading…' : 'Run OCR'}</Button>
-          </div>
-
-          {busy && (
-            <p className="animate-pulse text-sm text-muted-foreground">
-              Extracting text… (first run downloads the OCR model once)
+      {result && (
+        <div className="space-y-2">
+          {result.backend === 'wasm' && (
+            <p className="text-xs text-muted-foreground">
+              Ran in slower CPU (WASM) mode — WebGPU isn’t available in this browser.
             </p>
           )}
-        </div>
-      )}
-
-      {error && (
-        <Alert variant="error">
-          {error}
-          {retryable && <> <button className="underline" onClick={runOcr}>Retry</button></>}
-        </Alert>
-      )}
-
-      {text && (
-        <div className="space-y-2">
-          {backendNote && <p className="text-xs text-muted-foreground">{backendNote}</p>}
           <TextArea label="Recognized text" value={text} onChange={(e) => setText(e.target.value)} rows={12} />
           <div className="flex gap-2">
             <CopyButton value={text} />
             <Button variant="secondary" onClick={download}>Download .txt</Button>
           </div>
+
+          <label className="flex items-center gap-2 text-sm font-bold">
+            <input type="checkbox" checked={asReceipt} onChange={(e) => setAsReceipt(e.target.checked)} />
+            Parse as receipt
+          </label>
+          {asReceipt && receipt && <ReceiptFields data={receipt} />}
         </div>
       )}
     </div>

--- a/src/islands/image/ImageOcr.tsx
+++ b/src/islands/image/ImageOcr.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { TextArea } from '@/components/ui/TextArea';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { downloadService } from '@/services/download';
+import { applyCleanup, rotate90 } from '@/tools/image/ocr-preprocess.lib';
+import { recognize, OcrError } from '@/tools/image/ocr.lib';
+import { getPdfPageCount, renderPdfPage } from '@/tools/image/ocr-pdf.lib';
+
+// Oversized inputs are downscaled before inference (memory/perf guard).
+const MAX_DIM = 2000;
+
+// Draw a blob to an offscreen canvas (downscaled if huge) and return its ImageData (the "base").
+async function blobToImageData(blob: Blob): Promise<ImageData> {
+  const bitmap = await createImageBitmap(blob);
+  const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+  return ctx.getImageData(0, 0, w, h);
+}
+
+// Apply rotation + optional cleanup, returning a canvas ready for OCR/preview.
+function buildAdjusted(
+  base: ImageData,
+  opts: { quarters: number; cleanup: boolean; threshold: number },
+): HTMLCanvasElement {
+  let img = base;
+  for (let i = 0; i < opts.quarters; i++) img = rotate90(img);
+  if (opts.cleanup) img = applyCleanup(img, { threshold: opts.threshold });
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  const sink = ctx.createImageData(img.width, img.height);
+  sink.data.set(img.data);
+  ctx.putImageData(sink, 0, 0);
+  return canvas;
+}
+
+export default function ImageOcr() {
+  const [file, setFile] = useState<File | null>(null);
+  const [isPdf, setIsPdf] = useState(false);
+  const [pageCount, setPageCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [base, setBase] = useState<ImageData | null>(null);
+
+  const [quarters, setQuarters] = useState(0);
+  const [cleanup, setCleanup] = useState(false); // OFF by default
+  const [threshold, setThreshold] = useState(140);
+
+  const [busy, setBusy] = useState(false);
+  const [text, setText] = useState('');
+  const [backendNote, setBackendNote] = useState('');
+  const [error, setError] = useState('');
+  const [retryable, setRetryable] = useState(false);
+
+  const previewRef = useRef<HTMLCanvasElement | null>(null);
+
+  const reset = () => {
+    setBase(null); setText(''); setError(''); setRetryable(false);
+    setQuarters(0); setCleanup(false); setPage(1); setPageCount(0);
+  };
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find((x) => x.type.startsWith('image/') || x.type === 'application/pdf') ?? null;
+    reset();
+    setFile(f);
+    if (!f) return;
+    const pdf = f.type === 'application/pdf';
+    setIsPdf(pdf);
+    try {
+      if (pdf) {
+        const count = await getPdfPageCount(f);
+        setPageCount(count);
+        setBase(await blobToImageData(await renderPdfPage(f, 1)));
+      } else {
+        setBase(await blobToImageData(f));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load that file.');
+    }
+  };
+  usePasteImage((f) => onDrop([f]));
+
+  // Load a different PDF page.
+  useEffect(() => {
+    if (!file || !isPdf || pageCount === 0) return;
+    let alive = true;
+    renderPdfPage(file, page)
+      .then(blobToImageData)
+      .then((d) => alive && setBase(d))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : 'Could not render that page.'));
+    return () => { alive = false; };
+  }, [file, isPdf, page, pageCount]);
+
+  // Live preview of the adjusted image.
+  useEffect(() => {
+    if (!base || !previewRef.current) return;
+    const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+    const el = previewRef.current;
+    el.width = canvas.width;
+    el.height = canvas.height;
+    el.getContext('2d')?.drawImage(canvas, 0, 0);
+  }, [base, quarters, cleanup, threshold]);
+
+  const runOcr = async () => {
+    if (!base) return;
+    setBusy(true); setError(''); setRetryable(false); setText('');
+    try {
+      const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+      const result = await recognize(canvas);
+      setText(result.text);
+      setBackendNote(
+        result.backend === 'wasm'
+          ? 'Ran in slower CPU (WASM) mode — WebGPU isn’t available in this browser.'
+          : '',
+      );
+    } catch (e) {
+      if (e instanceof OcrError) {
+        setError(e.message);
+        setRetryable(e.reason === 'model-download');
+      } else {
+        setError(e instanceof Error ? e.message : 'OCR failed.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const outName = (file?.name.replace(/\.[^.]+$/, '') || 'ocr') + '.txt';
+  const download = () => downloadService.download(new Blob([text], { type: 'text/plain' }), outName);
+
+  return (
+    <div className="space-y-4">
+      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">Drop an image or PDF, or click to browse</p>
+          <p className="text-sm text-muted-foreground">Runs on-device · or paste (⌘V). First use downloads the OCR model once.</p>
+        </div>
+      </Dropzone>
+
+      {file && <p className="text-sm font-bold text-foreground">{file.name}</p>}
+
+      {isPdf && pageCount > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
+          <span>Page {page} / {pageCount}</span>
+          <Button variant="secondary" disabled={page >= pageCount} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      )}
+
+      {base && (
+        <div className="space-y-3">
+          <canvas ref={previewRef} className="max-h-96 w-auto border-2 border-border" />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="secondary" onClick={() => setQuarters((q) => (q + 1) % 4)}>Rotate 90°</Button>
+            <label className="flex items-center gap-2 text-sm font-bold">
+              <input type="checkbox" checked={cleanup} onChange={(e) => setCleanup(e.target.checked)} />
+              Clean up image
+            </label>
+            {cleanup && (
+              <label className="flex items-center gap-2 text-sm">
+                <span className="uppercase tracking-wide text-muted-foreground">Threshold {threshold}</span>
+                <input type="range" min={0} max={255} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} className="accent-accent" />
+              </label>
+            )}
+            <Button onClick={runOcr} disabled={busy}>{busy ? 'Reading…' : 'Run OCR'}</Button>
+          </div>
+
+          {busy && (
+            <p className="animate-pulse text-sm text-muted-foreground">
+              Extracting text… (first run downloads the OCR model once)
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error">
+          {error}
+          {retryable && <> <button className="underline" onClick={runOcr}>Retry</button></>}
+        </Alert>
+      )}
+
+      {text && (
+        <div className="space-y-2">
+          {backendNote && <p className="text-xs text-muted-foreground">{backendNote}</p>}
+          <TextArea label="Recognized text" value={text} onChange={(e) => setText(e.target.value)} rows={12} />
+          <div className="flex gap-2">
+            <CopyButton value={text} />
+            <Button variant="secondary" onClick={download}>Download .txt</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/islands/image/OcrWorkbench.tsx
+++ b/src/islands/image/OcrWorkbench.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { applyCleanup, rotate90 } from '@/tools/image/ocr-preprocess.lib';
+import { recognize, OcrError, type OcrResult } from '@/tools/image/ocr.lib';
+import { getPdfPageCount, renderPdfPage } from '@/tools/image/ocr-pdf.lib';
+
+const MAX_DIM = 2000;
+
+async function blobToImageData(blob: Blob): Promise<ImageData> {
+  const bitmap = await createImageBitmap(blob);
+  const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+  return ctx.getImageData(0, 0, w, h);
+}
+
+function buildAdjusted(
+  base: ImageData,
+  opts: { quarters: number; cleanup: boolean; threshold: number },
+): HTMLCanvasElement {
+  let img = base;
+  for (let i = 0; i < opts.quarters; i++) img = rotate90(img);
+  if (opts.cleanup) img = applyCleanup(img, { threshold: opts.threshold });
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas is not supported in this browser');
+  const sink = ctx.createImageData(img.width, img.height);
+  sink.data.set(img.data);
+  ctx.putImageData(sink, 0, 0);
+  return canvas;
+}
+
+export default function OcrWorkbench({
+  onResult,
+  onReset,
+}: {
+  onResult: (result: OcrResult) => void;
+  onReset: () => void;
+}) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isPdf, setIsPdf] = useState(false);
+  const [pageCount, setPageCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [base, setBase] = useState<ImageData | null>(null);
+  const [quarters, setQuarters] = useState(0);
+  const [cleanup, setCleanup] = useState(false);
+  const [threshold, setThreshold] = useState(140);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [retryable, setRetryable] = useState(false);
+  const previewRef = useRef<HTMLCanvasElement | null>(null);
+
+  const reset = () => {
+    setBase(null); setError(''); setRetryable(false);
+    setQuarters(0); setCleanup(false); setPage(1); setPageCount(0);
+    onReset();
+  };
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find((x) => x.type.startsWith('image/') || x.type === 'application/pdf') ?? null;
+    reset();
+    setFile(f);
+    if (!f) return;
+    const pdf = f.type === 'application/pdf';
+    setIsPdf(pdf);
+    try {
+      if (pdf) {
+        setPageCount(await getPdfPageCount(f));
+        setBase(await blobToImageData(await renderPdfPage(f, 1)));
+      } else {
+        setBase(await blobToImageData(f));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load that file.');
+    }
+  };
+  usePasteImage((f) => onDrop([f]));
+
+  useEffect(() => {
+    if (!file || !isPdf || pageCount === 0) return;
+    let alive = true;
+    renderPdfPage(file, page)
+      .then(blobToImageData)
+      .then((d) => alive && setBase(d))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : 'Could not render that page.'));
+    return () => { alive = false; };
+  }, [file, isPdf, page, pageCount]);
+
+  useEffect(() => {
+    if (!base || !previewRef.current) return;
+    const canvas = buildAdjusted(base, { quarters, cleanup, threshold });
+    const el = previewRef.current;
+    el.width = canvas.width;
+    el.height = canvas.height;
+    el.getContext('2d')?.drawImage(canvas, 0, 0);
+  }, [base, quarters, cleanup, threshold]);
+
+  const runOcr = async () => {
+    if (!base) return;
+    setBusy(true); setError(''); setRetryable(false);
+    try {
+      const result = await recognize(buildAdjusted(base, { quarters, cleanup, threshold }));
+      onResult(result);
+    } catch (e) {
+      if (e instanceof OcrError) {
+        setError(e.message);
+        setRetryable(e.reason === 'model-download');
+      } else {
+        setError(e instanceof Error ? e.message : 'OCR failed.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">Drop an image or PDF, or click to browse</p>
+          <p className="text-sm text-muted-foreground">Runs on-device · or paste (⌘V). First use downloads the OCR model once.</p>
+        </div>
+      </Dropzone>
+
+      {file && <p className="text-sm font-bold text-foreground">{file.name}</p>}
+
+      {isPdf && pageCount > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
+          <span>Page {page} / {pageCount}</span>
+          <Button variant="secondary" disabled={page >= pageCount} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      )}
+
+      {base && (
+        <div className="space-y-3">
+          <canvas ref={previewRef} className="max-h-96 w-auto border-2 border-border" />
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="secondary" onClick={() => setQuarters((q) => (q + 1) % 4)}>Rotate 90°</Button>
+            <label className="flex items-center gap-2 text-sm font-bold">
+              <input type="checkbox" checked={cleanup} onChange={(e) => setCleanup(e.target.checked)} />
+              Clean up image
+            </label>
+            {cleanup && (
+              <label className="flex items-center gap-2 text-sm">
+                <span className="uppercase tracking-wide text-muted-foreground">Threshold {threshold}</span>
+                <input type="range" min={0} max={255} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} className="accent-accent" />
+              </label>
+            )}
+            <Button onClick={runOcr} disabled={busy}>{busy ? 'Reading…' : 'Run OCR'}</Button>
+          </div>
+          {busy && (
+            <p className="animate-pulse text-sm text-muted-foreground">
+              Extracting text… (first run downloads the OCR model once)
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error">
+          {error}
+          {retryable && <> <button className="underline" onClick={runOcr}>Retry</button></>}
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/src/islands/image/ReceiptFields.tsx
+++ b/src/islands/image/ReceiptFields.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
+import type { ReceiptData } from '@/tools/image/receipt.lib';
+import { receiptToJson, receiptToCsv } from '@/tools/image/receipt-export.lib';
+
+const FIELDS: { key: keyof ReceiptData; label: string }[] = [
+  { key: 'merchant', label: 'Merchant' },
+  { key: 'dateRaw', label: 'Date (as printed)' },
+  { key: 'dateIso', label: 'Date (ISO)' },
+  { key: 'currency', label: 'Currency' },
+  { key: 'subtotal', label: 'Subtotal' },
+  { key: 'tax', label: 'Tax' },
+  { key: 'total', label: 'Total' },
+];
+
+// Editable string form of ReceiptData.
+type Form = Record<keyof ReceiptData, string>;
+
+function toForm(d: ReceiptData): Form {
+  return {
+    merchant: d.merchant ?? '', dateRaw: d.dateRaw ?? '', dateIso: d.dateIso ?? '',
+    currency: d.currency ?? '', subtotal: d.subtotal?.toString() ?? '',
+    tax: d.tax?.toString() ?? '', total: d.total?.toString() ?? '',
+  };
+}
+
+function toData(f: Form): ReceiptData {
+  const num = (s: string) => (s.trim() === '' || Number.isNaN(Number(s)) ? null : Number(s));
+  const str = (s: string) => (s.trim() === '' ? null : s);
+  return {
+    merchant: str(f.merchant), dateRaw: str(f.dateRaw), dateIso: str(f.dateIso),
+    currency: str(f.currency), subtotal: num(f.subtotal), tax: num(f.tax), total: num(f.total),
+  };
+}
+
+export default function ReceiptFields({ data }: { data: ReceiptData }) {
+  const [form, setForm] = useState<Form>(() => toForm(data));
+  useEffect(() => { setForm(toForm(data)); }, [data]);
+
+  const set = (key: keyof ReceiptData, value: string) => setForm((f) => ({ ...f, [key]: value }));
+  const current = toData(form);
+  const someMissing = Object.values(current).some((v) => v === null);
+
+  const downloadJson = () => downloadService.download(new Blob([receiptToJson(current)], { type: 'application/json' }), 'receipt.json');
+  const downloadCsv = () => downloadService.download(new Blob([receiptToCsv(current)], { type: 'text/csv' }), 'receipt.csv');
+
+  return (
+    <div className="space-y-3 border-2 border-border p-3">
+      <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Receipt fields</p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {FIELDS.map(({ key, label }) => (
+          <label key={key} className="space-y-1 text-sm">
+            <span className="block font-bold text-muted-foreground">{label}</span>
+            <input
+              value={form[key]}
+              onChange={(e) => set(key, e.target.value)}
+              className="w-full border-2 border-border bg-muted px-2 py-1.5 outline-none focus:shadow-brutal-sm"
+            />
+          </label>
+        ))}
+      </div>
+      {someMissing && (
+        <p className="text-xs text-muted-foreground">Some fields couldn’t be detected — fill them in above.</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <Button variant="secondary" onClick={downloadJson}>Download JSON</Button>
+        <Button variant="secondary" onClick={downloadCsv}>Download CSV</Button>
+        <CopyButton value={receiptToJson(current)} label="Copy JSON" />
+      </div>
+    </div>
+  );
+}

--- a/src/islands/image/ReceiptScanner.tsx
+++ b/src/islands/image/ReceiptScanner.tsx
@@ -1,0 +1,27 @@
+import { useMemo, useState } from 'react';
+import { type OcrResult } from '@/tools/image/ocr.lib';
+import { parseReceipt } from '@/tools/image/receipt.lib';
+import OcrWorkbench from './OcrWorkbench';
+import ReceiptFields from './ReceiptFields';
+
+export default function ReceiptScanner() {
+  const [result, setResult] = useState<OcrResult | null>(null);
+  // Stable per OCR result so re-renders don't reset the editable fields.
+  const receipt = useMemo(() => (result ? parseReceipt(result) : null), [result]);
+
+  return (
+    <div className="space-y-4">
+      <OcrWorkbench onResult={setResult} onReset={() => setResult(null)} />
+
+      {result && receipt && (
+        <>
+          <ReceiptFields data={receipt} />
+          <details className="border-2 border-border p-3">
+            <summary className="cursor-pointer text-sm font-bold text-muted-foreground">Raw recognized text</summary>
+            <pre className="mt-2 whitespace-pre-wrap break-words text-sm">{result.text}</pre>
+          </details>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -475,6 +475,17 @@ export const tools: ToolDef[] = [
     summary: 'Auto-detect and hide faces with on-device AI',
     load: () => import('@/islands/image/FaceBlur'),
     status: 'stable'
+  },
+  {
+    id: 'image-ocr',
+    name: 'Image to Text (OCR)',
+    category: 'Image',
+    route: '/tools/image-ocr',
+    keywords: ['ocr', 'receipt', 'scan', 'text', 'extract', 'recognize', 'read', 'document'],
+    icon: ScanText,
+    summary: 'Extract text from an image or PDF with on-device AI',
+    load: () => import('@/islands/image/ImageOcr'),
+    status: 'beta'
   },
   {
     id: 'image-bg-remove',

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -485,6 +485,17 @@ export const tools: ToolDef[] = [
     icon: ScanText,
     summary: 'Extract text from an image or PDF with on-device AI',
     load: () => import('@/islands/image/ImageOcr'),
+    status: 'beta'
+  },
+  {
+    id: 'image-receipt-scanner',
+    name: 'Receipt Scanner',
+    category: 'Image',
+    route: '/tools/image-receipt-scanner',
+    keywords: ['receipt', 'scanner', 'expense', 'invoice', 'ocr', 'extract', 'total', 'merchant'],
+    icon: Receipt,
+    summary: 'Pull merchant, date, and totals from a receipt on-device',
+    load: () => import('@/islands/image/ReceiptScanner'),
     status: 'beta'
   },
   {

--- a/src/tools/image/ocr-pdf.lib.test.ts
+++ b/src/tools/image/ocr-pdf.lib.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const renderPage = vi.fn();
+const destroy = vi.fn();
+const openPdfRenderer = vi.fn();
+
+vi.mock('@/tools/pdf/render.lib', () => ({
+  openPdfRenderer: (...args: unknown[]) => openPdfRenderer(...args),
+}));
+
+import { getPdfPageCount, renderPdfPage } from './ocr-pdf.lib';
+
+function fakeFile(): File {
+  // The lib only calls file.arrayBuffer(); jsdom's File lacks it, so stub it.
+  return { arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer } as unknown as File;
+}
+
+beforeEach(() => {
+  renderPage.mockReset();
+  destroy.mockReset();
+  openPdfRenderer.mockReset();
+  openPdfRenderer.mockResolvedValue({ pageCount: 3, renderPage, destroy });
+});
+
+describe('getPdfPageCount', () => {
+  it('returns the renderer page count and tears down', async () => {
+    expect(await getPdfPageCount(fakeFile())).toBe(3);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('renderPdfPage', () => {
+  it('renders the given 1-indexed page at default scale 2 and returns the blob', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    renderPage.mockResolvedValue({ blob, width: 10, height: 20 });
+    const out = await renderPdfPage(fakeFile(), 2);
+    expect(out).toBe(blob);
+    expect(renderPage).toHaveBeenCalledWith(2, 2, 'image/png');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('tears down even if rendering throws', async () => {
+    renderPage.mockRejectedValue(new Error('boom'));
+    await expect(renderPdfPage(fakeFile(), 1)).rejects.toThrow('boom');
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/tools/image/ocr-pdf.lib.ts
+++ b/src/tools/image/ocr-pdf.lib.ts
@@ -1,0 +1,22 @@
+import { openPdfRenderer } from '@/tools/pdf/render.lib';
+
+/** Number of pages in a PDF file. */
+export async function getPdfPageCount(file: File): Promise<number> {
+  const renderer = await openPdfRenderer(await file.arrayBuffer());
+  try {
+    return renderer.pageCount;
+  } finally {
+    renderer.destroy();
+  }
+}
+
+/** Rasterize one 1-indexed PDF page to a PNG blob. */
+export async function renderPdfPage(file: File, page: number, scale = 2): Promise<Blob> {
+  const renderer = await openPdfRenderer(await file.arrayBuffer());
+  try {
+    const { blob } = await renderer.renderPage(page, scale, 'image/png');
+    return blob;
+  } finally {
+    renderer.destroy();
+  }
+}

--- a/src/tools/image/ocr-preprocess.lib.test.ts
+++ b/src/tools/image/ocr-preprocess.lib.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { applyCleanup, rotate90, crop } from './ocr-preprocess.lib';
+
+// Plain ImageData is enough in jsdom — transforms only read width/height/data.
+function makeImageData(width: number, height: number, px: number[][]): ImageData {
+  const data = new Uint8ClampedArray(px.length * 4);
+  px.forEach(([r, g, b, a], i) => {
+    data[i * 4] = r; data[i * 4 + 1] = g; data[i * 4 + 2] = b; data[i * 4 + 3] = a ?? 255;
+  });
+  return { width, height, data, colorSpace: 'srgb' } as ImageData;
+}
+
+describe('applyCleanup', () => {
+  it('grayscales when no threshold (R=G=B, alpha kept)', () => {
+    const out = applyCleanup(makeImageData(2, 1, [[255, 0, 0, 255], [0, 0, 255, 128]]));
+    expect(out.data[0]).toBe(out.data[1]);
+    expect(out.data[1]).toBe(out.data[2]);
+    expect(out.data[3]).toBe(255);
+    expect(out.data[7]).toBe(128); // alpha preserved
+  });
+
+  it('binarizes to 0/255 when a threshold is given', () => {
+    const out = applyCleanup(makeImageData(2, 1, [[100, 100, 100, 255], [200, 200, 200, 255]]), { threshold: 128 });
+    expect(out.data[0]).toBe(0);   // lum 100 < 128
+    expect(out.data[4]).toBe(255); // lum 200 >= 128
+  });
+});
+
+describe('rotate90', () => {
+  it('turns a 2x1 into a 1x2 and moves pixels clockwise', () => {
+    // source row: [A=red, B=green]; 90° CW -> column top=A, bottom=B
+    const src = makeImageData(2, 1, [[255, 0, 0, 255], [0, 255, 0, 255]]);
+    const out = rotate90(src);
+    expect(out.width).toBe(1);
+    expect(out.height).toBe(2);
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([255, 0, 0]); // top = A
+    expect([out.data[4], out.data[5], out.data[6]]).toEqual([0, 255, 0]); // bottom = B
+  });
+
+  it('applied four times returns the original', () => {
+    const src = makeImageData(2, 1, [[1, 2, 3, 255], [4, 5, 6, 255]]);
+    let out = src;
+    for (let i = 0; i < 4; i++) out = rotate90(out);
+    expect(out.width).toBe(2);
+    expect(out.height).toBe(1);
+    expect(Array.from(out.data)).toEqual(Array.from(src.data));
+  });
+});
+
+describe('crop', () => {
+  it('copies the requested sub-rectangle', () => {
+    // 2x2: TL=1,TR=2,BL=3,BR=4 (red channel encodes id)
+    const src = makeImageData(2, 2, [[1, 0, 0, 255], [2, 0, 0, 255], [3, 0, 0, 255], [4, 0, 0, 255]]);
+    const out = crop(src, { x: 1, y: 0, width: 1, height: 2 }); // right column
+    expect(out.width).toBe(1);
+    expect(out.height).toBe(2);
+    expect(out.data[0]).toBe(2); // TR
+    expect(out.data[4]).toBe(4); // BR
+  });
+
+  it('clamps a region that exceeds bounds', () => {
+    const src = makeImageData(2, 1, [[1, 0, 0, 255], [2, 0, 0, 255]]);
+    const out = crop(src, { x: 0, y: 0, width: 99, height: 99 });
+    expect(out.width).toBe(2);
+    expect(out.height).toBe(1);
+  });
+});

--- a/src/tools/image/ocr-preprocess.lib.ts
+++ b/src/tools/image/ocr-preprocess.lib.ts
@@ -1,0 +1,59 @@
+import { toGrayscale, toBlackWhite } from './mono.lib';
+
+export interface OcrBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function emptyLike(width: number, height: number): ImageData {
+  return { width, height, data: new Uint8ClampedArray(width * height * 4), colorSpace: 'srgb' } as ImageData;
+}
+
+/** Grayscale; if a threshold is supplied, hard-binarize to black/white. */
+export function applyCleanup(src: ImageData, opts: { threshold?: number } = {}): ImageData {
+  const gray = toGrayscale(src);
+  return opts.threshold === undefined ? gray : toBlackWhite(gray, opts.threshold);
+}
+
+/** One 90° clockwise rotation. dest[x'=h-1-y, y'=x]. */
+export function rotate90(src: ImageData): ImageData {
+  const { width: w, height: h } = src;
+  const out = emptyLike(h, w); // dimensions swap
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const si = (y * w + x) * 4;
+      const dx = h - 1 - y;
+      const dy = x;
+      const di = (dy * h + dx) * 4;
+      out.data[di] = src.data[si];
+      out.data[di + 1] = src.data[si + 1];
+      out.data[di + 2] = src.data[si + 2];
+      out.data[di + 3] = src.data[si + 3];
+    }
+  }
+  return out;
+}
+
+/** Copy a sub-rectangle, clamped to the source bounds. */
+export function crop(src: ImageData, region: OcrBox): ImageData {
+  const x0 = Math.max(0, Math.min(region.x, src.width));
+  const y0 = Math.max(0, Math.min(region.y, src.height));
+  const x1 = Math.max(x0, Math.min(region.x + region.width, src.width));
+  const y1 = Math.max(y0, Math.min(region.y + region.height, src.height));
+  const w = x1 - x0;
+  const h = y1 - y0;
+  const out = emptyLike(w, h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const si = ((y0 + y) * src.width + (x0 + x)) * 4;
+      const di = (y * w + x) * 4;
+      out.data[di] = src.data[si];
+      out.data[di + 1] = src.data[si + 1];
+      out.data[di + 2] = src.data[si + 2];
+      out.data[di + 3] = src.data[si + 3];
+    }
+  }
+  return out;
+}

--- a/src/tools/image/ocr.engine.ts
+++ b/src/tools/image/ocr.engine.ts
@@ -1,0 +1,41 @@
+import type { OcrBox } from './ocr-preprocess.lib';
+
+export type OcrBackend = 'webgpu' | 'wasm';
+
+export interface RawLine {
+  text: string;
+  box: OcrBox;
+  confidence: number;
+}
+
+export interface OcrEngine {
+  backend: OcrBackend;
+  recognize(canvas: HTMLCanvasElement): Promise<RawLine[]>;
+}
+
+/**
+ * Create the on-device OCR engine (English default model). This is the only file
+ * that touches the OCR SDK; keep it thin so the SDK stays swappable. WebGPU is
+ * used when the browser exposes it, otherwise the SDK falls back to WASM.
+ *
+ * `ppu-paddle-ocr/web` returns `RecognitionResult` items ({ text, box, confidence })
+ * which already match our RawLine shape; `flatten: true` yields them in reading order.
+ */
+export async function createEngine(): Promise<OcrEngine> {
+  const { PaddleOcrService, isWebGpuAvailable } = await import('ppu-paddle-ocr/web');
+  const backend: OcrBackend = (await isWebGpuAvailable()) ? 'webgpu' : 'wasm';
+  const service = new PaddleOcrService();
+  await service.initialize();
+
+  return {
+    backend,
+    async recognize(canvas: HTMLCanvasElement): Promise<RawLine[]> {
+      const result = await service.recognize(canvas, { flatten: true });
+      return result.results.map((r): RawLine => ({
+        text: r.text,
+        box: r.box,
+        confidence: r.confidence,
+      }));
+    },
+  };
+}

--- a/src/tools/image/ocr.lib.test.ts
+++ b/src/tools/image/ocr.lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createEngine = vi.fn();
+vi.mock('./ocr.engine', () => ({ createEngine: () => createEngine() }));
+
+import { recognize, getEngine, resetEngine, OcrError } from './ocr.lib';
+
+function line(text: string, x: number, y: number, confidence = 0.9) {
+  return { text, box: { x, y, width: 40, height: 10 }, confidence };
+}
+
+beforeEach(() => {
+  createEngine.mockReset();
+  resetEngine(); // clear the module-level engine cache between tests
+});
+
+describe('recognize', () => {
+  it('joins lines in reading order (top-to-bottom, then left-to-right)', async () => {
+    const engineRecognize = vi.fn().mockResolvedValue([
+      line('world', 60, 0),
+      line('hello', 0, 0),
+      line('again', 0, 40),
+    ]);
+    createEngine.mockResolvedValue({ backend: 'webgpu', recognize: engineRecognize });
+    const res = await recognize({} as HTMLCanvasElement);
+    expect(res.text).toBe('hello world\nagain');
+    expect(res.backend).toBe('webgpu');
+    expect(res.lines).toHaveLength(3);
+  });
+
+  it('throws OcrError(no-text) when nothing is detected', async () => {
+    createEngine.mockResolvedValue({ backend: 'wasm', recognize: vi.fn().mockResolvedValue([]) });
+    await expect(recognize({} as HTMLCanvasElement)).rejects.toMatchObject({ reason: 'no-text' });
+  });
+
+  it('wraps an inference failure as OcrError(inference) with the cause', async () => {
+    createEngine.mockResolvedValue({ backend: 'wasm', recognize: vi.fn().mockRejectedValue(new Error('kernel died')) });
+    await expect(recognize({} as HTMLCanvasElement)).rejects.toMatchObject({
+      reason: 'inference',
+      message: expect.stringContaining('kernel died'),
+    });
+  });
+});
+
+describe('getEngine init errors', () => {
+  it('maps a network/fetch failure to model-download', async () => {
+    createEngine.mockRejectedValueOnce(new Error('Failed to fetch model'));
+    await expect(getEngine()).rejects.toMatchObject({ reason: 'model-download' });
+  });
+
+  it('maps other init failures to engine-unsupported and clears the cache for retry', async () => {
+    createEngine.mockRejectedValueOnce(new Error('no wasm SIMD'));
+    await expect(getEngine()).rejects.toMatchObject({ reason: 'engine-unsupported' });
+    // cache cleared: a second call re-invokes createEngine (now succeeding)
+    createEngine.mockResolvedValueOnce({ backend: 'wasm', recognize: vi.fn() });
+    await expect(getEngine()).resolves.toMatchObject({ backend: 'wasm' });
+    expect(createEngine).toHaveBeenCalledTimes(2);
+  });
+});
+
+it('OcrError carries name and reason', () => {
+  const e = new OcrError('input', 'bad file');
+  expect(e).toBeInstanceOf(Error);
+  expect(e.name).toBe('OcrError');
+  expect(e.reason).toBe('input');
+});

--- a/src/tools/image/ocr.lib.ts
+++ b/src/tools/image/ocr.lib.ts
@@ -1,0 +1,99 @@
+import { createEngine, type OcrEngine, type RawLine, type OcrBackend } from './ocr.engine';
+
+export type OcrReason = 'engine-unsupported' | 'model-download' | 'inference' | 'no-text' | 'input';
+
+export class OcrError extends Error {
+  reason: OcrReason;
+  constructor(reason: OcrReason, message: string) {
+    super(message);
+    this.name = 'OcrError';
+    this.reason = reason;
+  }
+}
+
+export type OcrLine = RawLine;
+export interface OcrResult {
+  text: string;
+  lines: OcrLine[];
+  backend: OcrBackend;
+}
+
+const NO_TEXT_MSG = 'No text detected — try turning on Clean up image, or use a clearer/tighter crop.';
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Init failures: a network/fetch problem means the model download failed;
+// anything else means the engine can't run in this browser.
+function toInitError(err: unknown): OcrError {
+  const msg = messageOf(err).toLowerCase();
+  if (msg.includes('fetch') || msg.includes('network') || msg.includes('download')) {
+    return new OcrError(
+      'model-download',
+      'Couldn’t download the OCR model (network error or blocked). First use needs a connection — check it and retry.',
+    );
+  }
+  return new OcrError(
+    'engine-unsupported',
+    'On-device OCR couldn’t start: this browser can’t run the OCR engine (missing WebAssembly SIMD support).',
+  );
+}
+
+let enginePromise: Promise<OcrEngine> | null = null;
+
+/** Lazily create the engine once. On failure, clear the cache so a retry re-inits. */
+export function getEngine(): Promise<OcrEngine> {
+  if (!enginePromise) {
+    enginePromise = createEngine().catch((err) => {
+      enginePromise = null;
+      throw toInitError(err);
+    });
+  }
+  return enginePromise;
+}
+
+/** Drop the cached engine (used by tests and any future "unload model" action). */
+export function resetEngine(): void {
+  enginePromise = null;
+}
+
+// Reading order: top-to-bottom, then left-to-right within a row (rows judged by
+// vertical overlap so items on the same visual line stay together).
+function sortReadingOrder(lines: RawLine[]): RawLine[] {
+  return [...lines].sort((a, b) => {
+    const rowTol = Math.min(a.box.height, b.box.height) * 0.5;
+    if (Math.abs(a.box.y - b.box.y) > rowTol) return a.box.y - b.box.y;
+    return a.box.x - b.box.x;
+  });
+}
+
+// Assemble text: group reading-ordered items into rows (same-row = space-joined),
+// then join rows with newlines. Handles both line-level and segment-level boxes.
+function assembleText(sorted: RawLine[]): string {
+  const rows: RawLine[][] = [];
+  for (const item of sorted) {
+    const row = rows[rows.length - 1];
+    const tol = row ? Math.min(row[0].box.height, item.box.height) * 0.5 : 0;
+    if (row && Math.abs(item.box.y - row[0].box.y) <= tol) {
+      row.push(item);
+    } else {
+      rows.push([item]);
+    }
+  }
+  return rows.map((row) => row.map((w) => w.text).join(' ')).join('\n');
+}
+
+/** Recognize text in a prepared canvas. Throws OcrError with a specific reason. */
+export async function recognize(canvas: HTMLCanvasElement): Promise<OcrResult> {
+  const engine = await getEngine();
+  let raw: RawLine[];
+  try {
+    raw = await engine.recognize(canvas);
+  } catch (err) {
+    throw new OcrError('inference', `OCR failed: ${messageOf(err)}`);
+  }
+  const lines = sortReadingOrder(raw);
+  if (lines.length === 0) throw new OcrError('no-text', NO_TEXT_MSG);
+  return { text: assembleText(lines), lines, backend: engine.backend };
+}

--- a/src/tools/image/receipt-export.lib.test.ts
+++ b/src/tools/image/receipt-export.lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { receiptToJson, receiptToCsv } from './receipt-export.lib';
+import type { ReceiptData } from './receipt.lib';
+
+const sample: ReceiptData = {
+  merchant: 'Blue Bottle', dateRaw: '02/03/2026', dateIso: '2026-03-02',
+  currency: '$', subtotal: 9, tax: 0.9, total: 9.9,
+};
+
+describe('receiptToJson', () => {
+  it('round-trips to the same object', () => {
+    expect(JSON.parse(receiptToJson(sample))).toEqual(sample);
+  });
+});
+
+describe('receiptToCsv', () => {
+  it('emits a header and one row', () => {
+    const csv = receiptToCsv(sample);
+    const [header, row] = csv.split('\n');
+    expect(header).toBe('merchant,dateRaw,dateIso,currency,subtotal,tax,total');
+    expect(row).toBe('Blue Bottle,02/03/2026,2026-03-02,$,9,0.9,9.9');
+  });
+  it('quotes and escapes fields containing commas or quotes', () => {
+    const row = receiptToCsv({ ...sample, merchant: 'A, "B" Store' }).split('\n')[1];
+    expect(row.startsWith('"A, ""B"" Store",')).toBe(true);
+  });
+  it('renders null fields as empty cells', () => {
+    const row = receiptToCsv({ ...sample, tax: null, dateRaw: null }).split('\n')[1];
+    expect(row).toBe('Blue Bottle,,2026-03-02,$,9,,9.9');
+  });
+});

--- a/src/tools/image/receipt-export.lib.ts
+++ b/src/tools/image/receipt-export.lib.ts
@@ -1,0 +1,19 @@
+import type { ReceiptData } from './receipt.lib';
+
+const FIELDS: (keyof ReceiptData)[] = ['merchant', 'dateRaw', 'dateIso', 'currency', 'subtotal', 'tax', 'total'];
+
+export function receiptToJson(d: ReceiptData): string {
+  return JSON.stringify(d, null, 2);
+}
+
+function csvCell(v: string | number | null): string {
+  if (v === null) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function receiptToCsv(d: ReceiptData): string {
+  const header = FIELDS.join(',');
+  const row = FIELDS.map((f) => csvCell(d[f])).join(',');
+  return `${header}\n${row}`;
+}

--- a/src/tools/image/receipt.lib.test.ts
+++ b/src/tools/image/receipt.lib.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { parseAmount, parseDate, parseReceipt, EN_KEYWORDS, type ReceiptData } from './receipt.lib';
+import type { OcrResult, OcrLine } from './ocr.lib';
+
+// Build an OcrResult from [text, y] pairs (x=0, fixed size). y drives layout.
+function ocr(rows: [string, number][]): OcrResult {
+  const lines: OcrLine[] = rows.map(([text, y]) => ({
+    text,
+    box: { x: 0, y, width: 100, height: 12 },
+    confidence: 0.9,
+  }));
+  return { text: rows.map((r) => r[0]).join('\n'), lines, backend: 'wasm' };
+}
+
+describe('parseAmount', () => {
+  const cases: [string, number | null][] = [
+    ['$12.34', 12.34],
+    ['TOTAL 1,234.56', 1234.56],
+    ['1.234,56', 1234.56],
+    ['12,50', 12.5],
+    ['1,234', 1234],
+    ['no digits here', null],
+  ];
+  it.each(cases)('parses %s', (input, expected) => {
+    expect(parseAmount(input)).toBe(expected);
+  });
+});
+
+describe('parseDate', () => {
+  it('parses ISO YYYY-MM-DD', () => {
+    expect(parseDate('Date: 2026-02-01')).toEqual({ raw: '2026-02-01', iso: '2026-02-01' });
+  });
+  it('parses numeric dates day-first', () => {
+    expect(parseDate('01/02/2026')).toEqual({ raw: '01/02/2026', iso: '2026-02-01' });
+  });
+  it('parses "5 Jan 2026"', () => {
+    expect(parseDate('5 Jan 2026')?.iso).toBe('2026-01-05');
+  });
+  it('parses "Jan 5, 2026"', () => {
+    expect(parseDate('Jan 5, 2026')?.iso).toBe('2026-01-05');
+  });
+  it('returns null when no date', () => {
+    expect(parseDate('THANK YOU')).toBeNull();
+  });
+});
+
+describe('parseReceipt', () => {
+  it('extracts all summary fields and disambiguates total from subtotal/tax', () => {
+    const result = parseReceipt(
+      ocr([
+        ['BLUE BOTTLE COFFEE', 0],
+        ['123 Main St', 10],
+        ['Date: 02/03/2026', 20],
+        ['Latte $4.50', 40],
+        ['Subtotal $9.00', 60],
+        ['Tax $0.90', 70],
+        ['TOTAL $9.90', 80],
+        ['VISA ****1234', 100],
+      ]),
+    );
+    const expected: ReceiptData = {
+      merchant: 'BLUE BOTTLE COFFEE',
+      dateRaw: '02/03/2026',
+      dateIso: '2026-03-02',
+      currency: '$',
+      subtotal: 9.0,
+      tax: 0.9,
+      total: 9.9,
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it('prefers "Grand Total" and handles "Amount Due" keyword variants', () => {
+    const r = parseReceipt(ocr([['Amount Due USD 42.00', 50], ['Grand Total USD 42.00', 60]]));
+    expect(r.total).toBe(42);
+    expect(r.currency).toBe('USD');
+  });
+
+  it('returns all-null when nothing matches', () => {
+    expect(parseReceipt(ocr([['xxxxx', 0], ['yyyyy', 10]]))).toEqual({
+      merchant: 'xxxxx', dateRaw: null, dateIso: null, currency: null, subtotal: null, tax: null, total: null,
+    });
+  });
+
+  it('accepts a custom keyword set', () => {
+    const idKeywords = { ...EN_KEYWORDS, total: ['jumlah'], totalExclude: ['pajak'] };
+    const r = parseReceipt(ocr([['Jumlah 15.00', 50]]), idKeywords);
+    expect(r.total).toBe(15);
+  });
+});

--- a/src/tools/image/receipt.lib.ts
+++ b/src/tools/image/receipt.lib.ts
@@ -1,0 +1,137 @@
+import type { OcrResult, OcrLine } from './ocr.lib';
+
+export interface ReceiptData {
+  merchant: string | null;
+  dateRaw: string | null;
+  dateIso: string | null;
+  currency: string | null;
+  subtotal: number | null;
+  tax: number | null;
+  total: number | null;
+}
+
+export interface ReceiptKeywords {
+  total: string[];
+  totalExclude: string[];
+  subtotal: string[];
+  tax: string[];
+}
+
+export const EN_KEYWORDS: ReceiptKeywords = {
+  total: ['grand total', 'amount due', 'balance due', 'total'],
+  totalExclude: ['subtotal', 'sub total', 'tax', 'vat', 'gst'],
+  subtotal: ['subtotal', 'sub total'],
+  tax: ['tax', 'vat', 'gst'],
+};
+
+// The (?!\d) lookaheads stop a token being cut mid-number (e.g. "1,234" must not
+// match as "1,23" + "4"); the thousands-only alternative then wins for "1,234".
+const NUMBER_RE = /\d{1,3}(?:[.,]\d{3})*[.,]\d{2}(?!\d)|\d+[.,]\d{2}(?!\d)|\d{1,3}(?:[.,]\d{3})+(?!\d)|\d+(?!\d)/g;
+
+// Normalize a single numeric token (handles 1,234.56 / 1.234,56 / 12,50 / 1,234 / 12).
+function normalizeNumber(tok: string): number | null {
+  let s = tok;
+  if (s.includes(',') && s.includes('.')) {
+    s = s.lastIndexOf(',') > s.lastIndexOf('.') ? s.replace(/\./g, '').replace(',', '.') : s.replace(/,/g, '');
+  } else if (s.includes(',')) {
+    s = /,\d{2}$/.test(s) ? s.replace(',', '.') : s.replace(/,/g, '');
+  } else if (s.includes('.')) {
+    if (!/\.\d{2}$/.test(s)) s = s.replace(/\./g, ''); // dots are thousands unless 2 trailing digits
+  }
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Extract a monetary amount from a line: prefer a 2-decimal (money) token, else the largest number. */
+export function parseAmount(text: string): number | null {
+  const tokens = text.match(NUMBER_RE);
+  if (!tokens) return null;
+  const money = tokens.filter((t) => /[.,]\d{2}$/.test(t));
+  if (money.length) return normalizeNumber(money[money.length - 1]);
+  const nums = tokens.map(normalizeNumber).filter((n): n is number => n !== null);
+  return nums.length ? Math.max(...nums) : null;
+}
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+const pad = (n: number) => String(n).padStart(2, '0');
+const normYear = (y: string) => (Number(y) < 100 ? 2000 + Number(y) : Number(y));
+
+/** Detect a date; ambiguous numeric dates are read day-first (DD/MM/YYYY). */
+export function parseDate(text: string): { raw: string; iso: string } | null {
+  let m: RegExpMatchArray | null;
+  if ((m = text.match(/\b(\d{4})-(\d{1,2})-(\d{1,2})\b/))) {
+    return { raw: m[0], iso: `${m[1]}-${pad(+m[2])}-${pad(+m[3])}` };
+  }
+  if ((m = text.match(/\b(\d{1,2})[/.-](\d{1,2})[/.-](\d{2,4})\b/))) {
+    return { raw: m[0], iso: `${normYear(m[3])}-${pad(+m[2])}-${pad(+m[1])}` };
+  }
+  if ((m = text.match(/\b(\d{1,2})\s+([A-Za-z]{3,})\.?\s+(\d{4})\b/))) {
+    const mo = MONTHS[m[2].slice(0, 3).toLowerCase()];
+    if (mo) return { raw: m[0], iso: `${m[3]}-${pad(mo)}-${pad(+m[1])}` };
+  }
+  if ((m = text.match(/\b([A-Za-z]{3,})\.?\s+(\d{1,2}),?\s+(\d{4})\b/))) {
+    const mo = MONTHS[m[1].slice(0, 3).toLowerCase()];
+    if (mo) return { raw: m[0], iso: `${m[3]}-${pad(mo)}-${pad(+m[2])}` };
+  }
+  return null;
+}
+
+function hasAny(text: string, kws: string[]): boolean {
+  const t = text.toLowerCase();
+  return kws.some((k) => t.includes(k));
+}
+
+function amountOnKeywordLine(lines: OcrLine[], kws: string[], exclude: string[] = []): OcrLine[] {
+  return lines.filter((l) => hasAny(l.text, kws) && !hasAny(l.text, exclude) && parseAmount(l.text) !== null);
+}
+
+function findTotal(lines: OcrLine[], kw: ReceiptKeywords): number | null {
+  const cands = amountOnKeywordLine(lines, kw.total, kw.totalExclude);
+  if (!cands.length) return null;
+  cands.sort((a, b) => b.box.y - a.box.y || (parseAmount(b.text)! - parseAmount(a.text)!));
+  return parseAmount(cands[0].text);
+}
+
+function firstAmount(lines: OcrLine[], kws: string[]): number | null {
+  const c = amountOnKeywordLine(lines, kws);
+  return c.length ? parseAmount(c[0].text) : null;
+}
+
+const CURRENCY_RE = /([$€£¥₹])|\b(USD|EUR|GBP|JPY|IDR|Rp)\b/i;
+function findCurrency(lines: OcrLine[]): string | null {
+  for (const l of lines) {
+    const m = l.text.match(CURRENCY_RE);
+    if (m) return m[1] ?? m[2];
+  }
+  return null;
+}
+
+function isAmountOnly(text: string): boolean {
+  return /^[\s$€£¥₹]*[\d.,\s]+$/.test(text.trim());
+}
+function findMerchant(lines: OcrLine[], kw: ReceiptKeywords): string | null {
+  const sorted = [...lines].sort((a, b) => a.box.y - b.box.y);
+  const skip = [...kw.total, ...kw.subtotal, ...kw.tax];
+  for (const l of sorted) {
+    const t = l.text.trim();
+    if (!t || parseDate(t) || isAmountOnly(t) || hasAny(t, skip)) continue;
+    return t;
+  }
+  return null;
+}
+
+export function parseReceipt(ocr: OcrResult, keywords: ReceiptKeywords = EN_KEYWORDS): ReceiptData {
+  const { lines } = ocr;
+  const date = parseDate(lines.map((l) => l.text).join('\n'));
+  return {
+    merchant: findMerchant(lines, keywords),
+    dateRaw: date?.raw ?? null,
+    dateIso: date?.iso ?? null,
+    currency: findCurrency(lines),
+    subtotal: firstAmount(lines, keywords.subtotal),
+    tax: firstAmount(lines, keywords.tax),
+    total: findTotal(lines, keywords),
+  };
+}


### PR DESCRIPTION
Promotes the on-device **Image → Text (OCR)** tool and **Receipt Scanner** (+ Parse-as-receipt mode) to production.

Everything runs client-side; only the OCR model is fetched (CDN, cached). 469 tests pass, lint clean, build green on develop.

Merging triggers the production Cloudflare deploy (goodwebtools.com).