### PR TITLE
fix(voice-to-text): make the recorded-audio player pausable/seekable

### DIFF
--- a/src/islands/media/VoiceToText.tsx
+++ b/src/islands/media/VoiceToText.tsx
@@ -63,6 +63,17 @@ export default function VoiceToText() {
     if (f) setAudio(f);
   };
 
+  // MediaRecorder blobs have no duration in their header, so the browser reports
+  // duration=Infinity and treats the clip like a live stream — which freezes the
+  // native pause/seek controls. Seek to the end once to force a real duration.
+  const fixAudioDuration = () => {
+    const el = audioRef.current;
+    if (!el || el.duration !== Infinity) return;
+    const onUpdate = () => { el.removeEventListener('timeupdate', onUpdate); el.currentTime = 0; };
+    el.addEventListener('timeupdate', onUpdate);
+    try { el.currentTime = 1e101; } catch { /* ignore */ }
+  };
+
   const toggleRecord = () => {
     if (recorder.recording) {
       recorder.stop();
@@ -138,7 +149,7 @@ export default function VoiceToText() {
       {recorder.error && <Alert variant="error">{recorder.error.message}</Alert>}
 
       {audioUrl && (
-        <audio ref={audioRef} controls src={audioUrl} className="w-full" />
+        <audio ref={audioRef} controls src={audioUrl} onLoadedMetadata={fixAudioDuration} className="w-full" />
       )}
 
       {/* Model + run */}


### PR DESCRIPTION
After recording, the preview player's pause/seek was unresponsive. MediaRecorder WebM/Opus blobs carry no duration in their header → browser reports `duration=Infinity` → treats it as a live stream → frozen controls (uploaded mp3/wav were fine). On `loadedmetadata`, seek to the end once to force a real duration, then reset to 0.

lint clean · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)