### PR TITLE
fix(voice-to-text): per-module dtype so the Whisper session loads

### DIFF
--- a/src/tools/media/stt.engine.ts
+++ b/src/tools/media/stt.engine.ts
@@ -45,8 +45,11 @@ export async function createTranscriber(
 
   const pipe = await pipeline('automatic-speech-recognition', model, {
     device: backend,
-    // Quantize on WASM to shrink the download; full precision on WebGPU for quality.
-    dtype: backend === 'wasm' ? 'q8' : 'fp32',
+    // Whisper is an encoder-decoder model. Per-module dtype is required: the
+    // quantized (q8/q4) decoder — which holds embed_tokens — trips an ONNX Runtime
+    // "MatMulNBits: Missing required scale" error, so load the decoder full
+    // precision. The encoder can stay quantized to keep the download smaller.
+    dtype: { encoder_model: backend === 'webgpu' ? 'fp32' : 'q8', decoder_model_merged: 'fp32' },
     progress_callback: (p: { status?: string; progress?: number }) => {
       if (onProgress && p?.status === 'progress' && typeof p.progress === 'number') {
         onProgress(Math.min(1, Math.max(0, p.progress / 100)));


### PR DESCRIPTION
**Reported:** `Can't create a session … MatMulNBits Missing required scale: model.decoder.embed_tokens.weight …`

**Cause:** Whisper is encoder-decoder. A single-string `dtype: 'q8'` (the WASM default) left the **decoder** (which holds `embed_tokens`) on a 4-bit MatMulNBits variant whose scale tensor the bundled ONNX Runtime can't resolve → session creation fails.

**Fix:** per-module dtype — force `decoder_model_merged: 'fp32'` (unquantized, valid scales); encoder stays `q8` on WASM / `fp32` on WebGPU to limit the download.

Not headless-verifiable (needs real model download in a browser) — needs a smoke test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)