### PR TITLE
feat(voice-to-text): on-device speech-to-text (Whisper)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -111,6 +111,8 @@ export default defineConfig({
           '**/DbDiagram*.js',
           '**/ppu-paddle-ocr*.js',
           '**/ort-*.wasm',
+          '**/transformers*.js',
+          '**/*huggingface*.js',
         ],
         runtimeCaching: [
           {

--- a/docs/superpowers/plans/2026-08-01-voice-to-text.md
+++ b/docs/superpowers/plans/2026-08-01-voice-to-text.md
@@ -1,0 +1,34 @@
+# Voice to Text — Implementation Plan
+
+Spec: `docs/superpowers/specs/2026-08-01-voice-to-text-design.md`. TDD per task:
+failing test → confirm fail → implement → confirm pass. Pure libs first, island last.
+
+## Task 0 — Dependency
+- `npm i @huggingface/transformers` (`.npmrc` handles peer deps).
+- Add `@huggingface/transformers` chunk glob to `astro.config.mjs` `workbox.globIgnores`.
+
+## Task 1 — `stt.lib.ts` (pure) + tests
+- `TranscriptSegment`, `mixToMono`, `segmentsToText`, `formatClock`,
+  `formatSrtTime`, `formatVttTime`, `segmentsToSrt`, `segmentsToVtt`.
+- Tests cover formatting edge cases + null-end fallback + channel averaging.
+
+## Task 2 — `stt-audio.lib.ts`
+- `decodeToMono16k(blob)` via `AudioContext({ sampleRate: 16000 })`, reuse `mixToMono`.
+- Browser API → build + manual smoke (no unit test).
+
+## Task 3 — `stt.engine.ts` (SDK boundary)
+- `createTranscriber(model, onProgress)`; WebGPU feature-detect; map chunks→segments.
+- Dynamically `import('@huggingface/transformers')`. Build + manual smoke.
+
+## Task 4 — `useAudioRecorder.ts` + tests
+- MediaRecorder capture → Blob; typed errors; track cleanup. Tests mock
+  `getUserMedia` + a fake `MediaRecorder`.
+
+## Task 5 — Island `VoiceToText.tsx`
+- Record/upload input, model selector, progress bar, transcribe, tabbed output
+  (Text / Timestamped / Subtitles), copy + download (.txt/.srt/.vtt).
+
+## Task 6 — Register + verify loop
+- Registry entry (`voice-to-text`, Media, `Mic`, beta).
+- `vitest run` + `lint` + `build` green; resolve any transformers.js/Vite SSR issue
+  (optimizeDeps.exclude / ssr.external); no precache warning.

--- a/docs/superpowers/specs/2026-08-01-voice-to-text-design.md
+++ b/docs/superpowers/specs/2026-08-01-voice-to-text-design.md
@@ -1,0 +1,166 @@
+# Voice to Text Tool — Design
+
+**Date:** 2026-08-01
+**Tool:** Media → Voice to Text (`/tools/voice-to-text`) — NEW
+**Type:** New tool (on-device ML)
+**Icon:** `Mic` (lucide-react)
+**Category:** Media
+
+## Problem
+
+Users want to transcribe speech to text — from a microphone recording or an uploaded
+audio/video file — without sending their audio to a server.
+
+## Goal
+
+A privacy-first, **fully on-device** transcription tool. Audio never leaves the browser;
+only the Whisper model weights are fetched from a CDN at runtime (same trade-off the OCR
+tool already makes). Output as editable plain text, subtitle files (SRT/VTT), and an
+inline timestamped view.
+
+## Approach
+
+On-device Whisper via **transformers.js** (`@huggingface/transformers`) — it wraps
+onnxruntime-web (already a project dep), provides the `automatic-speech-recognition`
+pipeline with a WebGPU→WASM device option, a model-download `progress_callback`, and
+segment timestamps via `return_timestamps: true`. Dynamically imported inside the engine
+boundary so the island chunk stays small; its built chunk + ORT wasm are added to
+`workbox.globIgnores`.
+
+**Scope (YAGNI):** batch "record/upload → transcribe," **not** live streaming
+transcription. Streaming (WhisperTextStreamer) is a possible follow-up.
+
+## Verified API (transformers.js v3, confirmed via docs)
+
+```js
+import { pipeline } from '@huggingface/transformers';
+const transcriber = await pipeline('automatic-speech-recognition', modelId, {
+  device: 'webgpu' | 'wasm',
+  dtype,                 // e.g. 'q8' on wasm to shrink the download
+  progress_callback,     // { status, file, progress, loaded, total }
+});
+const out = await transcriber(float32AudioAt16k, {
+  return_timestamps: true,
+  chunk_length_s: 30,
+  stride_length_s: 5,
+});
+// out = { text: string, chunks: [{ timestamp: [start, end], text }] }
+```
+
+Models (`onnx-community/*`, ONNX-ready):
+- **English · Fast** → `onnx-community/whisper-tiny.en`
+- **English · Accurate** → `onnx-community/whisper-base.en`
+- **Multilingual** → `onnx-community/whisper-base` (auto-detects language)
+
+## Files
+
+- `src/tools/media/stt.lib.ts` — pure transcript formatting (segments→text/SRT/VTT, time
+  formatters, `mixToMono`). Unit-tested.
+- `src/tools/media/stt.engine.ts` — the ONLY file touching transformers.js. `createTranscriber`.
+- `src/tools/media/stt-audio.lib.ts` — `decodeToMono16k(blob)` (Web Audio API; reuses `mixToMono`).
+- `src/hooks/useAudioRecorder.ts` — mic capture via MediaRecorder → Blob. Unit-tested (mocks).
+- `src/islands/media/VoiceToText.tsx` — thin island (default export).
+- `src/registry/tools.ts` — register `voice-to-text` (Media, `Mic`, `status: 'beta'`).
+- `astro.config.mjs` — add `@huggingface/transformers` chunk glob to `workbox.globIgnores`.
+
+## Library API
+
+### `stt.lib.ts` (pure)
+
+```ts
+export interface TranscriptSegment { start: number; end: number; text: string }
+
+export function mixToMono(channels: Float32Array[]): Float32Array; // avg channels
+export function segmentsToText(segments: TranscriptSegment[]): string; // trimmed, space-joined
+export function formatClock(seconds: number): string;   // 'm:ss' for the inline view
+export function formatSrtTime(seconds: number): string; // 'HH:MM:SS,mmm'
+export function formatVttTime(seconds: number): string; // 'HH:MM:SS.mmm'
+export function segmentsToSrt(segments: TranscriptSegment[]): string;
+export function segmentsToVtt(segments: TranscriptSegment[]): string; // 'WEBVTT\n\n' + cues
+```
+
+Robustness: a segment with a null/undefined `end` (Whisper can emit an open final
+timestamp) falls back to `start`; negatives clamp to 0.
+
+### `stt.engine.ts` (SDK boundary)
+
+```ts
+export type SttBackend = 'webgpu' | 'wasm';
+export type SttModelId =
+  | 'onnx-community/whisper-tiny.en'
+  | 'onnx-community/whisper-base.en'
+  | 'onnx-community/whisper-base';
+
+export interface Transcriber {
+  backend: SttBackend;
+  transcribe(audio: Float32Array): Promise<TranscriptSegment[]>;
+}
+
+export function createTranscriber(
+  model: SttModelId,
+  onProgress?: (ratio: number) => void, // 0..1 during model download
+): Promise<Transcriber>;
+```
+
+- Picks `webgpu` when available (feature-detect `navigator.gpu`), else `wasm` (with a
+  quantized `dtype` to shrink the download).
+- `transcribe` calls the pipeline with `return_timestamps: true`, maps `out.chunks` →
+  `TranscriptSegment[]` (falling back to a single segment from `out.text` if no chunks).
+
+### `stt-audio.lib.ts`
+
+```ts
+export function decodeToMono16k(blob: Blob): Promise<Float32Array>;
+```
+
+Uses `new AudioContext({ sampleRate: 16000 })` → `decodeAudioData` (resamples to 16k) →
+`mixToMono(channels)`; closes the context in a `finally`.
+
+### `useAudioRecorder.ts`
+
+Returns `{ recording, seconds, error, blob, start, stop, reset }`.
+`start()` → `getUserMedia({ audio: true })` → `MediaRecorder` collecting chunks; `stop()`
+finalizes a `Blob` and releases tracks. Errors map to typed reasons
+(`unsupported` / `denied` / `unknown`), mirroring `useCamera`.
+
+## Island (`VoiceToText.tsx`)
+
+1. **Input** — two ways:
+   - **Record**: mic button (via `useAudioRecorder`) with a running timer + Stop.
+   - **Upload**: `Dropzone` accepting `audio/*,video/*`.
+   Either produces a `Blob` shown with a small `<audio>` preview.
+2. **Model** selector — English Fast / English Accurate / Multilingual (default Fast).
+3. **Transcribe** button → decode (`decodeToMono16k`) → `createTranscriber` (progress bar
+   during first-time model download) → `transcribe`.
+4. **Output** — tabbed: **Text** (editable textarea) · **Timestamped** (`[m:ss] text`
+   lines) · **Subtitles** (SRT / VTT). Copy button + download (`downloadService`):
+   `.txt`, `.srt`, `.vtt`.
+5. Errors surfaced via `Alert`; busy states are plain (indeterminate) except the
+   determinate model-download `ProgressBar`.
+
+## Testing
+
+- `stt.lib.test.ts` — `mixToMono` (mono passthrough + 2-channel average); `segmentsToText`
+  (trim/space-join); `formatClock`/`formatSrtTime`/`formatVttTime` (e.g. `3661.5s` →
+  `61:01`, `01:01:01,500`, `01:01:01.500`); `segmentsToSrt`/`segmentsToVtt` (index, arrow,
+  header, null-end fallback).
+- `useAudioRecorder.test.ts` — `start()` acquires a stream (mocked `getUserMedia` +
+  fake `MediaRecorder`); missing `mediaDevices` → `unsupported`; `stop()` releases tracks.
+- `stt.engine.ts`, `stt-audio.lib.ts`, island → build + manual smoke (record → transcribe →
+  check text/SRT/VTT/download).
+
+## Build integration risks (resolve in the verify loop)
+
+- transformers.js may confuse Vite SSR (it references `onnxruntime-node`). Island is
+  client-only and the engine is dynamically imported inside a handler, so SSR shouldn't
+  touch it; if the build complains, add `@huggingface/transformers` to
+  `vite.optimizeDeps.exclude` / `vite.ssr.external`.
+- Confirm no PWA precache-size warning for the new heavy chunk (globIgnores covers it).
+- `.npmrc` already sets `legacy-peer-deps=true` for install.
+
+## Out of scope
+
+- Live streaming transcription.
+- Speaker diarization.
+- Translation task (Whisper can translate→English; not exposed in MVP).
+- Large/`whisper-large` models (download too heavy for the web MVP).

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@ffmpeg/core": "^0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
+        "@huggingface/transformers": "^4.2.0",
         "@imgly/background-removal": "^1.4.5",
         "@mediapipe/tasks-vision": "^0.10.35",
         "@nanostores/react": "^0.7.3",
@@ -3149,6 +3150,471 @@
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3236,7 +3702,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3357,7 +3822,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3374,7 +3838,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3499,7 +3962,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3522,7 +3984,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3652,7 +4113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7622,6 +8082,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8310,6 +8779,13 @@
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -9783,7 +10259,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -9801,7 +10276,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -9846,11 +10320,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -10211,6 +10690,12 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
     },
     "node_modules/es6-promise-pool": {
       "version": "2.5.0",
@@ -11518,6 +12003,35 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -11535,7 +12049,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -11647,7 +12160,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -12899,6 +13411,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -13343,6 +13861,30 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -15092,7 +15634,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15149,6 +15690,29 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
       "integrity": "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-node/node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
@@ -16802,6 +17366,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -17078,6 +17665,39 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@ffmpeg/core": "^0.12.10",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
+    "@huggingface/transformers": "^4.2.0",
     "@imgly/background-removal": "^1.4.5",
     "@mediapipe/tasks-vision": "^0.10.35",
     "@nanostores/react": "^0.7.3",

--- a/src/hooks/useAudioRecorder.test.ts
+++ b/src/hooks/useAudioRecorder.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAudioRecorder } from './useAudioRecorder';
+
+const trackStop = vi.fn();
+const track = { stop: trackStop };
+
+class FakeStream {
+  getTracks() { return [track]; }
+}
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = [];
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  state = 'inactive';
+  constructor(public stream: unknown) { FakeMediaRecorder.instances.push(this); }
+  start() { this.state = 'recording'; }
+  stop() {
+    this.state = 'inactive';
+    this.ondataavailable?.({ data: new Blob(['x'], { type: 'audio/webm' }) });
+    this.onstop?.();
+  }
+}
+
+function mockAudioDevices(getUserMedia = vi.fn().mockResolvedValue(new FakeStream())) {
+  Object.defineProperty(global.navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  });
+  (global as unknown as { MediaRecorder: unknown }).MediaRecorder = FakeMediaRecorder;
+}
+
+beforeEach(() => { trackStop.mockClear(); FakeMediaRecorder.instances = []; mockAudioDevices(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('useAudioRecorder', () => {
+  it('start() acquires the mic and enters the recording state', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => { await result.current.start(); });
+    expect(result.current.recording).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('stop() finalizes a blob and releases the mic tracks', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => { await result.current.start(); });
+    await act(async () => { result.current.stop(); });
+    expect(result.current.recording).toBe(false);
+    expect(result.current.blob).toBeInstanceOf(Blob);
+    expect(trackStop).toHaveBeenCalled();
+  });
+
+  it('maps a blocked mic to the "denied" reason', async () => {
+    const err = Object.assign(new Error('no'), { name: 'NotAllowedError' });
+    mockAudioDevices(vi.fn().mockRejectedValue(err));
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => { await result.current.start(); });
+    expect(result.current.error?.reason).toBe('denied');
+    expect(result.current.recording).toBe(false);
+  });
+
+  it('reports "unsupported" when mediaDevices is missing', async () => {
+    Object.defineProperty(global.navigator, 'mediaDevices', { configurable: true, value: undefined });
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => { await result.current.start(); });
+    expect(result.current.error?.reason).toBe('unsupported');
+  });
+
+  it('reset() clears the blob and error', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => { await result.current.start(); });
+    await act(async () => { result.current.stop(); });
+    act(() => { result.current.reset(); });
+    expect(result.current.blob).toBeNull();
+    expect(result.current.seconds).toBe(0);
+  });
+});

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type RecorderErrorReason = 'denied' | 'unsupported' | 'unknown';
+export interface RecorderError { reason: RecorderErrorReason; message: string }
+
+const MESSAGES: Record<RecorderErrorReason, string> = {
+  denied: 'Microphone access was blocked — allow it in your browser settings, or upload a file instead.',
+  unsupported: 'This browser can’t record audio.',
+  unknown: 'Could not start recording.',
+};
+
+function classify(err: unknown): RecorderErrorReason {
+  const name = err instanceof Error ? err.name : '';
+  if (name === 'NotAllowedError' || name === 'SecurityError') return 'denied';
+  return 'unknown';
+}
+
+export function useAudioRecorder() {
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const [recording, setRecording] = useState(false);
+  const [seconds, setSeconds] = useState(0);
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [error, setError] = useState<RecorderError | null>(null);
+
+  const releaseStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+    setBlob(null);
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
+      setError({ reason: 'unsupported', message: MESSAGES.unsupported });
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      chunksRef.current = [];
+      const recorder = new MediaRecorder(stream);
+      recorderRef.current = recorder;
+      recorder.ondataavailable = e => { if (e.data && e.data.size > 0) chunksRef.current.push(e.data); };
+      recorder.onstop = () => {
+        const type = chunksRef.current[0]?.type || 'audio/webm';
+        setBlob(new Blob(chunksRef.current, { type }));
+        releaseStream();
+      };
+      recorder.start();
+      setSeconds(0);
+      setRecording(true);
+      clearTimer();
+      timerRef.current = setInterval(() => setSeconds(s => s + 1), 1000);
+    } catch (err) {
+      releaseStream();
+      const reason = classify(err);
+      setError({ reason, message: MESSAGES[reason] });
+      setRecording(false);
+    }
+  }, [releaseStream, clearTimer]);
+
+  const stop = useCallback(() => {
+    clearTimer();
+    setRecording(false);
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.stop();
+    } else {
+      releaseStream();
+    }
+    recorderRef.current = null;
+  }, [clearTimer, releaseStream]);
+
+  const reset = useCallback(() => {
+    setBlob(null);
+    setSeconds(0);
+    setError(null);
+  }, []);
+
+  // Release mic + timer on unmount.
+  useEffect(() => () => { clearTimer(); releaseStream(); }, [clearTimer, releaseStream]);
+
+  return { recording, seconds, blob, error, start, stop, reset };
+}

--- a/src/islands/media/VoiceToText.tsx
+++ b/src/islands/media/VoiceToText.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Mic, Square, Upload } from 'lucide-react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ProgressBar } from '@/components/ui/ProgressBar';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
+import { useAudioRecorder } from '@/hooks/useAudioRecorder';
+import { decodeToMono16k } from '@/tools/media/stt-audio.lib';
+import { createTranscriber, type SttModelId } from '@/tools/media/stt.engine';
+import {
+  segmentsToText,
+  segmentsToSrt,
+  segmentsToVtt,
+  formatClock,
+  type TranscriptSegment,
+} from '@/tools/media/stt.lib';
+
+const MODELS: { value: SttModelId; label: string; note: string }[] = [
+  { value: 'onnx-community/whisper-tiny.en', label: 'English · Fast', note: 'smallest download' },
+  { value: 'onnx-community/whisper-base.en', label: 'English · Accurate', note: 'larger, more accurate' },
+  { value: 'onnx-community/whisper-base', label: 'Multilingual', note: 'auto-detects language' },
+];
+
+type Tab = 'text' | 'timestamped' | 'subtitles';
+
+export default function VoiceToText() {
+  const recorder = useAudioRecorder();
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string>('');
+  const [model, setModel] = useState<SttModelId>('onnx-community/whisper-tiny.en');
+  const [modelProgress, setModelProgress] = useState<number | null>(null);
+  const [transcribing, setTranscribing] = useState(false);
+  const [segments, setSegments] = useState<TranscriptSegment[] | null>(null);
+  const [editedText, setEditedText] = useState('');
+  const [tab, setTab] = useState<Tab>('text');
+  const [subFormat, setSubFormat] = useState<'srt' | 'vtt'>('srt');
+  const [error, setError] = useState('');
+  const urlRef = useRef('');
+
+  // Pick up a finished recording as the working audio.
+  useEffect(() => {
+    if (recorder.blob) setAudio(recorder.blob);
+  }, [recorder.blob]);
+
+  // Revoke the preview URL on unmount.
+  useEffect(() => () => { if (urlRef.current) URL.revokeObjectURL(urlRef.current); }, []);
+
+  const setAudio = (blob: Blob) => {
+    if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+    const url = URL.createObjectURL(blob);
+    urlRef.current = url;
+    setAudioUrl(url);
+    setAudioBlob(blob);
+    setSegments(null);
+    setError('');
+  };
+
+  const onDrop = (files: File[]) => {
+    const f = files.find(x => x.type.startsWith('audio/') || x.type.startsWith('video/'));
+    if (f) setAudio(f);
+  };
+
+  const toggleRecord = () => {
+    if (recorder.recording) {
+      recorder.stop();
+    } else {
+      setSegments(null);
+      setError('');
+      recorder.start();
+    }
+  };
+
+  const transcribe = async () => {
+    if (!audioBlob) return;
+    setError('');
+    setSegments(null);
+    setTranscribing(true);
+    setModelProgress(0);
+    try {
+      const audio = await decodeToMono16k(audioBlob);
+      const engine = await createTranscriber(model, r => setModelProgress(r));
+      setModelProgress(null); // model ready — now inference (indeterminate)
+      const segs = await engine.transcribe(audio);
+      setSegments(segs);
+      setEditedText(segmentsToText(segs));
+      setTab('text');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Transcription failed');
+    } finally {
+      setTranscribing(false);
+      setModelProgress(null);
+    }
+  };
+
+  const srt = useMemo(() => (segments ? segmentsToSrt(segments) : ''), [segments]);
+  const vtt = useMemo(() => (segments ? segmentsToVtt(segments) : ''), [segments]);
+  const currentSubs = subFormat === 'srt' ? srt : vtt;
+  const timestamped = useMemo(
+    () => (segments ? segments.map(s => `[${formatClock(s.start)}] ${s.text.trim()}`).join('\n') : ''),
+    [segments],
+  );
+
+  const copyValue = tab === 'text' ? editedText : tab === 'timestamped' ? timestamped : currentSubs;
+
+  const download = (kind: 'txt' | 'srt' | 'vtt') => {
+    const map = { txt: [editedText, 'text/plain'], srt: [srt, 'text/plain'], vtt: [vtt, 'text/vtt'] } as const;
+    const [content, mime] = map[kind];
+    downloadService.download(new Blob([content], { type: mime }), `transcript.${kind}`);
+  };
+
+  const busy = transcribing;
+
+  return (
+    <div className="space-y-4">
+      {/* Input: record or upload */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button onClick={toggleRecord} disabled={busy}>
+          {recorder.recording ? <Square className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+          {recorder.recording ? `Stop (${formatClock(recorder.seconds)})` : 'Record'}
+        </Button>
+        <span className="text-sm text-muted-foreground">or</span>
+      </div>
+
+      <Dropzone onDrop={onDrop} accept="audio/*,video/*" multiple={false}>
+        <div className="space-y-1">
+          <p className="flex items-center justify-center gap-2 text-lg font-bold">
+            <Upload className="h-5 w-5" /> Drop an audio or video file
+          </p>
+          <p className="text-sm text-muted-foreground">mp3, wav, m4a, mp4… · transcribed on your device</p>
+        </div>
+      </Dropzone>
+
+      {recorder.error && <Alert variant="error">{recorder.error.message}</Alert>}
+
+      {audioUrl && (
+        <audio controls src={audioUrl} className="w-full" />
+      )}
+
+      {/* Model + run */}
+      <div className="space-y-1.5">
+        <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">Model</span>
+        <div className="flex flex-wrap gap-2">
+          {MODELS.map(m => (
+            <Button
+              key={m.value}
+              variant={model === m.value ? 'primary' : 'secondary'}
+              aria-pressed={model === m.value}
+              onClick={() => setModel(m.value)}
+              disabled={busy}
+              title={m.note}
+            >
+              {m.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={transcribe} disabled={!audioBlob || busy}>
+          {busy ? 'Transcribing…' : 'Transcribe'}
+        </Button>
+      </div>
+
+      {modelProgress !== null && (
+        <ProgressBar percent={modelProgress * 100} label="Downloading model (first time only)" />
+      )}
+      {busy && modelProgress === null && (
+        <p className="text-sm text-muted-foreground">Transcribing on your device… this can take a moment.</p>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {/* Output */}
+      {segments && (
+        <div className="space-y-3 border-2 border-border p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant={tab === 'text' ? 'primary' : 'secondary'} onClick={() => setTab('text')}>Text</Button>
+            <Button variant={tab === 'timestamped' ? 'primary' : 'secondary'} onClick={() => setTab('timestamped')}>Timestamped</Button>
+            <Button variant={tab === 'subtitles' ? 'primary' : 'secondary'} onClick={() => setTab('subtitles')}>Subtitles</Button>
+            <div className="ml-auto">
+              <CopyButton value={copyValue} />
+            </div>
+          </div>
+
+          {tab === 'text' && (
+            <textarea
+              value={editedText}
+              onChange={e => setEditedText(e.target.value)}
+              rows={8}
+              className="w-full resize-y border-2 border-border bg-muted p-3 text-sm outline-none focus:shadow-brutal-sm"
+            />
+          )}
+
+          {tab === 'timestamped' && (
+            <pre className="max-h-96 overflow-auto whitespace-pre-wrap border-2 border-border bg-muted p-3 text-sm">{timestamped}</pre>
+          )}
+
+          {tab === 'subtitles' && (
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <Button variant={subFormat === 'srt' ? 'primary' : 'secondary'} onClick={() => setSubFormat('srt')}>SRT</Button>
+                <Button variant={subFormat === 'vtt' ? 'primary' : 'secondary'} onClick={() => setSubFormat('vtt')}>VTT</Button>
+              </div>
+              <pre className="max-h-96 overflow-auto whitespace-pre-wrap border-2 border-border bg-muted p-3 text-sm">{currentSubs}</pre>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button variant="secondary" onClick={() => download('txt')}>Download .txt</Button>
+            <Button variant="secondary" onClick={() => download('srt')}>Download .srt</Button>
+            <Button variant="secondary" onClick={() => download('vtt')}>Download .vtt</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -618,6 +618,17 @@ export const tools: ToolDef[] = [
     summary: 'Turn a video clip into an animated GIF (client-side)',
     load: () => import('@/islands/media/VideoToGif'),
     status: 'stable'
+  },
+  {
+    id: 'voice-to-text',
+    name: 'Voice to Text',
+    category: 'Media',
+    route: '/tools/voice-to-text',
+    keywords: ['voice', 'speech', 'transcribe', 'transcription', 'whisper', 'audio to text', 'dictation', 'subtitles', 'srt', 'vtt', 'stt'],
+    icon: Mic,
+    summary: 'Transcribe speech to text on-device (Whisper), with SRT/VTT export',
+    load: () => import('@/islands/media/VoiceToText'),
+    status: 'beta'
   },
   {
     id: 'video-convert',

--- a/src/tools/media/stt-audio.lib.ts
+++ b/src/tools/media/stt-audio.lib.ts
@@ -1,0 +1,29 @@
+import { mixToMono } from './stt.lib';
+
+const TARGET_RATE = 16000; // Whisper expects 16 kHz mono
+
+/**
+ * Decode an audio/video Blob to a 16 kHz mono Float32Array suitable for Whisper.
+ * Uses the Web Audio API; the AudioContext resamples to 16 kHz during decode.
+ */
+export async function decodeToMono16k(blob: Blob): Promise<Float32Array> {
+  const AudioCtx: typeof AudioContext =
+    (window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext);
+  if (!AudioCtx) throw new Error('This browser can’t decode audio.');
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const ctx = new AudioCtx({ sampleRate: TARGET_RATE });
+  try {
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+    const channels: Float32Array[] = [];
+    for (let c = 0; c < audioBuffer.numberOfChannels; c++) {
+      channels.push(audioBuffer.getChannelData(c));
+    }
+    // Copy out of the AudioBuffer before the context closes.
+    return new Float32Array(mixToMono(channels));
+  } catch {
+    throw new Error('Could not decode this audio file.');
+  } finally {
+    await ctx.close().catch(() => {});
+  }
+}

--- a/src/tools/media/stt.engine.ts
+++ b/src/tools/media/stt.engine.ts
@@ -1,0 +1,77 @@
+import type { TranscriptSegment } from './stt.lib';
+
+export type SttBackend = 'webgpu' | 'wasm';
+
+export type SttModelId =
+  | 'onnx-community/whisper-tiny.en'
+  | 'onnx-community/whisper-base.en'
+  | 'onnx-community/whisper-base';
+
+export interface Transcriber {
+  backend: SttBackend;
+  transcribe(audio: Float32Array): Promise<TranscriptSegment[]>;
+}
+
+interface AsrChunk {
+  timestamp: [number, number | null];
+  text: string;
+}
+
+async function webgpuAvailable(): Promise<boolean> {
+  try {
+    const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
+    if (!gpu) return false;
+    const adapter = await gpu.requestAdapter();
+    return !!adapter;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create the on-device speech-to-text engine. This is the ONLY file that touches
+ * transformers.js — keep it thin so the SDK stays swappable. WebGPU is used when
+ * available, otherwise a quantized WASM model keeps the download smaller.
+ *
+ * Audio never leaves the browser; only the model weights are fetched (from the HF
+ * CDN) the first time a model is used, then cached by the browser.
+ */
+export async function createTranscriber(
+  model: SttModelId,
+  onProgress?: (ratio: number) => void,
+): Promise<Transcriber> {
+  const { pipeline } = await import('@huggingface/transformers');
+  const backend: SttBackend = (await webgpuAvailable()) ? 'webgpu' : 'wasm';
+
+  const pipe = await pipeline('automatic-speech-recognition', model, {
+    device: backend,
+    // Quantize on WASM to shrink the download; full precision on WebGPU for quality.
+    dtype: backend === 'wasm' ? 'q8' : 'fp32',
+    progress_callback: (p: { status?: string; progress?: number }) => {
+      if (onProgress && p?.status === 'progress' && typeof p.progress === 'number') {
+        onProgress(Math.min(1, Math.max(0, p.progress / 100)));
+      }
+    },
+  });
+
+  return {
+    backend,
+    async transcribe(audio: Float32Array): Promise<TranscriptSegment[]> {
+      const out = (await pipe(audio, {
+        return_timestamps: true,
+        chunk_length_s: 30,
+        stride_length_s: 5,
+      })) as { text: string; chunks?: AsrChunk[] };
+
+      if (out.chunks && out.chunks.length > 0) {
+        return out.chunks.map((c): TranscriptSegment => ({
+          start: c.timestamp?.[0] ?? 0,
+          end: c.timestamp?.[1] ?? c.timestamp?.[0] ?? 0,
+          text: c.text ?? '',
+        }));
+      }
+      // No timestamps returned — fall back to a single segment.
+      return [{ start: 0, end: 0, text: out.text ?? '' }];
+    },
+  };
+}

--- a/src/tools/media/stt.lib.test.ts
+++ b/src/tools/media/stt.lib.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mixToMono,
+  segmentsToText,
+  formatClock,
+  formatSrtTime,
+  formatVttTime,
+  segmentsToSrt,
+  segmentsToVtt,
+  type TranscriptSegment,
+} from './stt.lib';
+
+describe('mixToMono', () => {
+  it('returns the single channel unchanged for mono input', () => {
+    const ch = new Float32Array([0.25, 0.5, -0.75]);
+    expect(Array.from(mixToMono([ch]))).toEqual([0.25, 0.5, -0.75]);
+  });
+  it('averages multiple channels sample-wise', () => {
+    const l = new Float32Array([1, 0, -1]);
+    const r = new Float32Array([1, 1, 1]);
+    const mono = mixToMono([l, r]);
+    expect(Array.from(mono).map(v => +v.toFixed(3))).toEqual([1, 0.5, 0]);
+  });
+  it('throws on empty channel list', () => {
+    expect(() => mixToMono([])).toThrow();
+  });
+});
+
+describe('segmentsToText', () => {
+  it('trims and space-joins segment text', () => {
+    const segs: TranscriptSegment[] = [
+      { start: 0, end: 1, text: ' Hello ' },
+      { start: 1, end: 2, text: 'world ' },
+    ];
+    expect(segmentsToText(segs)).toBe('Hello world');
+  });
+  it('drops empty segments', () => {
+    expect(segmentsToText([{ start: 0, end: 1, text: '   ' }])).toBe('');
+  });
+});
+
+describe('time formatters', () => {
+  it('formatClock renders m:ss', () => {
+    expect(formatClock(0)).toBe('0:00');
+    expect(formatClock(61)).toBe('1:01');
+    expect(formatClock(3661)).toBe('61:01');
+  });
+  it('formatSrtTime renders HH:MM:SS,mmm', () => {
+    expect(formatSrtTime(3661.5)).toBe('01:01:01,500');
+    expect(formatSrtTime(0)).toBe('00:00:00,000');
+  });
+  it('formatVttTime renders HH:MM:SS.mmm', () => {
+    expect(formatVttTime(3661.5)).toBe('01:01:01.500');
+  });
+  it('clamps negatives to zero', () => {
+    expect(formatSrtTime(-5)).toBe('00:00:00,000');
+  });
+});
+
+describe('subtitle export', () => {
+  const segs: TranscriptSegment[] = [
+    { start: 0, end: 2.5, text: 'Hello' },
+    { start: 2.5, end: 5, text: 'world' },
+  ];
+  it('segmentsToSrt numbers cues with the arrow separator', () => {
+    const srt = segmentsToSrt(segs);
+    expect(srt).toContain('1\n00:00:00,000 --> 00:00:02,500\nHello');
+    expect(srt).toContain('2\n00:00:02,500 --> 00:00:05,000\nworld');
+  });
+  it('segmentsToVtt starts with the WEBVTT header and uses dot millis', () => {
+    const vtt = segmentsToVtt(segs);
+    expect(vtt.startsWith('WEBVTT\n\n')).toBe(true);
+    expect(vtt).toContain('00:00:00.000 --> 00:00:02.500\nHello');
+  });
+  it('falls back to start when a segment end is missing', () => {
+    const open: TranscriptSegment[] = [{ start: 3, end: null as unknown as number, text: 'end' }];
+    expect(segmentsToSrt(open)).toContain('00:00:03,000 --> 00:00:03,000');
+  });
+});

--- a/src/tools/media/stt.lib.ts
+++ b/src/tools/media/stt.lib.ts
@@ -1,0 +1,93 @@
+export interface TranscriptSegment {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/** Average N audio channels into a single mono channel. */
+export function mixToMono(channels: Float32Array[]): Float32Array {
+  if (channels.length === 0) throw new Error('No audio channels to mix');
+  if (channels.length === 1) return channels[0];
+  const length = channels[0].length;
+  const out = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    let sum = 0;
+    for (const ch of channels) sum += ch[i] ?? 0;
+    out[i] = sum / channels.length;
+  }
+  return out;
+}
+
+/** Join segment text into a single trimmed transcript. */
+export function segmentsToText(segments: TranscriptSegment[]): string {
+  return segments
+    .map(s => s.text.trim())
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+}
+
+/** Clamp to a non-negative, finite number of seconds. */
+function safeSeconds(seconds: number): number {
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+}
+
+/** Whisper can emit an open final timestamp; fall back to the segment start. */
+function segmentEnd(seg: TranscriptSegment): number {
+  const end = seg.end;
+  return Number.isFinite(end) ? end : seg.start;
+}
+
+/** 'm:ss' — for the inline timestamped view. */
+export function formatClock(seconds: number): string {
+  const s = Math.floor(safeSeconds(seconds));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${mm}:${ss.toString().padStart(2, '0')}`;
+}
+
+function hms(seconds: number): { h: string; m: string; s: string; ms: string } {
+  const total = safeSeconds(seconds);
+  const whole = Math.floor(total);
+  const ms = Math.round((total - whole) * 1000);
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
+  return {
+    h: h.toString().padStart(2, '0'),
+    m: m.toString().padStart(2, '0'),
+    s: s.toString().padStart(2, '0'),
+    ms: ms.toString().padStart(3, '0'),
+  };
+}
+
+/** 'HH:MM:SS,mmm' — SRT. */
+export function formatSrtTime(seconds: number): string {
+  const { h, m, s, ms } = hms(seconds);
+  return `${h}:${m}:${s},${ms}`;
+}
+
+/** 'HH:MM:SS.mmm' — WebVTT. */
+export function formatVttTime(seconds: number): string {
+  const { h, m, s, ms } = hms(seconds);
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+/** Build an SRT subtitle document from segments. */
+export function segmentsToSrt(segments: TranscriptSegment[]): string {
+  return segments
+    .map((seg, i) => {
+      const line = `${i + 1}\n${formatSrtTime(seg.start)} --> ${formatSrtTime(segmentEnd(seg))}\n${seg.text.trim()}`;
+      return line;
+    })
+    .join('\n\n')
+    .concat('\n');
+}
+
+/** Build a WebVTT subtitle document from segments. */
+export function segmentsToVtt(segments: TranscriptSegment[]): string {
+  const cues = segments
+    .map(seg => `${formatVttTime(seg.start)} --> ${formatVttTime(segmentEnd(seg))}\n${seg.text.trim()}`)
+    .join('\n\n');
+  return `WEBVTT\n\n${cues}\n`;
+}


### PR DESCRIPTION
New **Voice to Text** tool (`/tools/voice-to-text`, Media) — transcribe speech fully on-device.

**Privacy:** audio never leaves the browser; only Whisper model weights are fetched from CDN on first use (same trade-off as the OCR tool).

- **Input:** record from the mic *or* upload an audio/video file.
- **Models:** English Fast (whisper-tiny.en) · English Accurate (base.en) · Multilingual (base). Model-download progress bar; WebGPU→WASM.
- **Output:** editable plain text · inline timestamped view · SRT/VTT subtitles (from Whisper segment timestamps). Copy + download .txt/.srt/.vtt.

Engine: transformers.js v4 on onnxruntime-web (dynamically imported; 549KB chunk excluded from PWA precache via globIgnores).

Pure tested logic (`stt.lib.ts`), SDK boundary (`stt.engine.ts`), audio decode (`stt-audio.lib.ts`), `useAudioRecorder` hook (tested). Spec+plan under `docs/superpowers/`.

514 tests pass · lint 0 errors · build green (`/tools/voice-to-text` built, no precache bloat).

⚠️ Note: the in-browser Whisper run (model fetch + WebGPU) is verified by build + manual smoke, not headless CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)