### PR TITLE
feat(webrtc): Network category + user-chosen ICE servers & serverless manual mode

### DIFF
--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -1,5 +1,5 @@
 import { tools } from '@/registry/tools';
-import { categories, categoryColors } from '@/registry/categories';
+import { categories, categoryColors, categoryNotes } from '@/registry/categories';
 
 /**
  * Static tool grid grouped by category. Rendered without a client directive so
@@ -25,6 +25,9 @@ export function ToolGrid() {
                 ({categoryTools.filter(tool => !tool.desktopOnly).length})
               </span>
             </div>
+            {categoryNotes[category] && (
+              <p className="mb-4 max-w-3xl text-sm text-muted-foreground">{categoryNotes[category]}</p>
+            )}
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {categoryTools.map(tool => {
                 const Icon = tool.icon;

--- a/src/hooks/useFileTransfer.ts
+++ b/src/hooks/useFileTransfer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { connectSignal, type SignalClient } from '@/tools/webrtc/signal-client';
 import { createPeer, type PeerHandles } from '@/tools/webrtc/peer';
+import { createManualConnection, type ManualConnection } from '@/tools/webrtc/manual';
 import {
   CHUNK_SIZE,
   chunkCount,
@@ -27,8 +28,10 @@ const HIGH_WATER = 8 * 1024 * 1024; // pause sending above this bufferedAmount
 export function useFileTransfer() {
   const signalRef = useRef<SignalClient | null>(null);
   const peerRef = useRef<PeerHandles | null>(null);
+  const manualRef = useRef<ManualConnection | null>(null);
   const channelRef = useRef<RTCDataChannel | null>(null);
   const modeRef = useRef<TransferMode>('send');
+  const iceRef = useRef<RTCIceServer[] | undefined>(undefined);
   const recvRef = useRef<{ meta: TransferMeta | null; chunks: ArrayBuffer[]; received: number }>({
     meta: null,
     chunks: [],
@@ -44,11 +47,20 @@ export function useFileTransfer() {
   const cleanup = useCallback(() => {
     channelRef.current?.close();
     peerRef.current?.close();
+    manualRef.current?.close();
     signalRef.current?.close();
     channelRef.current = null;
     peerRef.current = null;
+    manualRef.current = null;
     signalRef.current = null;
     recvRef.current = { meta: null, chunks: [], received: 0 };
+  }, []);
+
+  const handleState = useCallback((state: RTCPeerConnectionState) => {
+    if (state === 'failed' || state === 'disconnected') {
+      setError('Could not connect — the network may be too restrictive (no relay server).');
+      setStatus('error');
+    }
   }, []);
 
   const handleRecv = useCallback((data: string | ArrayBuffer) => {
@@ -92,20 +104,18 @@ export function useFileTransfer() {
     const signal = signalRef.current;
     peerRef.current = createPeer({
       initiator,
+      iceServers: iceRef.current,
       sendSignal: msg => signal.send(msg),
-      onState: state => {
-        if (state === 'failed' || state === 'disconnected') {
-          setError('Could not connect — the network may be too restrictive (no relay server).');
-          setStatus('error');
-        }
-      },
+      onState: handleState,
       onChannel: wireChannel,
     });
-  }, [wireChannel]);
+  }, [wireChannel, handleState]);
 
-  const connect = useCallback((mode: TransferMode, roomId: string) => {
+  // --- Automatic signaling (via our server) ---
+  const connect = useCallback((mode: TransferMode, roomId: string, iceServers?: RTCIceServer[]) => {
     cleanup();
     modeRef.current = mode;
+    iceRef.current = iceServers;
     setError('');
     setProgress(0);
     setReceivedBlob(null);
@@ -120,7 +130,7 @@ export function useFileTransfer() {
             else setStatus('waiting');
             break;
           case 'peer-joined':
-            setupPeer(true); // host starts the offer
+            setupPeer(true);
             break;
           case 'peer-left':
             setError('The other device disconnected.');
@@ -140,6 +150,41 @@ export function useFileTransfer() {
       onError: () => { setError('Signaling connection failed.'); setStatus('error'); },
     });
   }, [cleanup, setupPeer]);
+
+  // --- Manual signaling (serverless copy-paste) ---
+  const manualCreateOffer = useCallback(async (iceServers?: RTCIceServer[]): Promise<string> => {
+    cleanup();
+    modeRef.current = 'send';
+    setError('');
+    setProgress(0);
+    setReceivedBlob(null);
+    setIncoming(null);
+    setStatus('connecting');
+    const conn = createManualConnection({ initiator: true, iceServers, onState: handleState, onChannel: wireChannel });
+    manualRef.current = conn;
+    const code = await conn.createOfferCode();
+    setStatus('waiting');
+    return code;
+  }, [cleanup, wireChannel, handleState]);
+
+  const manualAcceptAnswer = useCallback(async (answerCode: string): Promise<void> => {
+    await manualRef.current?.acceptAnswer(answerCode);
+  }, []);
+
+  const manualAcceptOffer = useCallback(async (offerCode: string, iceServers?: RTCIceServer[]): Promise<string> => {
+    cleanup();
+    modeRef.current = 'receive';
+    setError('');
+    setProgress(0);
+    setReceivedBlob(null);
+    setIncoming(null);
+    setStatus('connecting');
+    const conn = createManualConnection({ initiator: false, iceServers, onState: handleState, onChannel: wireChannel });
+    manualRef.current = conn;
+    const answer = await conn.acceptOfferReturnAnswer(offerCode);
+    setStatus('waiting');
+    return answer;
+  }, [cleanup, wireChannel, handleState]);
 
   const sendFile = useCallback(async (file: File) => {
     const channel = channelRef.current;
@@ -177,5 +222,18 @@ export function useFileTransfer() {
 
   useEffect(() => () => cleanup(), [cleanup]);
 
-  return { status, error, progress, incoming, receivedBlob, connect, sendFile, reset, CHUNK_SIZE };
+  return {
+    status,
+    error,
+    progress,
+    incoming,
+    receivedBlob,
+    connect,
+    manualCreateOffer,
+    manualAcceptAnswer,
+    manualAcceptOffer,
+    sendFile,
+    reset,
+    CHUNK_SIZE,
+  };
 }

--- a/src/islands/files/FileTransfer.tsx
+++ b/src/islands/files/FileTransfer.tsx
@@ -1,40 +1,82 @@
 import { useEffect, useRef, useState } from 'react';
-import { Send, Download, ShieldCheck } from 'lucide-react';
+import { Send, Download, ShieldCheck, Settings } from 'lucide-react';
 import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { Alert } from '@/components/ui/Alert';
 import { ProgressBar } from '@/components/ui/ProgressBar';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { downloadService } from '@/services/download';
-import { useFileTransfer, type TransferMode } from '@/hooks/useFileTransfer';
+import { useFileTransfer } from '@/hooks/useFileTransfer';
 import { makeRoomId, roomLink, roomIdFromHash } from '@/tools/webrtc/signal.lib';
 import { formatBytes } from '@/tools/webrtc/file-transfer.lib';
+import { effectiveIceServers } from '@/tools/webrtc/ice.lib';
+
+type Signaling = 'auto' | 'manual';
+type ManualRole = 'send' | 'receive';
+
+const ICE_KEY = 'gwt.webrtc.ice';
+const SIGNALING_KEY = 'gwt.webrtc.signaling';
 
 export default function FileTransfer() {
   const t = useFileTransfer();
   const [acked, setAcked] = useState(false);
-  const [mode, setMode] = useState<TransferMode>('send');
+  const [signaling, setSignaling] = useState<Signaling>('auto');
+  const [iceText, setIceText] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Auto mode
+  const [joining, setJoining] = useState(false); // arrived via a shared link → receiver
   const [roomId, setRoomId] = useState('');
   const [link, setLink] = useState('');
+
+  // Manual mode
+  const [manualRole, setManualRole] = useState<ManualRole | null>(null);
+  const [offerCode, setOfferCode] = useState('');
+  const [answerCode, setAnswerCode] = useState('');
+  const [pastedAnswer, setPastedAnswer] = useState('');
+  const [pastedOffer, setPastedOffer] = useState('');
+  const [manualBusy, setManualBusy] = useState(false);
+  const [manualErr, setManualErr] = useState('');
+
   const sentName = useRef('');
 
-  // Decide role from the URL hash: a room id in the hash means we're receiving.
+  // Restore saved settings + decide role from the URL hash.
   useEffect(() => {
+    try {
+      setIceText(localStorage.getItem(ICE_KEY) ?? '');
+      const savedSig = localStorage.getItem(SIGNALING_KEY);
+      if (savedSig === 'manual' || savedSig === 'auto') setSignaling(savedSig);
+    } catch { /* ignore */ }
+
     const fromHash = roomIdFromHash(window.location.hash);
     if (fromHash) {
-      setMode('receive');
+      setJoining(true);
+      setSignaling('auto'); // a shared link is always automatic signaling
       setRoomId(fromHash);
     } else {
       const id = makeRoomId();
-      setMode('send');
       setRoomId(id);
       setLink(roomLink(window.location.origin, id));
     }
   }, []);
 
+  const persistIce = (text: string) => {
+    setIceText(text);
+    try { localStorage.setItem(ICE_KEY, text); } catch { /* ignore */ }
+  };
+  const persistSignaling = (s: Signaling) => {
+    setSignaling(s);
+    try { localStorage.setItem(SIGNALING_KEY, s); } catch { /* ignore */ }
+  };
+
+  const ice = () => effectiveIceServers(iceText);
+
   const start = () => {
     setAcked(true);
-    t.connect(mode, roomId);
+    if (signaling === 'auto') {
+      t.connect(joining ? 'receive' : 'send', roomId, ice());
+    }
+    // manual: wait for the user to pick a role
   };
 
   const onDrop = (files: File[]) => {
@@ -46,7 +88,42 @@ export default function FileTransfer() {
     if (t.receivedBlob && t.incoming) downloadService.download(t.receivedBlob, t.incoming.name);
   };
 
-  // --- Ack gate: nothing connects until the user agrees. ---
+  // Manual: sender
+  const chooseSend = async () => {
+    setManualRole('send');
+    setManualErr('');
+    setManualBusy(true);
+    try {
+      setOfferCode(await t.manualCreateOffer(ice()));
+    } catch (e) {
+      setManualErr(e instanceof Error ? e.message : 'Could not create the offer.');
+    } finally {
+      setManualBusy(false);
+    }
+  };
+  const submitAnswer = async () => {
+    setManualErr('');
+    try { await t.manualAcceptAnswer(pastedAnswer.trim()); }
+    catch (e) { setManualErr(e instanceof Error ? e.message : 'Invalid answer code.'); }
+  };
+
+  // Manual: receiver
+  const chooseReceive = () => { setManualRole('receive'); setManualErr(''); };
+  const submitOffer = async () => {
+    setManualErr('');
+    setManualBusy(true);
+    try {
+      setAnswerCode(await t.manualAcceptOffer(pastedOffer.trim(), ice()));
+    } catch (e) {
+      setManualErr(e instanceof Error ? e.message : 'Invalid offer code.');
+    } finally {
+      setManualBusy(false);
+    }
+  };
+
+  const isSending = signaling === 'auto' ? !joining : manualRole === 'send';
+
+  // ---------- Ack + settings gate ----------
   if (!acked) {
     return (
       <div className="space-y-4">
@@ -55,11 +132,59 @@ export default function FileTransfer() {
             <ShieldCheck className="h-5 w-5" /> Before you connect
           </p>
           <p className="text-sm text-muted-foreground">
-            To introduce your two devices, GoodWebTools uses a small <strong>signaling server</strong> to
-            exchange connection details (about 2&nbsp;KB). Your files transfer <strong>directly,
-            peer-to-peer</strong>, and never pass through our server. Connections are best-effort and may
-            fail on very restrictive networks (no relay server is used).
+            {signaling === 'auto' ? (
+              <>To introduce your two devices, GoodWebTools uses a small <strong>signaling server</strong> to
+              exchange connection details (about 2&nbsp;KB). Your files transfer <strong>directly,
+              peer-to-peer</strong>, and never pass through our server.</>
+            ) : (
+              <><strong>Manual mode uses no server at all.</strong> You&apos;ll copy-paste a connection code to the
+              other person yourself. Files transfer directly, peer-to-peer.</>
+            )}{' '}
+            Connections are best-effort and may fail on restrictive networks unless you add your own TURN server.
           </p>
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(v => !v)}
+            className="flex items-center gap-1.5 text-sm font-bold text-muted-foreground hover:text-foreground"
+          >
+            <Settings className="h-4 w-4" /> Advanced connection settings
+          </button>
+
+          {showAdvanced && (
+            <div className="space-y-3 border-2 border-border bg-muted/40 p-3">
+              {!joining && (
+                <div className="space-y-1.5">
+                  <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">Connection method</span>
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant={signaling === 'auto' ? 'primary' : 'secondary'} onClick={() => persistSignaling('auto')}>
+                      Automatic (share a link)
+                    </Button>
+                    <Button variant={signaling === 'manual' ? 'primary' : 'secondary'} onClick={() => persistSignaling('manual')}>
+                      Manual (copy-paste · no server)
+                    </Button>
+                  </div>
+                </div>
+              )}
+              <label className="block space-y-1.5">
+                <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">
+                  Your STUN / TURN servers (optional)
+                </span>
+                <textarea
+                  value={iceText}
+                  onChange={e => persistIce(e.target.value)}
+                  rows={3}
+                  spellCheck={false}
+                  placeholder={'stun:stun.example.com:3478\nturn:turn.example.com:3478 username credential'}
+                  className="w-full resize-y border-2 border-border bg-background p-2 font-mono text-xs outline-none focus:shadow-brutal-sm"
+                />
+                <span className="block text-xs text-muted-foreground">
+                  One per line. Leave empty to use public STUN. A TURN server makes connections work on strict networks.
+                </span>
+              </label>
+            </div>
+          )}
+
           <Button onClick={start}>Continue</Button>
         </div>
       </div>
@@ -68,16 +193,78 @@ export default function FileTransfer() {
 
   const statusLabel: Record<string, string> = {
     connecting: 'Connecting…',
-    waiting: 'Waiting for the other device to join…',
-    connected: mode === 'send' ? 'Connected — choose a file to send.' : 'Connected — waiting for a file…',
+    waiting: signaling === 'manual' ? 'Waiting to connect…' : 'Waiting for the other device to join…',
+    connected: isSending ? 'Connected — choose a file to send.' : 'Connected — waiting for a file…',
     transferring: 'Transferring…',
-    done: mode === 'send' ? 'Sent!' : 'Received!',
+    done: isSending ? 'Sent!' : 'Received!',
   };
+
+  const codeBox = (value: string) => (
+    <div className="space-y-1.5">
+      <textarea readOnly value={value} rows={3} className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs" />
+      <CopyButton value={value} label="Copy code" />
+    </div>
+  );
 
   return (
     <div className="space-y-4">
-      {/* Sender: shareable link */}
-      {mode === 'send' && (t.status === 'connecting' || t.status === 'waiting') && (
+      {/* ----- Manual mode ----- */}
+      {signaling === 'manual' && !manualRole && (
+        <div className="space-y-2">
+          <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Manual connection — pick a role</p>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={chooseSend} disabled={manualBusy}>I&apos;m sending</Button>
+            <Button variant="secondary" onClick={chooseReceive}>I&apos;m receiving</Button>
+          </div>
+        </div>
+      )}
+
+      {signaling === 'manual' && manualRole === 'send' && t.status !== 'connected' && t.status !== 'transferring' && t.status !== 'done' && (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 1 — send this offer code to the other person</p>
+            {manualBusy && !offerCode ? <p className="text-sm text-muted-foreground">Preparing…</p> : codeBox(offerCode)}
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 2 — paste the answer code they send back</p>
+            <textarea
+              value={pastedAnswer}
+              onChange={e => setPastedAnswer(e.target.value)}
+              rows={3}
+              spellCheck={false}
+              className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs outline-none focus:shadow-brutal-sm"
+            />
+            <Button onClick={submitAnswer} disabled={!pastedAnswer.trim()}>Connect</Button>
+          </div>
+        </div>
+      )}
+
+      {signaling === 'manual' && manualRole === 'receive' && t.status !== 'connected' && t.status !== 'transferring' && t.status !== 'done' && (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 1 — paste the offer code from the sender</p>
+            <textarea
+              value={pastedOffer}
+              onChange={e => setPastedOffer(e.target.value)}
+              rows={3}
+              spellCheck={false}
+              className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs outline-none focus:shadow-brutal-sm"
+            />
+            <Button onClick={submitOffer} disabled={!pastedOffer.trim() || manualBusy}>Generate answer</Button>
+          </div>
+          {answerCode && (
+            <div className="space-y-1.5">
+              <p className="text-sm font-bold">Step 2 — send this answer code back to the sender</p>
+              {codeBox(answerCode)}
+            </div>
+          )}
+        </div>
+      )}
+
+      {manualErr && <Alert variant="error">{manualErr}</Alert>}
+
+      {/* ----- Auto mode: shareable link ----- */}
+      {signaling === 'auto' && !joining && (t.status === 'connecting' || t.status === 'waiting') && (
         <div className="space-y-2">
           <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Share this link with the other device</p>
           <div className="flex flex-wrap items-center gap-2">
@@ -87,13 +274,13 @@ export default function FileTransfer() {
         </div>
       )}
 
+      {/* ----- Shared status + transfer ----- */}
       {t.status !== 'error' && statusLabel[t.status] && (
         <p className="text-sm text-muted-foreground">{statusLabel[t.status]}</p>
       )}
       {t.error && <Alert variant="error">{t.error}</Alert>}
 
-      {/* Sender: file picker once connected */}
-      {mode === 'send' && (t.status === 'connected' || t.status === 'done') && (
+      {isSending && (t.status === 'connected' || t.status === 'done') && (
         <Dropzone onDrop={onDrop} multiple={false}>
           <div className="space-y-1">
             <p className="flex items-center justify-center gap-2 text-lg font-bold">
@@ -104,13 +291,11 @@ export default function FileTransfer() {
         </Dropzone>
       )}
 
-      {/* Transfer progress */}
-      {(t.status === 'transferring' || (t.status === 'done' && mode === 'send')) && (
-        <ProgressBar percent={t.progress} label={mode === 'send' ? `Sending ${sentName.current}` : 'Transferring'} />
+      {(t.status === 'transferring' || (t.status === 'done' && isSending)) && (
+        <ProgressBar percent={t.progress} label={isSending ? `Sending ${sentName.current}` : 'Transferring'} />
       )}
 
-      {/* Receiver: incoming file + download */}
-      {mode === 'receive' && t.incoming && (
+      {!isSending && t.incoming && (
         <div className="space-y-2 border-2 border-border p-3">
           <p className="text-sm font-bold">{t.incoming.name} · {formatBytes(t.incoming.size)}</p>
           {t.status === 'transferring' && <ProgressBar percent={t.progress} label="Receiving" />}
@@ -121,6 +306,14 @@ export default function FileTransfer() {
           )}
         </div>
       )}
+
+      <p className="border-t border-border pt-3 text-xs text-muted-foreground">
+        <ShieldCheck className="mr-1 inline h-3.5 w-3.5" />
+        Files transfer directly between devices (peer-to-peer).{' '}
+        {signaling === 'manual'
+          ? 'Manual mode uses no server at all.'
+          : 'A minimal signaling server is used only to introduce the two devices (~2 KB handshake) — your files never pass through it.'}
+      </p>
     </div>
   );
 }

--- a/src/registry/categories.ts
+++ b/src/registry/categories.ts
@@ -7,6 +7,7 @@ export const categories: Category[] = [
   'Files',
   'Draw',
   'Media',
+  'Network',
   'Playground'
 ];
 
@@ -17,5 +18,17 @@ export const categoryColors: Record<Category, string> = {
   Files: 'bg-yellow-500',
   Draw: 'bg-purple-500',
   Media: 'bg-pink-500',
+  Network: 'bg-cyan-500',
   Playground: 'bg-orange-500'
+};
+
+/**
+ * Categories whose tools use a limited server-side component. Everything else on
+ * GoodWebTools runs fully client-side; Network tools additionally use a minimal
+ * signaling server to introduce two devices (only the ~2KB WebRTC handshake — no
+ * media or file bytes pass through it), and this can be disabled entirely with the
+ * manual (serverless) connection mode.
+ */
+export const categoryNotes: Partial<Record<Category, string>> = {
+  Network: 'These tools connect two devices directly (peer-to-peer). By default a minimal signaling server only introduces the devices — your media and files never pass through it — and you can switch to a fully serverless manual mode or bring your own STUN/TURN servers.',
 };

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -556,7 +556,7 @@ export const tools: ToolDef[] = [
   {
     id: 'file-transfer',
     name: 'P2P File Transfer',
-    category: 'Files',
+    category: 'Network',
     route: '/tools/file-transfer',
     keywords: ['file', 'transfer', 'send', 'share', 'p2p', 'peer to peer', 'webrtc', 'direct', 'device to device'],
     icon: Send,

--- a/src/tools/webrtc/ice.lib.test.ts
+++ b/src/tools/webrtc/ice.lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_ICE_SERVERS, parseIceConfig, effectiveIceServers } from './ice.lib';
+
+describe('parseIceConfig', () => {
+  it('parses a STUN line', () => {
+    const { servers, invalid } = parseIceConfig('stun:stun.example.com:3478');
+    expect(servers).toEqual([{ urls: ['stun:stun.example.com:3478'] }]);
+    expect(invalid).toEqual([]);
+  });
+  it('parses a TURN line with username and credential', () => {
+    const { servers } = parseIceConfig('turn:turn.example.com:3478 alice s3cret');
+    expect(servers[0]).toEqual({
+      urls: ['turn:turn.example.com:3478'],
+      username: 'alice',
+      credential: 's3cret',
+    });
+  });
+  it('ignores blank lines and # comments', () => {
+    const { servers } = parseIceConfig('\n# my servers\nstun:a.com:3478\n\n');
+    expect(servers).toHaveLength(1);
+  });
+  it('collects invalid lines by scheme', () => {
+    const { servers, invalid } = parseIceConfig('http://nope\nstun:ok.com:3478');
+    expect(servers).toHaveLength(1);
+    expect(invalid).toEqual(['http://nope']);
+  });
+  it('supports comma-separated urls on one line', () => {
+    const { servers } = parseIceConfig('stun:a.com:3478,stun:b.com:3478');
+    expect(servers[0].urls).toEqual(['stun:a.com:3478', 'stun:b.com:3478']);
+  });
+});
+
+describe('effectiveIceServers', () => {
+  it('falls back to the public default when input is empty', () => {
+    expect(effectiveIceServers('')).toBe(DEFAULT_ICE_SERVERS);
+    expect(effectiveIceServers('   \n # only comment')).toBe(DEFAULT_ICE_SERVERS);
+  });
+  it('uses parsed servers when provided', () => {
+    const servers = effectiveIceServers('stun:my.com:3478');
+    expect(servers).not.toBe(DEFAULT_ICE_SERVERS);
+    expect(servers[0].urls).toEqual(['stun:my.com:3478']);
+  });
+});

--- a/src/tools/webrtc/ice.lib.ts
+++ b/src/tools/webrtc/ice.lib.ts
@@ -1,0 +1,55 @@
+/**
+ * ICE (STUN/TURN) server configuration. Users can bring their own servers so they
+ * don't rely on the public defaults — a custom TURN server also fixes connections
+ * behind strict/symmetric NAT.
+ *
+ * Input format (one server per line; blank lines and `#` comments ignored):
+ *   stun:stun.example.com:3478
+ *   turn:turn.example.com:3478 <username> <credential>
+ *   stun:a.com:3478,stun:b.com:3478        (comma-separated urls share one entry)
+ */
+
+export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+  { urls: ['stun:stun.l.google.com:19302', 'stun:stun.cloudflare.com:3478'] },
+];
+
+const SCHEME_RE = /^(stun|stuns|turn|turns):/i;
+
+export interface IceParseResult {
+  servers: RTCIceServer[];
+  invalid: string[];
+}
+
+/** Parse user ICE-server input into RTCIceServer entries, collecting invalid lines. */
+export function parseIceConfig(text: string): IceParseResult {
+  const servers: RTCIceServer[] = [];
+  const invalid: string[] = [];
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const tokens = line.split(/\s+/);
+    const urls = tokens[0].split(',').map(u => u.trim()).filter(Boolean);
+    if (urls.length === 0 || !urls.every(u => SCHEME_RE.test(u))) {
+      invalid.push(line);
+      continue;
+    }
+
+    const entry: RTCIceServer = { urls };
+    const isTurn = urls.some(u => /^turns?:/i.test(u));
+    if (isTurn && tokens[1]) {
+      entry.username = tokens[1];
+      if (tokens[2]) entry.credential = tokens[2];
+    }
+    servers.push(entry);
+  }
+
+  return { servers, invalid };
+}
+
+/** The ICE servers to actually use: parsed custom servers, or the public default. */
+export function effectiveIceServers(text: string): RTCIceServer[] {
+  const { servers } = parseIceConfig(text);
+  return servers.length > 0 ? servers : DEFAULT_ICE_SERVERS;
+}

--- a/src/tools/webrtc/manual-sdp.lib.test.ts
+++ b/src/tools/webrtc/manual-sdp.lib.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSdp, decodeSdp } from './manual-sdp.lib';
+
+describe('encodeSdp / decodeSdp', () => {
+  it('round-trips an offer description', () => {
+    const desc = { type: 'offer' as RTCSdpType, sdp: 'v=0\r\no=- 1 2 IN IP4 127.0.0.1\r\n' };
+    const code = encodeSdp(desc);
+    expect(typeof code).toBe('string');
+    expect(code).not.toContain(' ');
+    expect(decodeSdp(code)).toEqual(desc);
+  });
+  it('handles unicode in the sdp safely', () => {
+    const desc = { type: 'answer' as RTCSdpType, sdp: 'naïve—café ☃' };
+    expect(decodeSdp(encodeSdp(desc))).toEqual(desc);
+  });
+  it('rejects malformed codes', () => {
+    expect(decodeSdp('')).toBeNull();
+    expect(decodeSdp('!!!not-base64!!!')).toBeNull();
+    expect(decodeSdp(btoa('{"type":"offer"}'))).toBeNull(); // missing sdp
+    expect(decodeSdp(btoa('not json'))).toBeNull();
+    expect(decodeSdp(btoa(JSON.stringify({ type: 'bogus', sdp: 'x' })))).toBeNull();
+  });
+});

--- a/src/tools/webrtc/manual-sdp.lib.ts
+++ b/src/tools/webrtc/manual-sdp.lib.ts
@@ -1,0 +1,47 @@
+/**
+ * Encode/decode an SDP offer or answer as a compact, copy-pasteable code for the
+ * manual (serverless) signaling mode. Base64 keeps it on a single line and robust
+ * to being pasted through chat/email. UTF-8 safe.
+ */
+
+function toBase64(str: string): string {
+  // Encode UTF-8 → base64 without relying on Node Buffer.
+  const utf8 = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) =>
+    String.fromCharCode(parseInt(h, 16)),
+  );
+  return btoa(utf8);
+}
+
+function fromBase64(b64: string): string {
+  const binary = atob(b64);
+  return decodeURIComponent(
+    Array.from(binary, c => '%' + c.charCodeAt(0).toString(16).padStart(2, '0')).join(''),
+  );
+}
+
+/** Serialize a session description to a single-line code. */
+export function encodeSdp(desc: RTCSessionDescriptionInit): string {
+  return toBase64(JSON.stringify({ type: desc.type, sdp: desc.sdp }));
+}
+
+/** Parse + validate a pasted code back into a session description, or null. */
+export function decodeSdp(code: string): RTCSessionDescriptionInit | null {
+  const trimmed = code.trim();
+  if (!trimmed) return null;
+  let json: string;
+  try {
+    json = fromBase64(trimmed);
+  } catch {
+    return null;
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const m = obj as Record<string, unknown>;
+  if ((m.type !== 'offer' && m.type !== 'answer') || typeof m.sdp !== 'string') return null;
+  return { type: m.type, sdp: m.sdp };
+}

--- a/src/tools/webrtc/manual.ts
+++ b/src/tools/webrtc/manual.ts
@@ -1,0 +1,83 @@
+import { DEFAULT_ICE_SERVERS } from './ice.lib';
+import { encodeSdp, decodeSdp } from './manual-sdp.lib';
+
+/**
+ * Serverless WebRTC connection: the two peers copy-paste an offer code and an
+ * answer code to each other through any channel (chat, email). No signaling
+ * server is involved. ICE is gathered fully before producing each code
+ * ("non-trickle") so all candidates travel inside the code.
+ */
+
+export interface ManualOptions {
+  initiator: boolean;
+  iceServers?: RTCIceServer[];
+  onState?: (state: RTCPeerConnectionState) => void;
+  onChannel?: (channel: RTCDataChannel) => void;
+}
+
+export interface ManualConnection {
+  pc: RTCPeerConnection;
+  /** Sender: produce the offer code to share. */
+  createOfferCode(): Promise<string>;
+  /** Receiver: accept the sender's offer code, return the answer code to share back. */
+  acceptOfferReturnAnswer(offerCode: string): Promise<string>;
+  /** Sender: accept the receiver's answer code to complete the connection. */
+  acceptAnswer(answerCode: string): Promise<void>;
+  close(): void;
+}
+
+/** Resolve once ICE gathering completes (or after a timeout, to avoid stalling). */
+function gatherComplete(pc: RTCPeerConnection, timeoutMs = 4000): Promise<void> {
+  if (pc.iceGatheringState === 'complete') return Promise.resolve();
+  return new Promise(resolve => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      pc.removeEventListener('icegatheringstatechange', check);
+      resolve();
+    };
+    const check = () => { if (pc.iceGatheringState === 'complete') finish(); };
+    pc.addEventListener('icegatheringstatechange', check);
+    setTimeout(finish, timeoutMs);
+  });
+}
+
+export function createManualConnection(opts: ManualOptions): ManualConnection {
+  const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
+  pc.onconnectionstatechange = () => opts.onState?.(pc.connectionState);
+
+  if (opts.initiator) {
+    const channel = pc.createDataChannel('data', { ordered: true });
+    opts.onChannel?.(channel);
+  } else {
+    pc.ondatachannel = e => opts.onChannel?.(e.channel);
+  }
+
+  return {
+    pc,
+    async createOfferCode() {
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      await gatherComplete(pc);
+      return encodeSdp(pc.localDescription!);
+    },
+    async acceptOfferReturnAnswer(offerCode: string) {
+      const offer = decodeSdp(offerCode);
+      if (!offer || offer.type !== 'offer') throw new Error('That doesn’t look like a valid offer code.');
+      await pc.setRemoteDescription(offer);
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      await gatherComplete(pc);
+      return encodeSdp(pc.localDescription!);
+    },
+    async acceptAnswer(answerCode: string) {
+      const answer = decodeSdp(answerCode);
+      if (!answer || answer.type !== 'answer') throw new Error('That doesn’t look like a valid answer code.');
+      await pc.setRemoteDescription(answer);
+    },
+    close() {
+      try { pc.close(); } catch { /* ignore */ }
+    },
+  };
+}

--- a/src/tools/webrtc/peer.ts
+++ b/src/tools/webrtc/peer.ts
@@ -1,15 +1,13 @@
 import type { SignalMessage } from './signal.lib';
-
-/** Public STUN only (no TURN). Connections may fail behind strict/symmetric NAT. */
-const ICE_SERVERS: RTCIceServer[] = [
-  { urls: ['stun:stun.l.google.com:19302', 'stun:stun.cloudflare.com:3478'] },
-];
+import { DEFAULT_ICE_SERVERS } from './ice.lib';
 
 export interface CreatePeerOptions {
   initiator: boolean;
   sendSignal: (msg: SignalMessage) => void;
   onState?: (state: RTCPeerConnectionState) => void;
   onChannel?: (channel: RTCDataChannel) => void;
+  /** Custom ICE servers; defaults to the public STUN set. */
+  iceServers?: RTCIceServer[];
 }
 
 export interface PeerHandles {
@@ -24,7 +22,7 @@ export interface PeerHandles {
  * side answers. ICE candidates that arrive before the remote description are queued.
  */
 export function createPeer(opts: CreatePeerOptions): PeerHandles {
-  const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+  const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
   const pendingIce: RTCIceCandidateInit[] = [];
 
   pc.onicecandidate = e => {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 
-export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Draw' | 'Media' | 'Playground';
+export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Draw' | 'Media' | 'Network' | 'Playground';
 
 export interface AssetRef {
   url: string;


### PR DESCRIPTION
Builds on the P2P file transfer (#63) to make our server **fully optional and user-chosen**, and gives the P2P tools their own home.

## Network category
- New **Network** category (cyan) for the peer-to-peer tools; moves P2P File Transfer into it.
- Category note + in-tool footer explaining the limited/optional server involvement.
- (Re-applies the category change whose earlier push didn't land before #63 merged.)

## User-chosen connection
- **Custom STUN/TURN servers:** users enter their own ICE servers (defaults to public STUN). A user-provided **TURN** server fixes connections on strict/symmetric NAT. (`ice.lib`, tested)
- **Manual (serverless) signaling:** copy-paste offer/answer codes between peers — **no signaling server used at all**. Automatic link mode stays the default. (`manual-sdp.lib` + `manual.ts`, non-trickle ICE)
- Settings persist to localStorage; shown in an Advanced panel behind the ack gate.

## Verification
- **Durable Object relay verified end-to-end** via local `wrangler dev`: correct host/guest roles, `peer-joined`, offer/answer relay, and room-capacity (2) enforcement — all pass.
- 539 tests · lint 0 errors · build green.

Promotes to production together with #63 (file transfer reaches prod WITH user-choice connection options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)