### PR TITLE
feat(video-call): P2P video call with screen share + chat

### DIFF
--- a/docs/superpowers/specs/2026-08-01-video-call-design.md
+++ b/docs/superpowers/specs/2026-08-01-video-call-design.md
@@ -1,0 +1,107 @@
+# Web Video Call — Design
+
+**Date:** 2026-08-01
+**Tool:** Network → Video Call (`/tools/video-call`) — NEW
+**Type:** New tool (WebRTC media)
+**Icon:** `Video` (lucide-react)
+**Category:** Network
+
+Item #5 of the batch. Reuses the entire P2P infrastructure built for file transfer
+(`SignalRoom` Durable Object, `signal.lib`, `signal-client`, `ice.lib`, manual serverless
+mode, ack gate, reconnect logic). The difference: **media tracks instead of a data channel**,
+and it's **symmetric** — both peers capture and display camera+mic.
+
+## Scope (from the scope decision)
+
+- **Basics:** mute mic, camera on/off, switch front/rear camera, hang up.
+- **Screen sharing:** either participant can replace their outgoing camera with their screen
+  (`getDisplayMedia` + `RTCRtpSender.replaceTrack`, no renegotiation); both can share at once
+  (each sees the other's shared screen). Stopping restores the camera.
+- **In-call text chat:** a small chat over a WebRTC **data channel** alongside the media.
+
+1:1 only (room capacity 2, already enforced by the DO). RTMP is not involved (browsers can't
+publish RTMP). STUN-only by default; users can add their own TURN in Advanced settings.
+
+## Reuse vs new
+
+**Reused unchanged:** `signal.lib`, `signal-client.ts`, `ice.lib.ts`, `SignalRoom` DO,
+the ack gate + Advanced settings UI pattern, Network category.
+
+**Generalized (additive, low-risk to file transfer):**
+- `peer.ts` `createPeer` — add optional `localStream?: MediaStream` (adds its tracks) and
+  `onTrack?: (stream: MediaStream) => void` (wires `pc.ontrack`). Data-channel path
+  (`onChannel`) unchanged. Adding tracks triggers `onnegotiationneeded` → offer, same as the
+  data channel does.
+- `manual.ts` `createManualConnection` — same optional `localStream` / `onTrack`.
+
+**New:**
+- `src/tools/webrtc/chat.lib.ts` — pure chat message encode/decode (tested).
+- `src/hooks/useVideoCall.ts` — orchestrates media capture + signaling + media peer + chat.
+  Signaling/reconnect logic mirrors `useFileTransfer` (kept separate to avoid destabilizing
+  the shipped file-transfer hook; a future refactor can extract a shared core).
+- `src/islands/network/VideoCall.tsx` — the tool UI.
+- Registry entry `video-call`.
+
+## Media capture (inside `useVideoCall`)
+
+- `getUserMedia({ video: { facingMode }, audio: true })` → local stream; show a self-view.
+- **Mute mic / camera off:** toggle `track.enabled` on the local audio/video track (no
+  renegotiation).
+- **Switch camera:** re-`getUserMedia` with the other `facingMode`; `replaceTrack` the video
+  sender with the new track; stop the old track. (Reuses the release-before-acquire lesson
+  from `useCamera`.)
+- **Screen share:** `getDisplayMedia({ video: true })` → `replaceTrack` the video sender with
+  the screen track; on the screen track's `ended` (user clicks the browser "stop sharing"),
+  restore the camera track. Toggle button.
+- **Hang up:** close the peer + signaling, stop all local tracks.
+
+## Peer / negotiation
+
+Both peers add their local tracks at peer creation, so the offer (initiator) and answer
+(guest) each include their media (`sendrecv`). The initiator also creates the chat data
+channel. `pc.ontrack` delivers the remote stream → attach to the remote `<video>`.
+
+Roles + reconnection identical to file transfer: DO assigns host/guest by join order; host
+offers on `peer-joined`; ICE `disconnected` → grace then re-establish; retry cap → "add a
+TURN server" message. Manual mode: copy-paste offer/answer codes (media negotiated in the
+same SDP, non-trickle).
+
+## Chat (`chat.lib.ts` + data channel)
+
+```ts
+export interface ChatMessage { id: string; mine: boolean; text: string; at: number }
+export function encodeChat(text: string): string;      // JSON control message
+export function decodeChat(raw: string): string | null; // validated text or null
+```
+
+The island keeps the message list; `at`/`id` are stamped in the island (not the pure lib, to
+keep it deterministic/testable). Chat sends over the same data channel; media is separate.
+
+## Island (`VideoCall.tsx`)
+
+1. **Ack gate + Advanced settings** — reuse the file-transfer pattern (auto link / manual /
+   custom STUN-TURN), same copy about the limited/optional signaling server. A shared link
+   (`/tools/video-call#<roomId>`) invites the other person.
+2. **Pre-join:** request camera/mic, show local self-view, "Start call" (auto) or role pick
+   (manual).
+3. **In call:** large **remote video**, small **local self-view** (mirrored), a control bar
+   (Mic / Camera / Screen share / Switch camera / Hang up), and a collapsible **chat** panel.
+4. **States:** waiting for peer, connecting, in-call, peer left, error (with the TURN hint).
+5. Permission/`NotAllowed`/`NotReadable` errors surfaced clearly (reuse `useCamera`'s error
+   taxonomy shape).
+
+## Testing
+
+- `chat.lib.test.ts` — `encodeChat`/`decodeChat` round-trip; rejects malformed/oversized/empty.
+- `peer.ts` / `manual.ts` generalization: covered by the existing file-transfer tests still
+  passing (data-channel path unchanged) + the local DO relay test. Media/track paths are
+  browser-only → build + manual smoke (two devices: see/hear each other, chat, screen share,
+  switch camera, hang up).
+- `useVideoCall` + island: build + manual smoke.
+
+## Out of scope
+
+- More than 2 participants (would need an SFU; DO room is 1:1).
+- Recording the call.
+- Simultaneous camera **and** screen as separate tiles (screen replaces camera for now).
+- RTMP/broadcast.

--- a/src/hooks/useVideoCall.ts
+++ b/src/hooks/useVideoCall.ts
@@ -1,0 +1,402 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { connectSignal, type SignalClient } from '@/tools/webrtc/signal-client';
+import { createPeer, type PeerHandles } from '@/tools/webrtc/peer';
+import { createManualConnection, type ManualConnection } from '@/tools/webrtc/manual';
+import { encodeChat, decodeChat } from '@/tools/webrtc/chat.lib';
+
+export type CallStatus = 'idle' | 'connecting' | 'waiting' | 'in-call' | 'ended' | 'error';
+export type Facing = 'user' | 'environment';
+
+export interface ChatMessage { id: string; mine: boolean; text: string; at: number }
+
+const RECONNECT_MS = 1200;
+const DISCONNECT_GRACE_MS = 5000;
+const MAX_FAILURES = 4;
+const BYE = JSON.stringify({ kind: 'bye' });
+
+function uid(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+export function useVideoCall() {
+  const signalRef = useRef<SignalClient | null>(null);
+  const peerRef = useRef<PeerHandles | null>(null);
+  const manualRef = useRef<ManualConnection | null>(null);
+  const chatChannelRef = useRef<RTCDataChannel | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const cameraTrackRef = useRef<MediaStreamTrack | null>(null);
+  const screenStreamRef = useRef<MediaStream | null>(null);
+  const videoSenderRef = useRef<RTCRtpSender | null>(null);
+  const facingRef = useRef<Facing>('user');
+  const iceRef = useRef<RTCIceServer[] | undefined>(undefined);
+  const sharingRef = useRef(false);
+
+  const reconnectRef = useRef<{ roomId: string } | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stoppedRef = useRef(false);
+  const connectedRef = useRef(false);
+  const failuresRef = useRef(0);
+  const openSignalingRef = useRef<() => void>(() => {});
+  const handleFailureRef = useRef<() => void>(() => {});
+
+  const [status, setStatus] = useState<CallStatus>('idle');
+  const [error, setError] = useState('');
+  const [localStream, setLocalStream] = useState<MediaStream | null>(null);
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+  const [micOn, setMicOn] = useState(true);
+  const [camOn, setCamOn] = useState(true);
+  const [sharing, setSharing] = useState(false);
+  const [hasMultipleCameras, setHasMultipleCameras] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const clearReconnect = () => { if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null; } };
+  const clearDisconnect = () => { if (disconnectTimerRef.current) { clearTimeout(disconnectTimerRef.current); disconnectTimerRef.current = null; } };
+
+  const stopSignalingAndPeer = useCallback(() => {
+    clearReconnect();
+    clearDisconnect();
+    peerRef.current?.close();
+    manualRef.current?.close();
+    signalRef.current?.close();
+    peerRef.current = null;
+    manualRef.current = null;
+    signalRef.current = null;
+    chatChannelRef.current = null;
+  }, []);
+
+  const stopMedia = useCallback(() => {
+    localStreamRef.current?.getTracks().forEach(t => t.stop());
+    screenStreamRef.current?.getTracks().forEach(t => t.stop());
+    localStreamRef.current = null;
+    screenStreamRef.current = null;
+    cameraTrackRef.current = null;
+    videoSenderRef.current = null;
+    sharingRef.current = false;
+  }, []);
+
+  // --- Chat over the data channel ---
+  const wireChat = useCallback((channel: RTCDataChannel) => {
+    chatChannelRef.current = channel;
+    channel.onmessage = e => {
+      if (typeof e.data !== 'string') return;
+      if (e.data === BYE) { stoppedRef.current = true; stopSignalingAndPeer(); setRemoteStream(null); setStatus('ended'); return; }
+      const text = decodeChat(e.data);
+      if (text) setMessages(m => [...m, { id: uid(), mine: false, text, at: Date.now() }]);
+    };
+  }, [stopSignalingAndPeer]);
+
+  const sendChat = useCallback((text: string) => {
+    const encoded = encodeChat(text);
+    if (!encoded) return;
+    const ch = chatChannelRef.current;
+    if (ch && ch.readyState === 'open') ch.send(encoded);
+    setMessages(m => [...m, { id: uid(), mine: true, text: text.trim(), at: Date.now() }]);
+  }, []);
+
+  const handleFailure = useCallback(() => {
+    if (stoppedRef.current) return;
+    clearDisconnect();
+    connectedRef.current = false;
+    peerRef.current?.close();
+    peerRef.current = null;
+    failuresRef.current += 1;
+    if (!reconnectRef.current) {
+      setError('The connection was lost.');
+      setStatus('error');
+    } else if (failuresRef.current > MAX_FAILURES) {
+      setError('Couldn’t keep a stable connection on this network. Try again, or add your own TURN server in Advanced settings.');
+      setStatus('error');
+    } else {
+      setStatus(s => (s === 'ended' ? s : 'connecting'));
+      // scheduleReconnect defined below via ref
+      if (typeof document === 'undefined' || !document.hidden) {
+        clearReconnect();
+        reconnectTimerRef.current = setTimeout(() => { if (!stoppedRef.current && !connectedRef.current) openSignalingRef.current(); }, RECONNECT_MS);
+      }
+    }
+  }, []);
+  useEffect(() => { handleFailureRef.current = handleFailure; }, [handleFailure]);
+
+  const handlePcState = useCallback((state: RTCPeerConnectionState) => {
+    if (state === 'connected') {
+      connectedRef.current = true;
+      failuresRef.current = 0;
+      clearDisconnect();
+      clearReconnect();
+      signalRef.current?.close();
+      signalRef.current = null;
+      setStatus('in-call');
+    } else if (state === 'disconnected') {
+      clearDisconnect();
+      disconnectTimerRef.current = setTimeout(() => handleFailureRef.current(), DISCONNECT_GRACE_MS);
+    } else if (state === 'failed') {
+      handleFailureRef.current();
+    }
+  }, []);
+
+  const setupPeer = useCallback((initiator: boolean) => {
+    peerRef.current?.close();
+    peerRef.current = null;
+    const signal = signalRef.current;
+    if (!signal) return;
+    const peer = createPeer({
+      initiator,
+      iceServers: iceRef.current,
+      localStream: localStreamRef.current ?? undefined,
+      sendSignal: msg => signal.send(msg),
+      onState: handlePcState,
+      onTrack: stream => { setRemoteStream(stream); },
+      onChannel: wireChat,
+    });
+    peerRef.current = peer;
+    videoSenderRef.current = peer.pc.getSenders().find(s => s.track?.kind === 'video') ?? null;
+  }, [handlePcState, wireChat]);
+
+  const scheduleReconnect = useCallback(() => {
+    if (stoppedRef.current || connectedRef.current || !reconnectRef.current) return;
+    clearReconnect();
+    if (typeof document !== 'undefined' && document.hidden) return;
+    reconnectTimerRef.current = setTimeout(() => {
+      if (stoppedRef.current || connectedRef.current) return;
+      openSignalingRef.current();
+    }, RECONNECT_MS);
+  }, []);
+
+  const openSignaling = useCallback(() => {
+    const info = reconnectRef.current;
+    if (!info || stoppedRef.current || connectedRef.current) return;
+    signalRef.current?.close();
+    signalRef.current = null;
+    signalRef.current = connectSignal(info.roomId, {
+      onMessage: msg => {
+        if (connectedRef.current) {
+          if (msg.type === 'offer' || msg.type === 'answer' || msg.type === 'ice') peerRef.current?.applySignal(msg);
+          return;
+        }
+        switch (msg.type) {
+          case 'welcome':
+            if (msg.role === 'guest') setupPeer(false);
+            else setStatus('waiting');
+            break;
+          case 'peer-joined':
+            setupPeer(true);
+            break;
+          case 'peer-left':
+            peerRef.current?.close();
+            peerRef.current = null;
+            setStatus('waiting');
+            break;
+          case 'full':
+            stoppedRef.current = true;
+            setError('This call room is already full (two people are connected).');
+            setStatus('error');
+            break;
+          case 'offer':
+          case 'answer':
+          case 'ice':
+            peerRef.current?.applySignal(msg);
+            break;
+        }
+      },
+      onClose: () => { if (!connectedRef.current && !stoppedRef.current) scheduleReconnect(); },
+      onError: () => { if (!connectedRef.current && !stoppedRef.current) scheduleReconnect(); },
+    });
+  }, [setupPeer, scheduleReconnect]);
+  useEffect(() => { openSignalingRef.current = openSignaling; }, [openSignaling]);
+
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && reconnectRef.current && !connectedRef.current && !stoppedRef.current) scheduleReconnect();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [scheduleReconnect]);
+
+  // --- Media capture ---
+  const startMedia = useCallback(async (): Promise<boolean> => {
+    setError('');
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setError('This browser can’t access the camera and microphone.');
+      setStatus('error');
+      return false;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: facingRef.current }, audio: true });
+      localStreamRef.current = stream;
+      cameraTrackRef.current = stream.getVideoTracks()[0] ?? null;
+      setLocalStream(stream);
+      setMicOn(true);
+      setCamOn(true);
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        setHasMultipleCameras(devices.filter(d => d.kind === 'videoinput').length > 1);
+      } catch { /* ignore */ }
+      return true;
+    } catch (err) {
+      const name = err instanceof Error ? err.name : '';
+      setError(name === 'NotAllowedError' || name === 'SecurityError'
+        ? 'Camera/microphone access was blocked — allow it in your browser settings.'
+        : 'Could not start the camera or microphone.');
+      setStatus('error');
+      return false;
+    }
+  }, []);
+
+  // --- Signaling entry points ---
+  const connect = useCallback((roomId: string, iceServers?: RTCIceServer[]) => {
+    stopSignalingAndPeer();
+    iceRef.current = iceServers;
+    reconnectRef.current = { roomId };
+    stoppedRef.current = false;
+    connectedRef.current = false;
+    failuresRef.current = 0;
+    setError('');
+    setRemoteStream(null);
+    setStatus('connecting');
+    openSignaling();
+  }, [stopSignalingAndPeer, openSignaling]);
+
+  const manualCreateOffer = useCallback(async (iceServers?: RTCIceServer[]): Promise<string> => {
+    stopSignalingAndPeer();
+    reconnectRef.current = null;
+    stoppedRef.current = false;
+    connectedRef.current = false;
+    setError('');
+    setStatus('connecting');
+    const conn = createManualConnection({
+      initiator: true,
+      iceServers,
+      localStream: localStreamRef.current ?? undefined,
+      onState: handlePcState,
+      onTrack: stream => setRemoteStream(stream),
+      onChannel: wireChat,
+    });
+    manualRef.current = conn;
+    videoSenderRef.current = conn.pc.getSenders().find(s => s.track?.kind === 'video') ?? null;
+    const code = await conn.createOfferCode();
+    setStatus('waiting');
+    return code;
+  }, [stopSignalingAndPeer, handlePcState, wireChat]);
+
+  const manualAcceptAnswer = useCallback(async (answerCode: string) => {
+    await manualRef.current?.acceptAnswer(answerCode);
+  }, []);
+
+  const manualAcceptOffer = useCallback(async (offerCode: string, iceServers?: RTCIceServer[]): Promise<string> => {
+    stopSignalingAndPeer();
+    reconnectRef.current = null;
+    stoppedRef.current = false;
+    connectedRef.current = false;
+    setError('');
+    setStatus('connecting');
+    const conn = createManualConnection({
+      initiator: false,
+      iceServers,
+      localStream: localStreamRef.current ?? undefined,
+      onState: handlePcState,
+      onTrack: stream => setRemoteStream(stream),
+      onChannel: wireChat,
+    });
+    manualRef.current = conn;
+    videoSenderRef.current = conn.pc.getSenders().find(s => s.track?.kind === 'video') ?? null;
+    const answer = await conn.acceptOfferReturnAnswer(offerCode);
+    setStatus('waiting');
+    return answer;
+  }, [stopSignalingAndPeer, handlePcState, wireChat]);
+
+  // --- Controls ---
+  const toggleMic = useCallback(() => {
+    const track = localStreamRef.current?.getAudioTracks()[0];
+    if (!track) return;
+    track.enabled = !track.enabled;
+    setMicOn(track.enabled);
+  }, []);
+
+  const toggleCam = useCallback(() => {
+    const track = cameraTrackRef.current;
+    if (!track) return;
+    track.enabled = !track.enabled;
+    setCamOn(track.enabled);
+  }, []);
+
+  const switchCamera = useCallback(async () => {
+    if (sharingRef.current) return; // don't switch while screen sharing
+    const next: Facing = facingRef.current === 'user' ? 'environment' : 'user';
+    try {
+      const ns = await navigator.mediaDevices.getUserMedia({ video: { facingMode: next }, audio: false });
+      const newTrack = ns.getVideoTracks()[0];
+      if (!newTrack) return;
+      newTrack.enabled = camOn;
+      if (videoSenderRef.current) await videoSenderRef.current.replaceTrack(newTrack);
+      const old = cameraTrackRef.current;
+      const stream = localStreamRef.current;
+      if (stream && old) { stream.removeTrack(old); old.stop(); stream.addTrack(newTrack); }
+      cameraTrackRef.current = newTrack;
+      facingRef.current = next;
+      setLocalStream(stream); // trigger re-render of the self-view
+    } catch { /* ignore switch failure */ }
+  }, [camOn]);
+
+  const stopScreen = useCallback(async () => {
+    const cam = cameraTrackRef.current;
+    if (videoSenderRef.current && cam) { try { await videoSenderRef.current.replaceTrack(cam); } catch { /* */ } }
+    screenStreamRef.current?.getTracks().forEach(t => t.stop());
+    screenStreamRef.current = null;
+    sharingRef.current = false;
+    setSharing(false);
+  }, []);
+
+  const toggleScreenShare = useCallback(async () => {
+    if (sharingRef.current) { await stopScreen(); return; }
+    const md = navigator.mediaDevices as MediaDevices & { getDisplayMedia?: (c: MediaStreamConstraints) => Promise<MediaStream> };
+    if (!md.getDisplayMedia) { setError('Screen sharing isn’t supported in this browser.'); return; }
+    try {
+      const display = await md.getDisplayMedia({ video: true });
+      const screenTrack = display.getVideoTracks()[0];
+      if (!screenTrack) return;
+      screenStreamRef.current = display;
+      if (videoSenderRef.current) await videoSenderRef.current.replaceTrack(screenTrack);
+      screenTrack.onended = () => { void stopScreen(); };
+      sharingRef.current = true;
+      setSharing(true);
+    } catch { /* user cancelled the picker */ }
+  }, [stopScreen]);
+
+  const hangUp = useCallback(() => {
+    try { if (chatChannelRef.current?.readyState === 'open') chatChannelRef.current.send(BYE); } catch { /* */ }
+    stoppedRef.current = true;
+    reconnectRef.current = null;
+    connectedRef.current = false;
+    stopSignalingAndPeer();
+    stopMedia();
+    setLocalStream(null);
+    setRemoteStream(null);
+    setStatus('ended');
+  }, [stopSignalingAndPeer, stopMedia]);
+
+  useEffect(() => () => { stoppedRef.current = true; stopSignalingAndPeer(); stopMedia(); }, [stopSignalingAndPeer, stopMedia]);
+
+  return {
+    status,
+    error,
+    localStream,
+    remoteStream,
+    micOn,
+    camOn,
+    sharing,
+    hasMultipleCameras,
+    messages,
+    startMedia,
+    connect,
+    manualCreateOffer,
+    manualAcceptAnswer,
+    manualAcceptOffer,
+    toggleMic,
+    toggleCam,
+    switchCamera,
+    toggleScreenShare,
+    sendChat,
+    hangUp,
+  };
+}

--- a/src/islands/network/VideoCall.tsx
+++ b/src/islands/network/VideoCall.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Video, VideoOff, Mic, MicOff, MonitorUp, SwitchCamera, PhoneOff, Send, ShieldCheck, Settings,
+} from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { useVideoCall } from '@/hooks/useVideoCall';
+import { makeRoomId, roomLink, roomIdFromHash } from '@/tools/webrtc/signal.lib';
+import { effectiveIceServers } from '@/tools/webrtc/ice.lib';
+
+type Signaling = 'auto' | 'manual';
+type ManualRole = 'call' | 'answer';
+
+const ICE_KEY = 'gwt.webrtc.ice';
+const SIGNALING_KEY = 'gwt.webrtc.signaling';
+const ROUTE = '/tools/video-call';
+
+function VideoTile({ stream, muted, mirror, className }: { stream: MediaStream | null; muted?: boolean; mirror?: boolean; className?: string }) {
+  const ref = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.srcObject = stream;
+  }, [stream]);
+  return (
+    <video
+      ref={ref}
+      autoPlay
+      playsInline
+      muted={muted}
+      className={`${mirror ? 'scale-x-[-1] ' : ''}${className ?? ''}`}
+    />
+  );
+}
+
+export default function VideoCall() {
+  const c = useVideoCall();
+  const [acked, setAcked] = useState(false);
+  const [signaling, setSignaling] = useState<Signaling>('auto');
+  const [iceText, setIceText] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const [joining, setJoining] = useState(false);
+  const [roomId, setRoomId] = useState('');
+  const [link, setLink] = useState('');
+
+  const [manualRole, setManualRole] = useState<ManualRole | null>(null);
+  const [offerCode, setOfferCode] = useState('');
+  const [answerCode, setAnswerCode] = useState('');
+  const [pastedAnswer, setPastedAnswer] = useState('');
+  const [pastedOffer, setPastedOffer] = useState('');
+  const [manualBusy, setManualBusy] = useState(false);
+  const [manualErr, setManualErr] = useState('');
+
+  const [chatInput, setChatInput] = useState('');
+  const [showChat, setShowChat] = useState(false);
+
+  useEffect(() => {
+    try {
+      setIceText(localStorage.getItem(ICE_KEY) ?? '');
+      const s = localStorage.getItem(SIGNALING_KEY);
+      if (s === 'manual' || s === 'auto') setSignaling(s);
+    } catch { /* ignore */ }
+    const fromHash = roomIdFromHash(window.location.hash);
+    if (fromHash) { setJoining(true); setSignaling('auto'); setRoomId(fromHash); }
+    else { const id = makeRoomId(); setRoomId(id); setLink(roomLink(window.location.origin, id, ROUTE)); }
+  }, []);
+
+  const persistIce = (t: string) => { setIceText(t); try { localStorage.setItem(ICE_KEY, t); } catch { /* */ } };
+  const persistSignaling = (s: Signaling) => { setSignaling(s); try { localStorage.setItem(SIGNALING_KEY, s); } catch { /* */ } };
+  const ice = () => effectiveIceServers(iceText);
+
+  const start = async () => {
+    setAcked(true);
+    const ok = await c.startMedia();
+    if (!ok) return;
+    if (signaling === 'auto') c.connect(roomId, ice());
+  };
+
+  const chooseCall = async () => {
+    setManualRole('call'); setManualErr(''); setManualBusy(true);
+    try { setOfferCode(await c.manualCreateOffer(ice())); }
+    catch (e) { setManualErr(e instanceof Error ? e.message : 'Could not create the invite.'); }
+    finally { setManualBusy(false); }
+  };
+  const submitAnswer = async () => {
+    setManualErr('');
+    try { await c.manualAcceptAnswer(pastedAnswer.trim()); }
+    catch (e) { setManualErr(e instanceof Error ? e.message : 'Invalid answer code.'); }
+  };
+  const chooseAnswer = () => { setManualRole('answer'); setManualErr(''); };
+  const submitOffer = async () => {
+    setManualErr(''); setManualBusy(true);
+    try { setAnswerCode(await c.manualAcceptOffer(pastedOffer.trim(), ice())); }
+    catch (e) { setManualErr(e instanceof Error ? e.message : 'Invalid invite code.'); }
+    finally { setManualBusy(false); }
+  };
+
+  const sendChat = () => { if (chatInput.trim()) { c.sendChat(chatInput); setChatInput(''); } };
+
+  const codeBox = (value: string) => (
+    <div className="space-y-1.5">
+      <textarea readOnly value={value} rows={3} className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs" />
+      <CopyButton value={value} label="Copy code" />
+    </div>
+  );
+
+  // ---------- Ack + settings gate ----------
+  if (!acked) {
+    return (
+      <div className="space-y-4">
+        <div className="space-y-3 border-2 border-border p-4">
+          <p className="flex items-center gap-2 text-lg font-bold"><ShieldCheck className="h-5 w-5" /> Before you connect</p>
+          <p className="text-sm text-muted-foreground">
+            {signaling === 'auto' ? (
+              <>To introduce your two devices, GoodWebTools uses a small <strong>signaling server</strong> to exchange
+              connection details (about 2&nbsp;KB). Your video, audio, and chat travel <strong>directly, peer-to-peer</strong>,
+              and never pass through our server.</>
+            ) : (
+              <><strong>Manual mode uses no server at all.</strong> You&apos;ll copy-paste an invite code to the other person
+              yourself. Video, audio and chat travel directly, peer-to-peer.</>
+            )}{' '}
+            You&apos;ll be asked for camera and microphone access. Connections are best-effort and may fail on restrictive
+            networks unless you add your own TURN server.
+          </p>
+
+          <button type="button" onClick={() => setShowAdvanced(v => !v)} className="flex items-center gap-1.5 text-sm font-bold text-muted-foreground hover:text-foreground">
+            <Settings className="h-4 w-4" /> Advanced connection settings
+          </button>
+          {showAdvanced && (
+            <div className="space-y-3 border-2 border-border bg-muted/40 p-3">
+              {!joining && (
+                <div className="space-y-1.5">
+                  <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">Connection method</span>
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant={signaling === 'auto' ? 'primary' : 'secondary'} onClick={() => persistSignaling('auto')}>Automatic (share a link)</Button>
+                    <Button variant={signaling === 'manual' ? 'primary' : 'secondary'} onClick={() => persistSignaling('manual')}>Manual (copy-paste · no server)</Button>
+                  </div>
+                </div>
+              )}
+              <label className="block space-y-1.5">
+                <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">Your STUN / TURN servers (optional)</span>
+                <textarea value={iceText} onChange={e => persistIce(e.target.value)} rows={3} spellCheck={false}
+                  placeholder={'stun:stun.example.com:3478\nturn:turn.example.com:3478 username credential'}
+                  className="w-full resize-y border-2 border-border bg-background p-2 font-mono text-xs outline-none focus:shadow-brutal-sm" />
+                <span className="block text-xs text-muted-foreground">One per line. Leave empty to use public STUN. A TURN server makes calls work on strict networks.</span>
+              </label>
+            </div>
+          )}
+          <Button onClick={start}>Continue</Button>
+        </div>
+      </div>
+    );
+  }
+
+  const inCall = c.status === 'in-call';
+
+  return (
+    <div className="space-y-4">
+      {c.error && <Alert variant="error">{c.error}</Alert>}
+      {manualErr && <Alert variant="error">{manualErr}</Alert>}
+
+      {c.status === 'ended' && (
+        <div className="space-y-3 border-2 border-border p-4">
+          <p className="text-lg font-bold">Call ended</p>
+          <Button onClick={() => location.reload()}>Start a new call</Button>
+        </div>
+      )}
+
+      {/* Video area */}
+      {c.status !== 'ended' && (
+        <div className="relative overflow-hidden border-2 border-border bg-black">
+          <VideoTile stream={c.remoteStream} className="max-h-[70vh] w-full bg-black object-contain" />
+          {!c.remoteStream && (
+            <div className="absolute inset-0 flex items-center justify-center p-6 text-center text-sm text-white/80">
+              {c.status === 'waiting' && !joining ? 'Share the link below to invite someone…'
+                : c.status === 'waiting' ? 'Waiting to connect…'
+                : c.status === 'connecting' ? 'Connecting…'
+                : 'Setting up your camera…'}
+            </div>
+          )}
+          {/* Local self-view */}
+          <div className="absolute bottom-3 right-3 w-28 overflow-hidden border-2 border-white/70 bg-black sm:w-40">
+            <VideoTile stream={c.localStream} muted mirror className="w-full" />
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      {(inCall || c.status === 'connecting' || c.status === 'waiting') && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant={c.micOn ? 'secondary' : 'primary'} onClick={c.toggleMic} aria-pressed={!c.micOn}>
+            {c.micOn ? <Mic className="h-4 w-4" /> : <MicOff className="h-4 w-4" />}{c.micOn ? 'Mute' : 'Unmute'}
+          </Button>
+          <Button variant={c.camOn ? 'secondary' : 'primary'} onClick={c.toggleCam} aria-pressed={!c.camOn}>
+            {c.camOn ? <Video className="h-4 w-4" /> : <VideoOff className="h-4 w-4" />}{c.camOn ? 'Camera off' : 'Camera on'}
+          </Button>
+          <Button variant={c.sharing ? 'primary' : 'secondary'} onClick={c.toggleScreenShare}>
+            <MonitorUp className="h-4 w-4" />{c.sharing ? 'Stop sharing' : 'Share screen'}
+          </Button>
+          {c.hasMultipleCameras && !c.sharing && (
+            <Button variant="secondary" onClick={c.switchCamera}><SwitchCamera className="h-4 w-4" />Flip</Button>
+          )}
+          <Button variant="secondary" onClick={() => setShowChat(s => !s)}>Chat{c.messages.length ? ` (${c.messages.length})` : ''}</Button>
+          <Button variant="ghost" onClick={c.hangUp}><PhoneOff className="h-4 w-4" />Hang up</Button>
+        </div>
+      )}
+
+      {/* Auto link (creator, before connect) */}
+      {signaling === 'auto' && !joining && !inCall && c.status !== 'ended' && (
+        <div className="space-y-2">
+          <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Share this link to invite someone</p>
+          <div className="flex flex-wrap items-center gap-2">
+            <code className="break-all border-2 border-border bg-muted px-3 py-2 text-sm">{link}</code>
+            <CopyButton value={link} label="Copy link" />
+          </div>
+        </div>
+      )}
+
+      {/* Manual mode */}
+      {signaling === 'manual' && !manualRole && !inCall && c.status !== 'ended' && (
+        <div className="space-y-2">
+          <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Manual connection — pick a role</p>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={chooseCall} disabled={manualBusy}>I&apos;m calling</Button>
+            <Button variant="secondary" onClick={chooseAnswer}>I&apos;m answering</Button>
+          </div>
+        </div>
+      )}
+      {signaling === 'manual' && manualRole === 'call' && !inCall && c.status !== 'ended' && (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 1 — send this invite code to the other person</p>
+            {manualBusy && !offerCode ? <p className="text-sm text-muted-foreground">Preparing…</p> : codeBox(offerCode)}
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 2 — paste the answer code they send back</p>
+            <textarea value={pastedAnswer} onChange={e => setPastedAnswer(e.target.value)} rows={3} spellCheck={false}
+              className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs outline-none focus:shadow-brutal-sm" />
+            <Button onClick={submitAnswer} disabled={!pastedAnswer.trim()}>Connect</Button>
+          </div>
+        </div>
+      )}
+      {signaling === 'manual' && manualRole === 'answer' && !inCall && c.status !== 'ended' && (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <p className="text-sm font-bold">Step 1 — paste the invite code from the caller</p>
+            <textarea value={pastedOffer} onChange={e => setPastedOffer(e.target.value)} rows={3} spellCheck={false}
+              className="w-full resize-y break-all border-2 border-border bg-muted p-2 font-mono text-xs outline-none focus:shadow-brutal-sm" />
+            <Button onClick={submitOffer} disabled={!pastedOffer.trim() || manualBusy}>Generate answer</Button>
+          </div>
+          {answerCode && (
+            <div className="space-y-1.5">
+              <p className="text-sm font-bold">Step 2 — send this answer code back to the caller</p>
+              {codeBox(answerCode)}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Chat panel */}
+      {showChat && (inCall || c.messages.length > 0) && (
+        <div className="space-y-2 border-2 border-border p-3">
+          <div className="max-h-56 space-y-1.5 overflow-y-auto">
+            {c.messages.length === 0 && <p className="text-sm text-muted-foreground">No messages yet.</p>}
+            {c.messages.map(m => (
+              <p key={m.id} className={`text-sm ${m.mine ? 'text-right' : ''}`}>
+                <span className={`inline-block max-w-[85%] border-2 border-border px-2 py-1 ${m.mine ? 'bg-accent text-accent-foreground' : 'bg-muted'}`}>{m.text}</span>
+              </p>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input value={chatInput} onChange={e => setChatInput(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') sendChat(); }}
+              placeholder="Type a message…"
+              className="flex-1 border-2 border-border bg-muted px-3 py-2 text-sm outline-none focus:shadow-brutal-sm" />
+            <Button onClick={sendChat} disabled={!chatInput.trim()}><Send className="h-4 w-4" /></Button>
+          </div>
+        </div>
+      )}
+
+      <p className="border-t border-border pt-3 text-xs text-muted-foreground">
+        <ShieldCheck className="mr-1 inline h-3.5 w-3.5" />
+        Video, audio and chat travel directly between devices (peer-to-peer).{' '}
+        {signaling === 'manual' ? 'Manual mode uses no server at all.' : 'A minimal signaling server only introduces the two devices — your media never passes through it.'}
+      </p>
+    </div>
+  );
+}

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -562,6 +562,17 @@ export const tools: ToolDef[] = [
     icon: Send,
     summary: 'Send a file directly to another device, peer-to-peer',
     load: () => import('@/islands/files/FileTransfer'),
+    status: 'beta'
+  },
+  {
+    id: 'video-call',
+    name: 'Video Call',
+    category: 'Network',
+    route: '/tools/video-call',
+    keywords: ['video', 'call', 'chat', 'webrtc', 'p2p', 'peer to peer', 'meeting', 'screen share', 'camera', 'conference'],
+    icon: Video,
+    summary: 'Peer-to-peer video call with screen sharing and chat',
+    load: () => import('@/islands/network/VideoCall'),
     status: 'beta'
   },
   {

--- a/src/tools/webrtc/chat.lib.test.ts
+++ b/src/tools/webrtc/chat.lib.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { encodeChat, decodeChat, MAX_CHAT_LEN } from './chat.lib';
+
+describe('encodeChat / decodeChat', () => {
+  it('round-trips a chat message', () => {
+    expect(decodeChat(encodeChat('hello there'))).toBe('hello there');
+  });
+  it('trims and preserves unicode', () => {
+    expect(decodeChat(encodeChat('  café ☕  '))).toBe('café ☕');
+  });
+  it('rejects empty / whitespace-only', () => {
+    expect(encodeChat('   ')).toBeNull();
+  });
+  it('caps overly long messages', () => {
+    const long = 'a'.repeat(MAX_CHAT_LEN + 100);
+    const decoded = decodeChat(encodeChat(long)!);
+    expect(decoded?.length).toBe(MAX_CHAT_LEN);
+  });
+  it('rejects malformed control messages', () => {
+    expect(decodeChat('not json')).toBeNull();
+    expect(decodeChat(JSON.stringify({ kind: 'meta', text: 'x' }))).toBeNull();
+    expect(decodeChat(JSON.stringify({ kind: 'chat' }))).toBeNull();
+    expect(decodeChat(JSON.stringify({ kind: 'chat', text: 42 }))).toBeNull();
+  });
+});

--- a/src/tools/webrtc/chat.lib.ts
+++ b/src/tools/webrtc/chat.lib.ts
@@ -1,0 +1,25 @@
+/** In-call text chat sent over the WebRTC data channel (video call). */
+
+export const MAX_CHAT_LEN = 2000;
+
+/** Encode a chat message; returns null for empty/whitespace-only input. */
+export function encodeChat(text: string): string | null {
+  const trimmed = text.trim().slice(0, MAX_CHAT_LEN);
+  if (!trimmed) return null;
+  return JSON.stringify({ kind: 'chat', text: trimmed });
+}
+
+/** Decode + validate a chat message. Returns the text, or null if invalid. */
+export function decodeChat(raw: string): string | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const m = obj as Record<string, unknown>;
+  if (m.kind !== 'chat' || typeof m.text !== 'string') return null;
+  const text = m.text.trim().slice(0, MAX_CHAT_LEN);
+  return text || null;
+}

--- a/src/tools/webrtc/manual.ts
+++ b/src/tools/webrtc/manual.ts
@@ -13,6 +13,10 @@ export interface ManualOptions {
   iceServers?: RTCIceServer[];
   onState?: (state: RTCPeerConnectionState) => void;
   onChannel?: (channel: RTCDataChannel) => void;
+  /** Local media whose tracks are added to the connection (video call). */
+  localStream?: MediaStream;
+  /** Called with the remote media stream (video call). */
+  onTrack?: (stream: MediaStream) => void;
 }
 
 export interface ManualConnection {
@@ -47,9 +51,16 @@ export function createManualConnection(opts: ManualOptions): ManualConnection {
   const pc = new RTCPeerConnection({ iceServers: opts.iceServers ?? DEFAULT_ICE_SERVERS });
   pc.onconnectionstatechange = () => opts.onState?.(pc.connectionState);
 
+  if (opts.onTrack) pc.ontrack = e => { if (e.streams[0]) opts.onTrack!(e.streams[0]); };
+  if (opts.localStream) {
+    for (const track of opts.localStream.getTracks()) pc.addTrack(track, opts.localStream);
+  }
+
   if (opts.initiator) {
-    const channel = pc.createDataChannel('data', { ordered: true });
-    opts.onChannel?.(channel);
+    if (opts.onChannel) {
+      const channel = pc.createDataChannel('data', { ordered: true });
+      opts.onChannel(channel);
+    }
   } else {
     pc.ondatachannel = e => opts.onChannel?.(e.channel);
   }

--- a/src/tools/webrtc/peer.ts
+++ b/src/tools/webrtc/peer.ts
@@ -8,6 +8,10 @@ export interface CreatePeerOptions {
   onChannel?: (channel: RTCDataChannel) => void;
   /** Custom ICE servers; defaults to the public STUN set. */
   iceServers?: RTCIceServer[];
+  /** Local media whose tracks are added to the connection (video call). */
+  localStream?: MediaStream;
+  /** Called with the remote media stream (video call). */
+  onTrack?: (stream: MediaStream) => void;
 }
 
 export interface PeerHandles {
@@ -30,15 +34,30 @@ export function createPeer(opts: CreatePeerOptions): PeerHandles {
   };
   pc.onconnectionstatechange = () => opts.onState?.(pc.connectionState);
 
+  // Media (video call): deliver the remote stream and add our local tracks.
+  if (opts.onTrack) pc.ontrack = e => { if (e.streams[0]) opts.onTrack!(e.streams[0]); };
+  if (opts.localStream) {
+    for (const track of opts.localStream.getTracks()) pc.addTrack(track, opts.localStream);
+  }
+
   if (opts.initiator) {
-    const channel = pc.createDataChannel('data', { ordered: true });
-    opts.onChannel?.(channel);
+    if (opts.onChannel) {
+      const channel = pc.createDataChannel('data', { ordered: true });
+      opts.onChannel(channel);
+    }
+    let makingOffer = false;
+    // Adding a data channel AND media tracks can each fire negotiationneeded;
+    // the guard collapses them into a single offer and avoids glare.
     pc.onnegotiationneeded = async () => {
+      if (makingOffer || pc.signalingState !== 'stable') return;
+      makingOffer = true;
       try {
         const offer = await pc.createOffer();
         await pc.setLocalDescription(offer);
         opts.sendSignal({ type: 'offer', sdp: pc.localDescription });
-      } catch { /* surfaced via connection state */ }
+      } catch { /* surfaced via connection state */ } finally {
+        makingOffer = false;
+      }
     };
   } else {
     pc.ondatachannel = e => opts.onChannel?.(e.channel);

--- a/src/tools/webrtc/signal.lib.ts
+++ b/src/tools/webrtc/signal.lib.ts
@@ -27,9 +27,9 @@ export function makeRoomId(): string {
   return out;
 }
 
-/** Same-origin shareable link for a file-transfer room. */
-export function roomLink(origin: string, roomId: string): string {
-  return `${origin}/tools/file-transfer#${roomId}`;
+/** Same-origin shareable link for a P2P room (file transfer by default). */
+export function roomLink(origin: string, roomId: string, path = '/tools/file-transfer'): string {
+  return `${origin}${path}#${roomId}`;
 }
 
 /** Extract a valid room id from a URL hash (with or without the leading '#'). */


### PR DESCRIPTION
New **Video Call** tool (`/tools/video-call`, Network) — 1:1 peer-to-peer video call. Item #5 of the batch.

Reuses the entire file-transfer P2P stack (SignalRoom DO, signal.lib/signal-client, custom ICE, manual serverless mode, ack gate, reconnect + retry cap). **Video, audio, and chat travel peer-to-peer**; only the ~2KB handshake touches the signaling server.

- **Controls:** mute mic, camera on/off, switch front/rear camera, **screen share** (getDisplayMedia + replaceTrack), hang up.
- **In-call text chat** over a data channel.
- **Both** peers send + receive (symmetric); either can share their screen.
- Generalized `createPeer`/`createManualConnection` with optional `localStream`+`onTrack` (media) + a `makingOffer` guard; **file-transfer's data-channel path is unchanged**.
- Same reconnect resilience + manual (serverless) copy-paste mode + custom STUN/TURN.

Spec: `docs/superpowers/specs/2026-08-01-video-call-design.md`.

545 tests · lint clean · build green (`/tools/video-call` built).

⚠️ Media paths (camera/mic, screen share, track negotiation) are verified by build + manual smoke, not headless CI — needs a two-device smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)