### PR TITLE
feat(legacy): Digital Legacy Letter (encrypted 'in case I die' vault)

### DIFF
--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -20,7 +20,7 @@ const fonts = [
 
 const CAT_COLOR = {
   Dev: '#3b82f6', PDF: '#ef4444', Image: '#22c55e', Files: '#eab308', Draw: '#a855f7',
-  Media: '#ec4899', Network: '#06b6d4', Maps: '#10b981', Playground: '#f97316',
+  Media: '#ec4899', Network: '#06b6d4', Maps: '#10b981', Legacy: '#6366f1', Playground: '#f97316',
 };
 
 // Parse the registry without importing TS (aliases + lucide). id, name, category, summary.

--- a/src/islands/legacy/LegacyLetter.tsx
+++ b/src/islands/legacy/LegacyLetter.tsx
@@ -1,0 +1,291 @@
+import { useState } from 'react';
+import { Plus, Trash2, Lock, Users, Upload, Download, Eye, EyeOff, ShieldAlert, Printer, KeyRound } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
+import {
+  createVault, openWithPassword, openWithShares, vaultCapabilities,
+  VAULT_EXT, type Account, type LegacyContent,
+} from '@/tools/legacy/vault.lib';
+
+type Mode = 'create' | 'open' | null;
+const input = 'w-full border-2 border-border bg-muted px-3 py-2 text-sm outline-none focus:shadow-brutal-sm';
+const emptyAccount = (): Account => ({ service: '', username: '', password: '', url: '', notes: '' });
+
+export default function LegacyLetter() {
+  const [mode, setMode] = useState<Mode>(null);
+  return (
+    <div className="space-y-4">
+      {mode === null && (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Write a private letter — passwords, accounts, and final words — that your family can open only
+            when the time comes. It is encrypted <strong>on your device</strong>; nothing is ever uploaded.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={() => setMode('create')}><Lock className="h-4 w-4" /> Write a new letter</Button>
+            <Button variant="secondary" onClick={() => setMode('open')}><Upload className="h-4 w-4" /> Open a letter</Button>
+          </div>
+        </div>
+      )}
+      {mode === 'create' && <CreateView onBack={() => setMode(null)} />}
+      {mode === 'open' && <OpenView onBack={() => setMode(null)} />}
+    </div>
+  );
+}
+
+function CreateView({ onBack }: { onBack: () => void }) {
+  const [message, setMessage] = useState('');
+  const [accounts, setAccounts] = useState<Account[]>([emptyAccount()]);
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [useShares, setUseShares] = useState(false);
+  const [n, setN] = useState(5);
+  const [k, setK] = useState(3);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<{ file: string; shares: string[] } | null>(null);
+
+  const setAccount = (i: number, patch: Partial<Account>) =>
+    setAccounts(a => a.map((x, j) => (j === i ? { ...x, ...patch } : x)));
+
+  const generate = async () => {
+    setError('');
+    const usePw = password.length > 0;
+    if (!usePw && !useShares) { setError('Choose at least one way to unlock: a password or family shares.'); return; }
+    if (usePw && password !== confirm) { setError('The passwords do not match.'); return; }
+    if (usePw && password.length < 8) { setError('Use a password of at least 8 characters.'); return; }
+    if (useShares && (k < 2 || n < k || n > 20)) { setError('Check the family-share numbers (threshold ≥ 2, and total ≥ threshold).'); return; }
+    const content: LegacyContent = {
+      message,
+      accounts: accounts.filter(a => a.service.trim() || a.username?.trim() || a.password?.trim()),
+      createdAt: new Date().toISOString().slice(0, 10),
+    };
+    setBusy(true);
+    try {
+      const res = await createVault(content, { password: usePw ? password : undefined, shares: useShares ? { n, k } : undefined });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create the letter.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <Button variant="ghost" onClick={onBack}>← Back</Button>
+        <Alert variant="success">Your encrypted letter is ready. Download it and keep it safe.</Alert>
+        <Button onClick={() => downloadService.download(new Blob([result.file], { type: 'application/json' }), `surat-wasiat.${VAULT_EXT}`)}>
+          <Download className="h-4 w-4" /> Download the letter (.{VAULT_EXT})
+        </Button>
+
+        {result.shares.length > 0 && (
+          <div className="space-y-2 border-2 border-border p-3">
+            <p className="flex items-center gap-2 font-bold uppercase tracking-wide"><Users className="h-4 w-4" /> Family shares — hand out {k} of these {result.shares.length} are needed</p>
+            <p className="text-sm text-muted-foreground">Give each share to a different trusted person (a relative — and consider giving one to your lawyer/executor). No single person can open the letter alone; any {k} together can.</p>
+            {result.shares.map((s, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <code className="min-w-0 flex-1 truncate border-2 border-border bg-muted px-2 py-1 text-xs">{s}</code>
+                <CopyButton value={s} label={`#${i + 1}`} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="border-2 border-border bg-muted px-3 py-2 text-sm">
+          <p className="flex items-center gap-2 font-bold"><ShieldAlert className="h-4 w-4" /> Keep it recoverable</p>
+          <p className="mt-1 text-muted-foreground">
+            This letter can be opened <strong>only</strong> with its password{result.shares.length > 0 ? ` or ${k} family shares` : ''}.
+            If those are lost, the contents are gone forever — by design, so no one else can read them. Store the
+            file and the way to unlock it separately.
+          </p>
+        </div>
+        <Button variant="secondary" onClick={() => setResult(null)}>Edit the letter</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <Button variant="ghost" onClick={onBack}>← Back</Button>
+
+      <div className="space-y-2">
+        <label className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Your message</label>
+        <textarea value={message} onChange={e => setMessage(e.target.value)} rows={5} placeholder="Final words for your family…" className={input} />
+      </div>
+
+      <div className="space-y-3">
+        <label className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Accounts &amp; secrets</label>
+        {accounts.map((a, i) => (
+          <div key={i} className="space-y-2 border-2 border-border p-3">
+            <div className="flex gap-2">
+              <input value={a.service} onChange={e => setAccount(i, { service: e.target.value })} placeholder="Service (e.g. Instagram)" className={input} />
+              {accounts.length > 1 && <Button variant="ghost" aria-label="Remove" onClick={() => setAccounts(x => x.filter((_, j) => j !== i))}><Trash2 className="h-4 w-4" /></Button>}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <input value={a.username} onChange={e => setAccount(i, { username: e.target.value })} placeholder="Username / email" className={input} />
+              <input value={a.password} onChange={e => setAccount(i, { password: e.target.value })} placeholder="Password / PIN" className={input} />
+              <input value={a.url} onChange={e => setAccount(i, { url: e.target.value })} placeholder="Website (optional)" className={input} />
+              <input value={a.notes} onChange={e => setAccount(i, { notes: e.target.value })} placeholder="Notes (e.g. 2FA on my phone)" className={input} />
+            </div>
+          </div>
+        ))}
+        <Button variant="secondary" onClick={() => setAccounts(a => [...a, emptyAccount()])}><Plus className="h-4 w-4" /> Add account</Button>
+      </div>
+
+      <div className="space-y-3 border-2 border-border p-3">
+        <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">How family will unlock it</p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className={input} />
+          <input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} placeholder="Confirm password" className={input} />
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={useShares} onChange={e => setUseShares(e.target.checked)} />
+          <span className="font-bold">Also split into family shares</span>
+          <span className="text-muted-foreground">— so no single person can open it alone</span>
+        </label>
+        {useShares && (
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <label className="flex items-center gap-2">Any <input type="number" min={2} max={n} value={k} onChange={e => setK(Math.max(2, Math.min(n, +e.target.value)))} className="w-16 border-2 border-border bg-muted px-2 py-1" /></label>
+            <label className="flex items-center gap-2">of <input type="number" min={k} max={20} value={n} onChange={e => setN(Math.max(k, Math.min(20, +e.target.value)))} className="w-16 border-2 border-border bg-muted px-2 py-1" /> shares</label>
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">Set a password, family shares, or both. At least one is required.</p>
+      </div>
+
+      {error && <Alert variant="error">{error}</Alert>}
+      <Button onClick={generate} disabled={busy}><Lock className="h-4 w-4" /> {busy ? 'Encrypting…' : 'Encrypt & create letter'}</Button>
+    </div>
+  );
+}
+
+function OpenView({ onBack }: { onBack: () => void }) {
+  const [file, setFile] = useState<string | null>(null);
+  const [caps, setCaps] = useState<{ password: boolean; shares: { n: number; k: number } | null } | null>(null);
+  const [password, setPassword] = useState('');
+  const [sharesText, setSharesText] = useState('');
+  const [content, setContent] = useState<LegacyContent | null>(null);
+  const [reveal, setReveal] = useState<Record<number, boolean>>({});
+  const [error, setError] = useState('');
+
+  const onDrop = async (files: File[]) => {
+    setError(''); setContent(null);
+    const f = files[0];
+    if (!f) return;
+    try {
+      const text = await f.text();
+      setCaps(vaultCapabilities(text));
+      setFile(text);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not read this file.');
+      setFile(null); setCaps(null);
+    }
+  };
+
+  const openPw = async () => {
+    if (!file) return;
+    setError('');
+    try { setContent(await openWithPassword(file, password)); }
+    catch (e) { setError(e instanceof Error ? e.message : 'Could not open the letter.'); }
+  };
+  const openShares = async () => {
+    if (!file) return;
+    setError('');
+    try {
+      const list = sharesText.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      setContent(await openWithShares(file, list));
+    } catch (e) { setError(e instanceof Error ? e.message : 'Could not open the letter.'); }
+  };
+
+  if (content) {
+    return (
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2 print:hidden">
+          <Button variant="ghost" onClick={onBack}>← Back</Button>
+          <Button variant="secondary" onClick={() => window.print()}><Printer className="h-4 w-4" /> Print / Save PDF</Button>
+        </div>
+        {content.message && (
+          <div className="space-y-1 border-2 border-border p-4">
+            <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Message</p>
+            <p className="whitespace-pre-wrap">{content.message}</p>
+          </div>
+        )}
+        {content.accounts.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-bold uppercase tracking-wide text-muted-foreground">Accounts &amp; secrets</p>
+            {content.accounts.map((a, i) => (
+              <div key={i} className="space-y-1 border-2 border-border p-3">
+                <p className="font-bold">{a.service || '(untitled)'}</p>
+                {a.username && <Row label="Username" value={a.username} />}
+                {a.password && (
+                  <div className="flex flex-wrap items-center gap-2 text-sm">
+                    <span className="w-24 shrink-0 font-bold text-muted-foreground">Password</span>
+                    <code className="border-2 border-border bg-muted px-2 py-0.5">{reveal[i] ? a.password : '••••••••'}</code>
+                    <button onClick={() => setReveal(r => ({ ...r, [i]: !r[i] }))} aria-label="Reveal" className="press-brutal">{reveal[i] ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}</button>
+                    <CopyButton value={a.password} label="Copy" />
+                  </div>
+                )}
+                {a.url && <Row label="Website" value={a.url} />}
+                {a.notes && <Row label="Notes" value={a.notes} />}
+              </div>
+            ))}
+          </div>
+        )}
+        {content.createdAt && <p className="text-xs text-muted-foreground">Written {content.createdAt}.</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Button variant="ghost" onClick={onBack}>← Back</Button>
+      {!file && (
+        <Dropzone onDrop={onDrop} accept={`.${VAULT_EXT},application/json`} multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">Drop the letter file (.{VAULT_EXT})</p>
+            <p className="text-sm text-muted-foreground">It is decrypted here on your device — nothing is uploaded.</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {file && caps && (
+        <div className="space-y-4">
+          {caps.password && (
+            <div className="space-y-2 border-2 border-border p-3">
+              <p className="flex items-center gap-2 font-bold uppercase tracking-wide"><KeyRound className="h-4 w-4" /> Open with password</p>
+              <div className="flex gap-2">
+                <input type="password" value={password} onChange={e => setPassword(e.target.value)} onKeyDown={e => { if (e.key === 'Enter') openPw(); }} placeholder="Password" className={input} />
+                <Button onClick={openPw}>Open</Button>
+              </div>
+            </div>
+          )}
+          {caps.shares && (
+            <div className="space-y-2 border-2 border-border p-3">
+              <p className="flex items-center gap-2 font-bold uppercase tracking-wide"><Users className="h-4 w-4" /> Open with family shares</p>
+              <p className="text-sm text-muted-foreground">Paste {caps.shares.k} of the {caps.shares.n} shares, one per line.</p>
+              <textarea value={sharesText} onChange={e => setSharesText(e.target.value)} rows={caps.shares.k + 1} placeholder={'gwt-wasiat.v1.…\ngwt-wasiat.v1.…'} className={input} />
+              <Button onClick={openShares}>Combine &amp; open</Button>
+            </div>
+          )}
+          <Button variant="ghost" onClick={() => { setFile(null); setCaps(null); setError(''); }}>Choose a different file</Button>
+        </div>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-sm">
+      <span className="w-24 shrink-0 font-bold text-muted-foreground">{label}</span>
+      <span className="min-w-0 break-all">{value}</span>
+      <CopyButton value={value} label="Copy" />
+    </div>
+  );
+}

--- a/src/registry/categories.ts
+++ b/src/registry/categories.ts
@@ -10,6 +10,7 @@ export const categories: Category[] = [
   'Media',
   'Network',
   'Maps',
+  'Legacy',
   'Playground'
 ];
 
@@ -22,6 +23,7 @@ export const categoryColors: Record<Category, string> = {
   Media: 'bg-pink-500',
   Network: 'bg-cyan-500',
   Maps: 'bg-emerald-500',
+  Legacy: 'bg-indigo-500',
   Playground: 'bg-orange-500'
 };
 
@@ -56,6 +58,7 @@ export const categoryDescriptionsId: Record<Category, string> = {
   Media: 'Utilitas audio dan video privat — konversi, pangkas, rekam, dan transkripsi media sepenuhnya di perangkat Anda. Rekaman Anda tidak pernah meninggalkan browser.',
   Network: 'Tool peer-to-peer yang menghubungkan dua perangkat secara langsung untuk mentransfer berkas atau berkomunikasi — data Anda mengalir antar perangkat, bukan melalui server.',
   Maps: 'Tool pemetaan sumber terbuka — konversi koordinat, jelajahi dan ekspor peta, serta lihat berkas GeoJSON, GPX, dan KML. Dibangun di atas data peta terbuka, berjalan di browser Anda.',
+  Legacy: 'Titipkan pesan dan kata sandi penting untuk keluarga — dienkripsi di perangkat Anda dan hanya bisa dibuka saat waktunya tiba. Tidak ada yang diunggah ke server.',
   Playground: 'Playground interaktif dan eksperimen untuk menjelajah dan belajar — semuanya berjalan di sisi klien di browser Anda.',
 };
 
@@ -69,5 +72,6 @@ export const categoryDescriptions: Record<Category, string> = {
   Media: 'Private audio and video utilities — convert, trim, record and transcribe media entirely on your device using on-device processing. Your recordings never leave your browser.',
   Network: 'Peer-to-peer tools that connect two devices directly to transfer files or communicate — your data flows device to device, not through a server.',
   Maps: 'Open-source mapping tools — convert coordinates, explore and export maps, and view GeoJSON, GPX and KML files. Built on open map data, running in your browser.',
+  Legacy: 'Entrust messages and important passwords to your family — encrypted on your device and openable only when the time comes. Nothing is uploaded to any server.',
   Playground: 'Interactive playgrounds and experiments to explore and learn — all running client-side in your browser.',
 };

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -7,6 +7,23 @@ import type { Lang } from '@/i18n/config';
  * a locale entry is missing. Feeds on-page copy + HowTo/FAQPage structured data.
  */
 const en: Record<string, ToolSeoContent> = {
+  'legacy-letter': {
+    title: 'Free Digital Legacy Letter Tool — Encrypted',
+    description: 'A free tool to write an encrypted letter of passwords and final words for your family — opened by password or family shares, only when the time comes. 100% in your browser.',
+    intro: 'This free digital legacy letter tool lets you write a private message and store account passwords for your loved ones, sealed with AES-256 encryption. Unlock it with a password or split it into family shares — nothing is ever uploaded.',
+    howTo: [
+      'Write your message and add each account — service, username, password, and notes.',
+      'Choose how family will unlock it: a password, family shares (any 3 of 5, say), or both.',
+      'Download the encrypted .gwtvault file and store it safely; hand out the shares separately.',
+      'When the time comes, your family opens the file here with the password or by combining shares.',
+    ],
+    faqs: [
+      { q: 'Is my letter or my passwords uploaded anywhere?', a: 'No. Everything is encrypted and decrypted on your device with AES-256-GCM. The file never leaves your browser, so your passwords are never sent to any server.' },
+      { q: 'How do family shares work?', a: 'The key is split into several shares (for example 5) using Shamir Secret Sharing, and a chosen number of them (say any 3) are needed to open the letter. No single person can open it alone, and it still works if a few shares are lost. Tip: give one share to your lawyer or executor.' },
+      { q: 'Can it release automatically when I die?', a: 'Not automatically — a private, in-browser tool cannot know when you have died without a server holding your data. Instead you control the handoff: share the password or the family shares so they can only be brought together when the time comes.' },
+      { q: 'What if I lose the password and the shares?', a: 'Then the letter cannot be opened — by design, so no one else can read it either. Keep the file and the way to unlock it stored separately and safely.' },
+    ],
+  },
   'json-format': {
     title: 'Free JSON Formatter Tool — Validate & Minify',
     description: 'A free online JSON formatter tool to format, beautify, minify and validate JSON — 100% private. Your JSON is processed in your browser and never uploaded.',
@@ -1274,6 +1291,23 @@ const en: Record<string, ToolSeoContent> = {
 };
 
 const id: Record<string, ToolSeoContent> = {
+  'legacy-letter': {
+    title: 'Tool Surat Wasiat Digital Gratis — Terenkripsi',
+    description: 'Tool gratis untuk menulis surat terenkripsi berisi kata sandi dan pesan terakhir untuk keluarga — dibuka dengan kata sandi atau bagian keluarga, hanya saat waktunya tiba. 100% di browser Anda.',
+    intro: 'Tool surat wasiat digital gratis ini memungkinkan Anda menulis pesan pribadi dan menyimpan kata sandi akun untuk orang terkasih, tersegel dengan enkripsi AES-256. Buka dengan kata sandi atau bagi menjadi beberapa bagian keluarga — tidak ada yang pernah diunggah.',
+    howTo: [
+      'Tulis pesan Anda dan tambahkan setiap akun — layanan, nama pengguna, kata sandi, dan catatan.',
+      'Pilih cara keluarga membukanya: kata sandi, bagian keluarga (misalnya 3 dari 5), atau keduanya.',
+      'Unduh berkas .gwtvault terenkripsi dan simpan dengan aman; bagikan setiap bagian secara terpisah.',
+      'Saat waktunya tiba, keluarga membuka berkas di sini dengan kata sandi atau dengan menggabungkan bagian.',
+    ],
+    faqs: [
+      { q: 'Apakah surat atau kata sandi saya diunggah ke suatu tempat?', a: 'Tidak. Semuanya dienkripsi dan didekripsi di perangkat Anda dengan AES-256-GCM. Berkas tidak pernah meninggalkan browser, jadi kata sandi Anda tidak pernah dikirim ke server mana pun.' },
+      { q: 'Bagaimana cara kerja bagian keluarga?', a: 'Kunci dibagi menjadi beberapa bagian (misalnya 5) menggunakan Shamir Secret Sharing, dan sejumlah tertentu (misalnya 3) diperlukan untuk membuka surat. Tidak ada satu orang pun yang bisa membukanya sendirian, dan tetap berfungsi meski beberapa bagian hilang. Tips: berikan satu bagian kepada notaris atau pelaksana wasiat Anda.' },
+      { q: 'Bisakah surat terbuka otomatis saat saya meninggal?', a: 'Tidak secara otomatis — tool privat di browser tidak bisa mengetahui kapan Anda meninggal tanpa server yang menyimpan data Anda. Sebagai gantinya, Anda mengendalikan penyerahannya: bagikan kata sandi atau bagian keluarga agar hanya dapat disatukan saat waktunya tiba.' },
+      { q: 'Bagaimana jika saya kehilangan kata sandi dan bagiannya?', a: 'Maka surat tidak bisa dibuka — memang dirancang begitu, agar tidak ada orang lain yang bisa membacanya. Simpan berkas dan cara membukanya secara terpisah dan aman.' },
+    ],
+  },
   'json-format': {
     title: 'Tool Format JSON Gratis — Validasi & Perkecil',
     description: 'Tool format JSON online gratis untuk merapikan, memperindah, memperkecil, dan memvalidasi JSON — 100% privat. JSON Anda diproses di browser dan tidak pernah diunggah.',

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -651,6 +651,17 @@ export const tools: ToolDef[] = [
     summary: 'Password-encrypt any file with AES-256 (client-side)',
     load: () => import('@/islands/files/FileCrypt'),
     status: 'stable'
+  },
+  {
+    id: 'legacy-letter',
+    name: 'Digital Legacy Letter',
+    category: 'Legacy',
+    route: '/tools/legacy-letter',
+    keywords: ['legacy', 'will', 'digital will', 'surat wasiat', 'wasiat', 'password', 'inheritance', 'family', 'encrypt', 'in case i die', 'dead man switch', 'secret', 'shamir'],
+    icon: ScrollText,
+    summary: 'Encrypt a private letter of passwords & final words for your family',
+    load: () => import('@/islands/legacy/LegacyLetter'),
+    status: 'beta'
   },
   {
     id: 'zip',

--- a/src/tools/legacy/crypto.lib.ts
+++ b/src/tools/legacy/crypto.lib.ts
@@ -1,0 +1,78 @@
+/**
+ * Crypto layer for the Digital Legacy Letter. The letter is encrypted with a random
+ * 256-bit Data Encryption Key (DEK) using AES-256-GCM. The DEK itself has two
+ * independent recovery paths: it can be wrapped by a PBKDF2-derived password key, and
+ * it can be Shamir-split into family shares (see shamir.lib). Everything runs in the
+ * browser via WebCrypto; nothing is uploaded.
+ */
+
+const ITERATIONS = 250_000;
+const SALT_LEN = 16;
+const IV_LEN = 12;
+
+/** A fresh 256-bit data encryption key. */
+export function generateDek(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(32));
+}
+
+async function importAesKey(raw: Uint8Array, usages: KeyUsage[]): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM' }, false, usages);
+}
+
+async function deriveKeyFromPassword(password: string, salt: Uint8Array, usages: KeyUsage[]): Promise<CryptoKey> {
+  const base = await crypto.subtle.importKey('raw', new TextEncoder().encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: ITERATIONS, hash: 'SHA-256' },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    usages,
+  );
+}
+
+export interface Ciphertext {
+  iv: Uint8Array;
+  ct: Uint8Array;
+}
+
+/** Encrypt bytes under the DEK (AES-256-GCM, random IV). */
+export async function encryptWithDek(plain: Uint8Array, dek: Uint8Array): Promise<Ciphertext> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+  const key = await importAesKey(dek, ['encrypt']);
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plain));
+  return { iv, ct };
+}
+
+/** Decrypt bytes under the DEK. Throws if the key is wrong or the data is tampered. */
+export async function decryptWithDek({ iv, ct }: Ciphertext, dek: Uint8Array): Promise<Uint8Array> {
+  const key = await importAesKey(dek, ['decrypt']);
+  return new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct));
+}
+
+export interface PasswordWrap {
+  salt: Uint8Array;
+  iters: number;
+  iv: Uint8Array;
+  ct: Uint8Array;
+}
+
+/** Wrap (encrypt) the DEK with a password-derived key. */
+export async function wrapDekWithPassword(dek: Uint8Array, password: string): Promise<PasswordWrap> {
+  if (!password) throw new Error('Enter a password.');
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_LEN));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+  const key = await deriveKeyFromPassword(password, salt, ['encrypt']);
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, dek));
+  return { salt, iters: ITERATIONS, iv, ct };
+}
+
+/** Recover the DEK from a password wrap. Throws on the wrong password. */
+export async function unwrapDekWithPassword(wrap: PasswordWrap, password: string): Promise<Uint8Array> {
+  if (!password) throw new Error('Enter the password.');
+  const key = await deriveKeyFromPassword(password, wrap.salt, ['decrypt']);
+  try {
+    return new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: wrap.iv }, key, wrap.ct));
+  } catch {
+    throw new Error('Wrong password.');
+  }
+}

--- a/src/tools/legacy/shamir.lib.test.ts
+++ b/src/tools/legacy/shamir.lib.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { split, combine } from './shamir.lib';
+
+// Deterministic PRNG so tests don't depend on real randomness.
+function seededRandom(seed = 1) {
+  let a = seed >>> 0;
+  return (len: number) => {
+    const out = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      a = (a * 1664525 + 1013904223) >>> 0;
+      out[i] = (a >>> 16) & 0xff;
+    }
+    return out;
+  };
+}
+
+const secret = new Uint8Array([0, 1, 2, 42, 127, 128, 200, 255, 99, 7]);
+const random = seededRandom(12345);
+
+// All k-sized subsets of [0..n).
+function subsets(n: number, k: number): number[][] {
+  const res: number[][] = [];
+  const pick = (start: number, cur: number[]) => {
+    if (cur.length === k) { res.push([...cur]); return; }
+    for (let i = start; i < n; i++) pick(i + 1, [...cur, i]);
+  };
+  pick(0, []);
+  return res;
+}
+
+describe('shamir split/combine', () => {
+  it('reconstructs from ANY k-of-n subset (n=5, k=3)', () => {
+    const shares = split(secret, 5, 3, { random });
+    for (const subset of subsets(5, 3)) {
+      const got = combine(subset.map(i => shares[i]));
+      expect([...got]).toEqual([...secret]);
+    }
+  });
+
+  it('reconstructs from all n shares too', () => {
+    const shares = split(secret, 5, 3, { random });
+    expect([...combine(shares)]).toEqual([...secret]);
+  });
+
+  it('works for k=2 and for k=n', () => {
+    const s2 = split(secret, 3, 2, { random });
+    expect([...combine([s2[0], s2[2]])]).toEqual([...secret]);
+    const sn = split(secret, 4, 4, { random });
+    expect([...combine(sn)]).toEqual([...secret]);
+  });
+
+  it('k=1 is a trivial share equal to the secret at every point', () => {
+    const s = split(secret, 3, 1, { random });
+    expect([...combine([s[0]])]).toEqual([...secret]);
+    expect([...combine([s[2]])]).toEqual([...secret]);
+  });
+
+  it('fewer than k shares does NOT reveal the secret', () => {
+    const shares = split(secret, 5, 3, { random });
+    const got = combine([shares[0], shares[1]]); // only 2 of 3
+    expect([...got]).not.toEqual([...secret]);
+  });
+
+  it('handles a full 32-byte key with random coefficients', () => {
+    const key = crypto.getRandomValues(new Uint8Array(32));
+    const shares = split(key, 6, 4);
+    expect([...combine([shares[5], shares[0], shares[3], shares[2]])]).toEqual([...key]);
+  });
+
+  it('rejects invalid parameters', () => {
+    expect(() => split(secret, 2, 3, { random })).toThrow();       // n < k
+    expect(() => split(secret, 3, 0, { random })).toThrow();       // k < 1
+    expect(() => split(new Uint8Array(0), 3, 2, { random })).toThrow(); // empty
+    expect(() => split(secret, 300, 2, { random })).toThrow();     // n > 255
+  });
+
+  it('rejects duplicate shares on combine', () => {
+    const shares = split(secret, 5, 3, { random });
+    expect(() => combine([shares[0], shares[0], shares[1]])).toThrow(/[Dd]uplicate/);
+  });
+});

--- a/src/tools/legacy/shamir.lib.ts
+++ b/src/tools/legacy/shamir.lib.ts
@@ -1,0 +1,118 @@
+/**
+ * Shamir Secret Sharing over GF(2^8) — splits a secret (the vault's 32-byte data
+ * key) into `n` shares such that any `k` of them reconstruct it, and fewer than `k`
+ * reveal nothing. Pure and framework-free; the field is the AES field (reducing
+ * polynomial 0x11b, generator 0x03). Operates byte-wise, so the secret can be any
+ * length. Correctness of a reconstruction is verified downstream by AES-GCM's auth
+ * tag (a wrong/insufficient combine yields a key that fails to decrypt).
+ */
+
+// GF(2^8) log/exp tables (generator g = 3).
+const EXP = new Uint8Array(512);
+const LOG = new Uint8Array(256);
+(() => {
+  let x = 1;
+  for (let i = 0; i < 255; i++) {
+    EXP[i] = x;
+    LOG[x] = i;
+    x ^= xtime(x); // x = x*2 ^ x = x*3
+  }
+  for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255];
+})();
+
+function xtime(a: number): number {
+  const b = a << 1;
+  return (b & 0x100 ? b ^ 0x11b : b) & 0xff;
+}
+
+function mul(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return EXP[LOG[a] + LOG[b]];
+}
+
+/** Multiplicative inverse in GF(2^8). */
+function inv(a: number): number {
+  if (a === 0) throw new Error('division by zero in GF(256)');
+  return EXP[255 - LOG[a]];
+}
+
+/** Evaluate a polynomial (coeffs low→high) at x via Horner's method. */
+function evalPoly(coeffs: Uint8Array, x: number): number {
+  let result = 0;
+  for (let i = coeffs.length - 1; i >= 0; i--) result = mul(result, x) ^ coeffs[i];
+  return result;
+}
+
+export interface SplitOptions {
+  /** Injectable randomness for tests; defaults to crypto.getRandomValues. */
+  random?: (len: number) => Uint8Array;
+}
+
+function defaultRandom(len: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(len));
+}
+
+/**
+ * Split `secret` into `n` shares, any `k` of which reconstruct it. Each returned
+ * share is `[x, ...values]` where x (1..n) is the share's evaluation point.
+ */
+export function split(secret: Uint8Array, n: number, k: number, opts: SplitOptions = {}): Uint8Array[] {
+  if (!Number.isInteger(n) || !Number.isInteger(k)) throw new Error('n and k must be integers.');
+  if (k < 1) throw new Error('Threshold k must be at least 1.');
+  if (n < k) throw new Error('Total shares n must be ≥ threshold k.');
+  if (n > 255) throw new Error('At most 255 shares are supported.');
+  if (secret.length === 0) throw new Error('Secret must not be empty.');
+  const random = opts.random ?? defaultRandom;
+
+  const shares: Uint8Array[] = [];
+  for (let x = 1; x <= n; x++) {
+    const out = new Uint8Array(secret.length + 1);
+    out[0] = x;
+    shares.push(out);
+  }
+
+  for (let j = 0; j < secret.length; j++) {
+    // Polynomial with constant term = secret byte, k-1 random higher coeffs.
+    const coeffs = new Uint8Array(k);
+    coeffs[0] = secret[j];
+    if (k > 1) coeffs.set(random(k - 1), 1);
+    for (let s = 0; s < n; s++) {
+      shares[s][j + 1] = evalPoly(coeffs, s + 1);
+    }
+  }
+  return shares;
+}
+
+/**
+ * Reconstruct the secret from shares via Lagrange interpolation at x=0. Requires at
+ * least `k` valid, distinct shares; passing fewer (or mismatched) yields a wrong
+ * secret rather than an error — verified downstream by decryption.
+ */
+export function combine(shares: Uint8Array[]): Uint8Array {
+  if (shares.length === 0) throw new Error('Provide at least one share.');
+  const len = shares[0].length - 1;
+  if (len < 1) throw new Error('Malformed share.');
+  const xs = shares.map(s => s[0]);
+  if (new Set(xs).size !== xs.length) throw new Error('Duplicate shares — each share must be different.');
+  if (xs.some((x, i) => x === 0 || shares[i].length - 1 !== len)) throw new Error('Malformed or inconsistent shares.');
+
+  // Precompute each share's Lagrange basis at 0: L_i = ∏_{m≠i} x_m / (x_i ⊕ x_m).
+  const basis = xs.map((xi, i) => {
+    let num = 1;
+    let den = 1;
+    for (let m = 0; m < xs.length; m++) {
+      if (m === i) continue;
+      num = mul(num, xs[m]);
+      den = mul(den, xi ^ xs[m]);
+    }
+    return mul(num, inv(den));
+  });
+
+  const secret = new Uint8Array(len);
+  for (let j = 0; j < len; j++) {
+    let acc = 0;
+    for (let i = 0; i < shares.length; i++) acc ^= mul(shares[i][j + 1], basis[i]);
+    secret[j] = acc;
+  }
+  return secret;
+}

--- a/src/tools/legacy/vault.lib.test.ts
+++ b/src/tools/legacy/vault.lib.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createVault, openWithPassword, openWithShares, parseVault,
+  vaultCapabilities, encodeShare, decodeShare, type LegacyContent,
+} from './vault.lib';
+
+const content: LegacyContent = {
+  message: 'Untuk keluargaku — terima kasih untuk segalanya. 🙏',
+  accounts: [
+    { service: 'Instagram', username: 'me@example.com', password: 'sup3r-s3cret!', url: 'instagram.com', notes: '2FA di HP' },
+    { service: 'Bank', username: '1234567890', password: 'pinpin', notes: 'rekening utama' },
+  ],
+};
+
+describe('vault — password path', () => {
+  it('round-trips content through create → openWithPassword', async () => {
+    const { file } = await createVault(content, { password: 'correct horse battery staple' });
+    const out = await openWithPassword(file, 'correct horse battery staple');
+    expect(out.message).toBe(content.message);
+    expect(out.accounts).toEqual(content.accounts);
+  });
+
+  it('rejects the wrong password', async () => {
+    const { file } = await createVault(content, { password: 'right' });
+    await expect(openWithPassword(file, 'wrong')).rejects.toThrow(/[Ww]rong password/);
+  });
+
+  it('a password-only vault cannot be opened with shares', async () => {
+    const { file, shares } = await createVault(content, { password: 'x' });
+    expect(shares).toHaveLength(0);
+    await expect(openWithShares(file, [])).rejects.toThrow(/does not use family shares/);
+  });
+});
+
+describe('vault — family shares path', () => {
+  it('opens with any k of n shares', async () => {
+    const { file, shares } = await createVault(content, { shares: { n: 5, k: 3 } });
+    expect(shares).toHaveLength(5);
+    const out = await openWithShares(file, [shares[4], shares[1], shares[2]]);
+    expect(out.accounts).toEqual(content.accounts);
+    const out2 = await openWithShares(file, [shares[0], shares[3], shares[4]]);
+    expect(out2.message).toBe(content.message);
+  });
+
+  it('refuses fewer than k shares', async () => {
+    const { file, shares } = await createVault(content, { shares: { n: 5, k: 3 } });
+    await expect(openWithShares(file, [shares[0], shares[1]])).rejects.toThrow(/[Nn]eed at least 3/);
+  });
+
+  it('a shares-only vault has no password path', async () => {
+    const { file } = await createVault(content, { shares: { n: 3, k: 2 } });
+    expect(vaultCapabilities(file)).toEqual({ password: false, shares: { n: 3, k: 2 } });
+    await expect(openWithPassword(file, 'anything')).rejects.toThrow(/not protected by a password/);
+  });
+});
+
+describe('vault — both paths', () => {
+  it('opens the same content via password OR shares', async () => {
+    const { file, shares } = await createVault(content, { password: 'pw', shares: { n: 4, k: 2 } });
+    const viaPw = await openWithPassword(file, 'pw');
+    const viaShares = await openWithShares(file, [shares[0], shares[2]]);
+    expect(viaPw).toEqual(viaShares);
+    expect(viaPw.message).toBe(content.message);
+    expect(vaultCapabilities(file)).toEqual({ password: true, shares: { n: 4, k: 2 } });
+  });
+});
+
+describe('vault — validation & shares encoding', () => {
+  it('requires at least one recovery path', async () => {
+    await expect(createVault(content, {})).rejects.toThrow(/at least one way to unlock/);
+  });
+
+  it('rejects nonsensical share params', async () => {
+    await expect(createVault(content, { shares: { n: 2, k: 1 } })).rejects.toThrow(/threshold of at least 2/);
+    await expect(createVault(content, { shares: { n: 2, k: 3 } })).rejects.toThrow(/at least the threshold/);
+  });
+
+  it('share strings round-trip and detect tampering', () => {
+    const raw = new Uint8Array([3, 10, 20, 30, 40]);
+    const s = encodeShare(raw);
+    expect([...decodeShare(s)]).toEqual([...raw]);
+    // Corrupt a character in the payload → checksum should fail.
+    const broken = s.slice(0, -6) + (s[s.length - 6] === 'A' ? 'B' : 'A') + s.slice(-5);
+    expect(() => decodeShare(broken)).toThrow();
+    expect(() => decodeShare('hello')).toThrow(/does not look like a family share/);
+  });
+
+  it('parseVault rejects foreign/corrupt files', () => {
+    expect(() => parseVault('{"not":"ours"}')).toThrow(/not a GoodWebTools legacy vault/);
+    expect(() => parseVault('not json')).toThrow(/not a valid/);
+  });
+
+  it('the vault file never contains the shares', async () => {
+    const { file, shares } = await createVault(content, { shares: { n: 3, k: 2 } });
+    for (const s of shares) expect(file).not.toContain(s.split('.').slice(-2)[0]);
+  });
+});

--- a/src/tools/legacy/vault.lib.ts
+++ b/src/tools/legacy/vault.lib.ts
@@ -1,0 +1,185 @@
+/**
+ * The Digital Legacy Letter "vault": turns the letter + accounts into a single
+ * encrypted, self-describing file, and opens it again via either the password or a
+ * quorum of family shares. The file never contains the shares — those are handed out
+ * separately. Text-based (JSON) so it survives email/copy-paste.
+ */
+import {
+  generateDek, encryptWithDek, decryptWithDek,
+  wrapDekWithPassword, unwrapDekWithPassword, type PasswordWrap, type Ciphertext,
+} from './crypto.lib';
+import { split, combine } from './shamir.lib';
+
+export const VAULT_EXT = 'gwtvault';
+const APP = 'gwt-legacy';
+const VERSION = 1;
+const SHARE_PREFIX = 'gwt-wasiat.v1.';
+
+export interface Account {
+  service: string;
+  username?: string;
+  password?: string;
+  url?: string;
+  notes?: string;
+}
+
+export interface LegacyContent {
+  /** The personal message / letter. */
+  message: string;
+  accounts: Account[];
+  /** ISO date the vault was created. */
+  createdAt?: string;
+}
+
+// ---- base64 helpers (binary-safe) ----
+function b64(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function unb64(str: string): Uint8Array {
+  const s = atob(str);
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+  return out;
+}
+const b64url = (b: Uint8Array) => b64(b).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+const unb64url = (s: string) => unb64(s.replace(/-/g, '+').replace(/_/g, '/'));
+
+function fnv1a(bytes: Uint8Array): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    h ^= bytes[i];
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0').slice(0, 4);
+}
+
+// ---- share strings ----
+/** Encode a raw share ([x, ...bytes]) as a human-transportable string with a checksum. */
+export function encodeShare(share: Uint8Array): string {
+  return `${SHARE_PREFIX}${b64url(share)}.${fnv1a(share)}`;
+}
+
+/** Decode + checksum-verify a share string back to raw bytes. */
+export function decodeShare(str: string): Uint8Array {
+  const trimmed = str.trim();
+  if (!trimmed.startsWith(SHARE_PREFIX)) throw new Error('This does not look like a family share.');
+  const body = trimmed.slice(SHARE_PREFIX.length);
+  const dot = body.lastIndexOf('.');
+  if (dot < 0) throw new Error('This share is incomplete.');
+  const bytes = unb64url(body.slice(0, dot));
+  if (fnv1a(bytes) !== body.slice(dot + 1)) throw new Error('This share looks mistyped (checksum failed).');
+  return bytes;
+}
+
+interface Envelope {
+  app: string;
+  v: number;
+  content: { iv: string; ct: string };
+  password: { salt: string; iters: number; iv: string; ct: string } | null;
+  shares: { n: number; k: number } | null;
+}
+
+const encodeCt = (c: Ciphertext) => ({ iv: b64(c.iv), ct: b64(c.ct) });
+const decodeCt = (o: { iv: string; ct: string }): Ciphertext => ({ iv: unb64(o.iv), ct: unb64(o.ct) });
+
+export interface CreateOptions {
+  password?: string;
+  shares?: { n: number; k: number };
+}
+
+export interface CreateResult {
+  /** The .gwtvault file text to download. */
+  file: string;
+  /** Share strings to distribute (empty if shares weren't requested). */
+  shares: string[];
+}
+
+/** Encrypt the content into a vault file (+ optional shares). Requires at least one recovery path. */
+export async function createVault(content: LegacyContent, opts: CreateOptions): Promise<CreateResult> {
+  const hasPw = !!opts.password;
+  const hasShares = !!opts.shares;
+  if (!hasPw && !hasShares) throw new Error('Choose at least one way to unlock: a password or family shares.');
+  if (opts.shares) {
+    const { n, k } = opts.shares;
+    if (k < 2) throw new Error('Family shares need a threshold of at least 2.');
+    if (n < k) throw new Error('Total shares must be at least the threshold.');
+    if (n > 20) throw new Error('Keep total shares to 20 or fewer.');
+  }
+
+  const dek = generateDek();
+  const plain = new TextEncoder().encode(JSON.stringify({ ...content, createdAt: content.createdAt ?? undefined }));
+  const contentCt = await encryptWithDek(plain, dek);
+
+  let password: Envelope['password'] = null;
+  if (opts.password) {
+    const w = await wrapDekWithPassword(dek, opts.password);
+    password = { salt: b64(w.salt), iters: w.iters, iv: b64(w.iv), ct: b64(w.ct) };
+  }
+
+  let shareStrings: string[] = [];
+  let sharesMeta: Envelope['shares'] = null;
+  if (opts.shares) {
+    const raw = split(dek, opts.shares.n, opts.shares.k);
+    shareStrings = raw.map(encodeShare);
+    sharesMeta = { n: opts.shares.n, k: opts.shares.k };
+  }
+
+  const envelope: Envelope = { app: APP, v: VERSION, content: encodeCt(contentCt), password, shares: sharesMeta };
+  return { file: JSON.stringify(envelope, null, 2), shares: shareStrings };
+}
+
+/** Parse + validate a vault file. Throws with a clear message on a bad/foreign file. */
+export function parseVault(file: string): Envelope {
+  let obj: Envelope;
+  try {
+    obj = JSON.parse(file);
+  } catch {
+    throw new Error('This is not a valid GoodWebTools legacy vault file.');
+  }
+  if (obj?.app !== APP) throw new Error('This is not a GoodWebTools legacy vault (.gwtvault) file.');
+  if (obj.v !== VERSION) throw new Error(`Unsupported vault version (${obj.v}).`);
+  if (!obj.content?.iv || !obj.content?.ct) throw new Error('This vault file is missing its contents.');
+  return obj;
+}
+
+/** What unlock methods a given vault supports. */
+export function vaultCapabilities(file: string): { password: boolean; shares: { n: number; k: number } | null } {
+  const env = parseVault(file);
+  return { password: !!env.password, shares: env.shares };
+}
+
+async function decryptContent(env: Envelope, dek: Uint8Array): Promise<LegacyContent> {
+  let plain: Uint8Array;
+  try {
+    plain = await decryptWithDek(decodeCt(env.content), dek);
+  } catch {
+    throw new Error('The letter could not be opened — the key was incorrect.');
+  }
+  return JSON.parse(new TextDecoder().decode(plain)) as LegacyContent;
+}
+
+/** Open a vault with the password. */
+export async function openWithPassword(file: string, password: string): Promise<LegacyContent> {
+  const env = parseVault(file);
+  if (!env.password) throw new Error('This vault is not protected by a password — use the family shares instead.');
+  const wrap: PasswordWrap = {
+    salt: unb64(env.password.salt), iters: env.password.iters,
+    iv: unb64(env.password.iv), ct: unb64(env.password.ct),
+  };
+  const dek = await unwrapDekWithPassword(wrap, password);
+  return decryptContent(env, dek);
+}
+
+/** Open a vault with a quorum of family shares. */
+export async function openWithShares(file: string, shareStrings: string[]): Promise<LegacyContent> {
+  const env = parseVault(file);
+  if (!env.shares) throw new Error('This vault does not use family shares — use the password instead.');
+  const decoded = shareStrings.map(decodeShare);
+  if (decoded.length < env.shares.k) {
+    throw new Error(`Need at least ${env.shares.k} shares to open this letter — you provided ${decoded.length}.`);
+  }
+  const dek = combine(decoded);
+  return decryptContent(env, dek);
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 
-export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Draw' | 'Media' | 'Network' | 'Maps' | 'Playground';
+export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Draw' | 'Media' | 'Network' | 'Maps' | 'Legacy' | 'Playground';
 
 export interface AssetRef {
   url: string;


### PR DESCRIPTION
New client-side tool + **Legacy** category. Write an encrypted letter — final words + account passwords — that family opens only when the time comes.

## Security (all in-browser)
- Content encrypted under a random 256-bit **DEK** with **AES-256-GCM**.
- DEK has **two independent recovery paths**: a **PBKDF2** (250k) password wrap, and a **Shamir Secret Sharing** split over GF(256) into N shares needing any K (e.g. 3 of 5). No single relative can open it alone; survives lost shares.
- The vault file never contains the shares; unrecoverable-by-design warning; tip to give one share to a lawyer/executor.

## Why not auto-release on death
A purely client-side tool can't detect death without a server holding your data — so handoff is human-arranged via the password/shares (the honest, zero-infrastructure trigger). Documented in the FAQ.

## Verify
- `npx vitest run` → 624 passed (20 new: shamir 8 + vault 12, real WebCrypto round-trips) · lint 0 errors · build 183 pages (EN+ID tool, EN+ID category hub, OG image).
- Bahasa content uses 'Surat Wasiat Digital' / 'tool' loanword (no 'alat').