### PR TITLE
fix(pwa): cache ML model weights so they don't re-download on refresh

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -128,6 +128,23 @@ export default defineConfig({
                 statuses: [0, 200]
               }
             }
+          },
+          {
+            // On-device ML model weights + runtime (Whisper from Hugging Face, ORT
+            // wasm from jsDelivr). CacheFirst so they load from our cache on refresh
+            // instead of re-downloading. Immutable, versioned by URL.
+            urlPattern: /^https:\/\/([^/]*\.)?(huggingface\.co|hf\.co)\/.*|^https:\/\/cdn\.jsdelivr\.net\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'ml-models-cache',
+              expiration: {
+                maxEntries: 120,
+                maxAgeSeconds: 60 * 60 * 24 * 90 // 90 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
           }
         ]
       },


### PR DESCRIPTION
The Whisper model re-downloaded on every refresh — transformers.js fetches it from huggingface.co (cross-origin) and its own Cache Storage wasn't persisting. Add a **service-worker CacheFirst** runtimeCaching rule for the HF hosts (incl. `cdn-lfs*`/`*.hf.co` redirect CDNs) + `cdn.jsdelivr.net` (ORT wasm), so our SW serves them from cache across refreshes.

Verified the rule is in the generated `sw.js`. build green.

⚠️ Caveat: if HF redirects the large-file bytes to a CDN host outside `*.huggingface.co`/`*.hf.co` (e.g. CloudFront), that host won't match — the fully-robust fallback is self-hosting the models on our R2. Will confirm with the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)