### PR TITLE
fix(voice-to-text): explain why Transcribe is disabled

### DIFF
--- a/src/islands/media/VoiceToText.tsx
+++ b/src/islands/media/VoiceToText.tsx
@@ -157,10 +157,15 @@ export default function VoiceToText() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-3">
         <Button onClick={transcribe} disabled={!audioBlob || busy}>
           {busy ? 'Transcribing…' : 'Transcribe'}
         </Button>
+        {!audioBlob && !busy && (
+          <span className="text-sm text-muted-foreground">
+            {recorder.recording ? 'Press Stop to finish the recording first.' : 'Record or drop a file to enable this.'}
+          </span>
+        )}
       </div>
 
       {modelProgress !== null && (


### PR DESCRIPTION
From a screenshot: user was mid-recording ('Stop (0:13)') and expected Transcribe to be enabled after picking a model — not realizing recording must be **stopped** first to produce audio. Adds a hint next to the disabled button ('Press Stop to finish the recording first' / 'Record or drop a file to enable this'). Pure UX; the record→stop→audio→enable flow already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)