### PR TITLE
fix(models): stop OCR model re-downloading on refresh + honest voice cache indicator

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -132,9 +132,10 @@ export default defineConfig({
           },
           {
             // On-device ML model weights + runtime (Whisper from Hugging Face, ORT
-            // wasm from jsDelivr). CacheFirst so they load from our cache on refresh
-            // instead of re-downloading. Immutable, versioned by URL.
-            urlPattern: /^https:\/\/([^/]*\.)?(huggingface\.co|hf\.co)\/.*|^https:\/\/cdn\.jsdelivr\.net\/.*/i,
+            // wasm from jsDelivr, PaddleOCR models from GitHub raw/LFS). CacheFirst so
+            // they load from our cache on refresh instead of re-downloading. Immutable,
+            // versioned by URL.
+            urlPattern: /^https:\/\/([^/]*\.)?(huggingface\.co|hf\.co)\/.*|^https:\/\/cdn\.jsdelivr\.net\/.*|^https:\/\/(raw|media)\.githubusercontent\.com\/.*/i,
             handler: 'CacheFirst',
             options: {
               cacheName: 'ml-models-cache',

--- a/src/islands/media/VoiceToText.tsx
+++ b/src/islands/media/VoiceToText.tsx
@@ -67,6 +67,7 @@ export default function VoiceToText() {
   const [modelProgress, setModelProgress] = useState<number | null>(null);
   const [transcribing, setTranscribing] = useState(false);
   const [elapsed, setElapsed] = useState(0);
+  const [modelCached, setModelCached] = useState(false);
   const [segments, setSegments] = useState<TranscriptSegment[] | null>(null);
   const [editedText, setEditedText] = useState('');
   const [tab, setTab] = useState<Tab>('text');
@@ -145,6 +146,20 @@ export default function VoiceToText() {
     }
   };
 
+  // Is the selected model already in the browser cache? (Definitive — the bar
+  // shows even on a cache read, so this tells the user whether it's a real download.)
+  const refreshModelCached = async () => {
+    try {
+      const cache = await caches.open('transformers-cache');
+      const keys = await cache.keys();
+      setModelCached(keys.some(r => r.url.includes(`${model}/resolve`)));
+    } catch { setModelCached(false); }
+  };
+  useEffect(() => {
+    void refreshModelCached();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model]);
+
   const transcribe = async () => {
     if (!audioBlob) return;
     audioRef.current?.pause(); // don't leave the preview playing while inference blocks the thread
@@ -163,6 +178,7 @@ export default function VoiceToText() {
         r => setModelProgress(r),
       );
       setModelProgress(null); // model ready (or cached) — now inference (indeterminate)
+      void refreshModelCached(); // it's cached now
       setSegments(segs);
       setEditedText(segmentsToText(segs));
       setTab('text');
@@ -268,7 +284,7 @@ export default function VoiceToText() {
       </div>
 
       {modelProgress !== null && (
-        <ProgressBar percent={modelProgress * 100} label="Downloading model (first time only)" />
+        <ProgressBar percent={modelProgress * 100} label={modelCached ? 'Loading model from cache…' : 'Downloading model (first time only)…'} />
       )}
       {busy && modelProgress === null && (
         <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## What
- **OCR:** `ppu-paddle-ocr` fetches its model from `raw/media.githubusercontent.com` (git-LFS). Those hosts weren't in the service-worker `ml-models-cache` rule, so the OCR model re-downloaded on every refresh. Added them to the CacheFirst `urlPattern` (alongside Hugging Face + jsDelivr).
- **Voice-to-Text:** transformers.js fires the download progress bar even on cache **hits**, which looked like a re-download. Added a definitive `modelCached` check (`caches.open('transformers-cache')`) and the progress label now says *'Loading model from cache…'* vs *'Downloading model (first time only)…'*.

## Audit (the actual ask: 'ensure other tools don't re-download after refresh')
Background-removal, ffmpeg, face-blur, upscale, object-remove all load **same-origin** from `/models/*`, which the worker serves `cache-control: immutable, max-age=1yr` → held by the HTTP cache across refreshes, no SW rule needed. OCR was the only outlier (cross-origin GitHub host).

## Verify
- `npx vitest run` → 592 passed
- `npm run lint` → 0 errors
- `npm run build` → success, precache clean