### PR TITLE
feat(documents): PDF to Word (DOCX) with OCR fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "astro": "^4.16.19",
         "cmdk": "^0.2.1",
         "comlink": "^4.4.2",
+        "docx": "^9.7.1",
         "docx-preview": "^0.4.0",
         "dompurify": "^3.4.12",
         "epubjs": "^0.3.93",
@@ -10914,6 +10915,23 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/docx": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
+      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/docx-preview": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.4.0.tgz",
@@ -10922,6 +10940,39 @@
       "dependencies": {
         "jszip": ">=3.0.0"
       }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.6.3",
@@ -12844,6 +12895,16 @@
       "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
       "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
       "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.4",
@@ -16086,6 +16147,12 @@
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -21783,6 +21850,24 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "astro": "^4.16.19",
     "cmdk": "^0.2.1",
     "comlink": "^4.4.2",
+    "docx": "^9.7.1",
     "docx-preview": "^0.4.0",
     "dompurify": "^3.4.12",
     "epubjs": "^0.3.93",

--- a/src/islands/documents/PdfToDocx.tsx
+++ b/src/islands/documents/PdfToDocx.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { FileOutput } from 'lucide-react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Alert } from '@/components/ui/Alert';
+import { ProgressBar } from '@/components/ui/ProgressBar';
+import { downloadService } from '@/services/download.service';
+import { reconstruct, textDensity, type TextItem, type DocParagraph } from '@/tools/documents/pdf-docx.lib';
+import type { Lang } from '@/i18n/config';
+
+const OCR_MIN_CHARS = 8; // pages with fewer real characters are treated as scanned
+
+const TR: Record<Lang, {
+  intro: string; drop: string; dropSub: string; how: string; forceOcr: string; forceOcrHint: string;
+  reading: (p: number, n: number) => string; ocr: (p: number, n: number) => string; building: string;
+  another: string; note: string; errRead: string; errConvert: string;
+}> = {
+  en: {
+    intro: 'Convert a PDF to an editable Word document (.docx) in your browser. Text and headings are reconstructed into real paragraphs; scanned pages fall back to on-device OCR. Nothing is uploaded.',
+    drop: 'Drop a PDF', dropSub: 'Converted on your device — no upload.',
+    how: 'Best for text documents. Complex tables and multi-column layouts may need cleanup afterwards.',
+    forceOcr: 'Force OCR (scanned PDFs)', forceOcrHint: 'Run OCR on every page instead of only pages with no selectable text.',
+    reading: (p, n) => `Reading text — page ${p} of ${n}…`, ocr: (p, n) => `Reading (OCR) — page ${p} of ${n}…`, building: 'Building the Word document…',
+    another: 'Convert another',
+    note: 'The .docx contains editable, reflowable text (paragraphs and headings), not a pixel-perfect copy of the PDF layout. Exact positioning, tables and columns are not preserved.',
+    errRead: 'Could not open this file — is it a valid PDF?', errConvert: 'Sorry, converting this PDF failed.',
+  },
+  id: {
+    intro: 'Konversi PDF menjadi dokumen Word (.docx) yang dapat diedit di browser Anda. Teks dan judul disusun ulang menjadi paragraf nyata; halaman hasil pindaian memakai OCR di perangkat. Tidak ada yang diunggah.',
+    drop: 'Letakkan PDF', dropSub: 'Dikonversi di perangkat Anda — tanpa unggahan.',
+    how: 'Paling cocok untuk dokumen teks. Tabel rumit dan tata letak multi-kolom mungkin perlu dirapikan setelahnya.',
+    forceOcr: 'Paksa OCR (PDF hasil pindaian)', forceOcrHint: 'Jalankan OCR pada setiap halaman, bukan hanya halaman tanpa teks yang dapat dipilih.',
+    reading: (p, n) => `Membaca teks — halaman ${p} dari ${n}…`, ocr: (p, n) => `Membaca (OCR) — halaman ${p} dari ${n}…`, building: 'Menyusun dokumen Word…',
+    another: 'Konversi yang lain',
+    note: 'Berkas .docx berisi teks yang dapat diedit dan disusun ulang (paragraf dan judul), bukan salinan tata letak PDF yang sempurna. Posisi persis, tabel, dan kolom tidak dipertahankan.',
+    errRead: 'Tidak dapat membuka berkas ini — apakah PDF yang valid?', errConvert: 'Maaf, konversi PDF ini gagal.',
+  },
+};
+
+export default function PdfToDocx({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState('');
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState('');
+  const [forceOcr, setForceOcr] = useState(false);
+
+  const onDrop = async (files: File[]) => {
+    const f = files[0];
+    if (!f) return;
+    setError('');
+    setBusy(true);
+    setProgress(0);
+    const pdfjs = await import('pdfjs-dist');
+    const PdfjsWorker = (await import('pdfjs-dist/build/pdf.worker.min.mjs?worker')).default;
+    const worker = new PdfjsWorker();
+    pdfjs.GlobalWorkerOptions.workerPort = worker;
+    const loadingTask = pdfjs.getDocument({ data: await f.arrayBuffer() });
+    try {
+      const pdf = await loadingTask.promise;
+      const total = pdf.numPages;
+      const pages: DocParagraph[][] = [];
+
+      for (let p = 1; p <= total; p++) {
+        const page = await pdf.getPage(p);
+        const viewport = page.getViewport({ scale: 1 });
+        const tc = await page.getTextContent();
+        const items: TextItem[] = tc.items
+          .filter((i): i is Extract<typeof i, { str: string }> => 'str' in i)
+          .map((i) => {
+            const tr = pdfjs.Util.transform(viewport.transform, i.transform);
+            const height = Math.hypot(tr[2], tr[3]) || 10;
+            return { text: i.str, x: tr[4], y: tr[5], width: i.width, height };
+          });
+
+        if (forceOcr || textDensity(items) < OCR_MIN_CHARS) {
+          setStatus(t.ocr(p, total));
+          pages.push(await ocrPage(page));
+        } else {
+          setStatus(t.reading(p, total));
+          pages.push(reconstruct(items));
+        }
+        page.cleanup();
+        setProgress(Math.round((p / total) * 90));
+      }
+
+      setStatus(t.building);
+      const blob = await buildDocx(pages);
+      setProgress(100);
+      await downloadService.download(blob, f.name.replace(/\.pdf$/i, '') + '.docx');
+    } catch {
+      setError(t.errConvert);
+    } finally {
+      loadingTask.destroy();
+      worker.terminate();
+      setBusy(false);
+      setStatus('');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={forceOcr} onChange={(e) => setForceOcr(e.target.checked)} disabled={busy} className="h-4 w-4 accent-accent" />
+        {t.forceOcr}
+      </label>
+      <p className="-mt-2 text-xs text-muted-foreground">{t.forceOcrHint}</p>
+
+      {!busy && (
+        <div>
+          <Dropzone onDrop={onDrop} accept=".pdf,application/pdf" multiple={false}>
+            <div className="space-y-1">
+              <p className="flex items-center justify-center gap-2 text-lg font-bold"><FileOutput className="h-5 w-5" /> {t.drop}</p>
+              <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+            </div>
+          </Dropzone>
+          <p className="mt-2 text-xs text-muted-foreground">{t.how}</p>
+        </div>
+      )}
+
+      {busy && (
+        <div className="space-y-2">
+          <ProgressBar percent={progress} label={status} />
+        </div>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      <p className="text-xs text-muted-foreground">{t.note}</p>
+    </div>
+  );
+}
+
+// Render a page to a canvas and reconstruct paragraphs from on-device OCR.
+async function ocrPage(page: import('pdfjs-dist').PDFPageProxy): Promise<DocParagraph[]> {
+  const viewport = page.getViewport({ scale: 2 });
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.floor(viewport.width);
+  canvas.height = Math.floor(viewport.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return [];
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  await page.render({ canvasContext: ctx, viewport, canvas }).promise;
+  const { getEngine } = await import('@/tools/image/ocr.lib');
+  const engine = await getEngine();
+  const lines = await engine.recognize(canvas);
+  const items: TextItem[] = lines.map((l) => ({ text: l.text, x: l.box.x, y: l.box.y, width: l.box.width, height: l.box.height }));
+  return reconstruct(items);
+}
+
+async function buildDocx(pages: DocParagraph[][]): Promise<Blob> {
+  const { Document, Packer, Paragraph, HeadingLevel } = await import('docx');
+  const children: InstanceType<typeof Paragraph>[] = [];
+  pages.forEach((paras, pageIdx) => {
+    paras.forEach((par, i) => {
+      children.push(new Paragraph({
+        text: par.text,
+        heading: par.heading === 1 ? HeadingLevel.HEADING_1 : par.heading === 2 ? HeadingLevel.HEADING_2 : undefined,
+        pageBreakBefore: pageIdx > 0 && i === 0 ? true : undefined,
+      }));
+    });
+  });
+  if (children.length === 0) children.push(new Paragraph({ text: '' }));
+  const doc = new Document({ sections: [{ children }] });
+  return Packer.toBlob(doc);
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -7,6 +7,23 @@ import type { Lang } from '@/i18n/config';
  * a locale entry is missing. Feeds on-page copy + HowTo/FAQPage structured data.
  */
 const en: Record<string, ToolSeoContent> = {
+  'pdf-to-docx': {
+    title: 'Free PDF to Word Converter — PDF to DOCX Online',
+    description: 'Convert a PDF to an editable Word (.docx) document in your browser — with OCR for scanned pages. 100% private; nothing is uploaded.',
+    intro: 'This free PDF to Word converter turns a PDF into an editable .docx document right in your browser. It rebuilds the text into real paragraphs and headings, and scanned or image-only pages fall back to on-device OCR — all without uploading your file anywhere.',
+    howTo: [
+      'Drop a PDF (or click to browse) — it is processed entirely in your browser.',
+      'Pages with selectable text are extracted directly; scanned pages use on-device OCR automatically.',
+      'Tick “Force OCR” if your PDF is a scan the tool doesn’t detect as one.',
+      'The editable .docx downloads when it is ready.',
+    ],
+    faqs: [
+      { q: 'Is my PDF uploaded to a server?', a: 'No. The PDF is parsed, OCR’d and converted to Word entirely in your browser with JavaScript and WebAssembly. It never leaves your device.' },
+      { q: 'Will the Word file look exactly like the PDF?', a: 'No — it contains editable, reflowable text (paragraphs and headings), not a pixel-perfect copy. Because PDF stores positioned glyphs rather than paragraphs, exact layout, tables and multi-column pages are reconstructed heuristically and may need cleanup. This is a fundamental limit of PDF→Word, not specific to this tool.' },
+      { q: 'Does it work on scanned PDFs?', a: 'Yes. Pages with no selectable text are run through on-device OCR to recover the words, and you can force OCR on every page with the checkbox.' },
+      { q: 'Which languages does the OCR read?', a: 'The on-device OCR is tuned for Latin-script text (including English and Indonesian). Other scripts may be less accurate.' },
+    ],
+  },
   'sql-format': {
     title: 'Free SQL Formatter — Beautify SQL Queries Online',
     description: 'A free SQL formatter to beautify and pretty-print SQL queries in your browser — PostgreSQL, MySQL, SQLite, BigQuery and more. 100% private; nothing is uploaded.',
@@ -1427,6 +1444,23 @@ const en: Record<string, ToolSeoContent> = {
 };
 
 const id: Record<string, ToolSeoContent> = {
+  'pdf-to-docx': {
+    title: 'Konverter PDF ke Word Gratis — PDF ke DOCX Online',
+    description: 'Konversi PDF menjadi dokumen Word (.docx) yang dapat diedit di browser Anda — dengan OCR untuk halaman hasil pindaian. 100% privat; tidak ada yang diunggah.',
+    intro: 'Konverter PDF ke Word gratis ini mengubah PDF menjadi dokumen .docx yang dapat diedit langsung di browser Anda. Teks disusun ulang menjadi paragraf dan judul nyata, dan halaman hasil pindaian atau gambar memakai OCR di perangkat — semua tanpa mengunggah berkas Anda ke mana pun.',
+    howTo: [
+      'Letakkan PDF (atau klik untuk menelusuri) — diproses sepenuhnya di browser Anda.',
+      'Halaman dengan teks yang dapat dipilih diekstrak langsung; halaman pindaian memakai OCR di perangkat secara otomatis.',
+      'Centang “Paksa OCR” jika PDF Anda adalah pindaian yang tidak terdeteksi sebagai pindaian.',
+      'Berkas .docx yang dapat diedit akan terunduh saat siap.',
+    ],
+    faqs: [
+      { q: 'Apakah PDF saya diunggah ke server?', a: 'Tidak. PDF diurai, di-OCR, dan dikonversi ke Word sepenuhnya di browser Anda dengan JavaScript dan WebAssembly. Berkas tidak pernah meninggalkan perangkat.' },
+      { q: 'Apakah berkas Word akan tampak persis seperti PDF?', a: 'Tidak — berkas berisi teks yang dapat diedit dan disusun ulang (paragraf dan judul), bukan salinan yang sempurna. Karena PDF menyimpan glif berposisi, bukan paragraf, tata letak persis, tabel, dan halaman multi-kolom disusun ulang secara heuristik dan mungkin perlu dirapikan. Ini keterbatasan mendasar PDF→Word, bukan khusus tool ini.' },
+      { q: 'Apakah bekerja pada PDF hasil pindaian?', a: 'Ya. Halaman tanpa teks yang dapat dipilih dijalankan melalui OCR di perangkat untuk memulihkan kata-kata, dan Anda dapat memaksa OCR pada setiap halaman dengan kotak centang.' },
+      { q: 'Bahasa apa yang dibaca OCR?', a: 'OCR di perangkat disetel untuk teks beraksara Latin (termasuk Inggris dan Indonesia). Aksara lain mungkin kurang akurat.' },
+    ],
+  },
   'sql-format': {
     title: 'Pemformat SQL Gratis — Rapikan Kueri SQL Online',
     description: 'Pemformat SQL gratis untuk merapikan dan mempercantik kueri SQL di browser Anda — PostgreSQL, MySQL, SQLite, BigQuery, dan lainnya. 100% privat; tidak ada yang diunggah.',

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -232,6 +232,17 @@ export const tools: ToolDef[] = [
     icon: FileDown,
     summary: 'Convert Word .docx documents to PDF in your browser',
     load: () => import('@/islands/documents/DocxToPdf'),
+    status: 'beta'
+  },
+  {
+    id: 'pdf-to-docx',
+    name: 'PDF to Word (DOCX)',
+    category: 'Documents',
+    route: '/tools/pdf-to-docx',
+    keywords: ['pdf', 'docx', 'word', 'convert', 'converter', 'pdf to word', 'pdf to docx', 'editable', 'ocr', 'extract', 'scanned'],
+    icon: FileOutput,
+    summary: 'Convert a PDF to an editable Word document (with OCR for scans)',
+    load: () => import('@/islands/documents/PdfToDocx'),
     status: 'beta'
   },
   {

--- a/src/tools/documents/pdf-docx.lib.test.ts
+++ b/src/tools/documents/pdf-docx.lib.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { groupLines, paragraphsFromLines, reconstruct, textDensity, type TextItem } from './pdf-docx.lib';
+
+const item = (text: string, x: number, y: number, width: number, height = 10): TextItem => ({ text, x, y, width, height });
+
+describe('groupLines', () => {
+  it('clusters items on the same baseline into one line, ordered by x', () => {
+    const lines = groupLines([item('world', 60, 100, 40), item('Hello', 10, 100, 40), item('Bottom', 10, 130, 50)]);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].text).toBe('Hello world'); // gap → space, x-ordered
+    expect(lines[1].text).toBe('Bottom');
+  });
+
+  it('does not add a space when items already abut', () => {
+    // 'foo' ends at x=30, 'bar' starts at x=31 → no visible gap
+    const [line] = groupLines([item('foo', 10, 50, 20), item('bar', 31, 50, 20)]);
+    expect(line.text).toBe('foobar');
+  });
+
+  it('tolerates small baseline jitter within one line', () => {
+    const lines = groupLines([item('a', 10, 100, 8), item('b', 22, 102, 8)]);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('returns nothing for empty/blank items', () => {
+    expect(groupLines([])).toEqual([]);
+    expect(groupLines([item('   ', 0, 0, 10)])).toEqual([]);
+  });
+});
+
+describe('paragraphsFromLines', () => {
+  it('merges tightly-spaced lines into one paragraph and splits on a big gap', () => {
+    const paras = paragraphsFromLines([
+      { text: 'line one', x: 0, y: 100, height: 10 },
+      { text: 'line two', x: 0, y: 112, height: 10 }, // gap 12 ≈ line height → same para
+      { text: 'far away', x: 0, y: 200, height: 10 }, // big gap → new para
+    ]);
+    expect(paras).toHaveLength(2);
+    expect(paras[0].text).toBe('line one line two');
+    expect(paras[1].text).toBe('far away');
+  });
+
+  it('promotes a much larger line to a standalone heading', () => {
+    const paras = paragraphsFromLines([
+      { text: 'TITLE', x: 0, y: 40, height: 24 },     // ~2.4× body → heading 1
+      { text: 'body text here', x: 0, y: 70, height: 10 },
+      { text: 'more body', x: 0, y: 82, height: 10 },
+    ]);
+    expect(paras[0]).toEqual({ text: 'TITLE', heading: 1 });
+    expect(paras[1]).toEqual({ text: 'body text here more body', heading: 0 });
+  });
+});
+
+describe('reconstruct + textDensity', () => {
+  it('turns a positioned page into paragraphs end to end', () => {
+    const items = [
+      item('Report', 10, 20, 60, 20),
+      item('This', 10, 60, 25), item('is', 40, 60, 12), item('body.', 55, 60, 30),
+      item('More', 10, 72, 30),
+      item('text', 10, 84, 30),
+    ];
+    const paras = reconstruct(items);
+    expect(paras[0]).toEqual({ text: 'Report', heading: 1 }); // 2× body height → heading
+    expect(paras[1].text).toBe('This is body. More text');
+  });
+
+  it('textDensity counts non-whitespace characters (for the OCR-fallback decision)', () => {
+    expect(textDensity([item('a b', 0, 0, 10), item('  ', 0, 0, 10)])).toBe(2);
+    expect(textDensity([])).toBe(0);
+  });
+});

--- a/src/tools/documents/pdf-docx.lib.ts
+++ b/src/tools/documents/pdf-docx.lib.ts
@@ -1,0 +1,125 @@
+/**
+ * Reconstruct flow-document structure (lines → paragraphs → headings) from the
+ * positioned text a PDF gives us. PDF has no paragraphs or reading order — just
+ * glyphs at coordinates — so this heuristic layer is what makes a PDF→DOCX
+ * conversion produce editable, reflowable text. Pure and unit-tested; the pdf.js
+ * extraction, OCR fallback and .docx generation live in the island.
+ *
+ * Coordinate convention: top-down (origin top-left, y increases downward), so
+ * sorting by y ascending yields natural reading order. Both the pdf.js and OCR
+ * paths normalise into this before calling here.
+ */
+
+export interface TextItem {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DocLine {
+  text: string;
+  x: number;
+  y: number;
+  height: number;
+}
+
+/** heading: 0 = body text, 1 = large heading, 2 = smaller heading. */
+export interface DocParagraph {
+  text: string;
+  heading: 0 | 1 | 2;
+}
+
+function median(nums: number[]): number {
+  if (!nums.length) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/** Join x-sorted items into a line, inserting a space across visible gaps. */
+function joinItems(items: TextItem[]): string {
+  let out = '';
+  let prevEnd: number | null = null;
+  for (const it of items) {
+    if (prevEnd !== null) {
+      const gap = it.x - prevEnd;
+      if (gap > it.height * 0.25 && !/\s$/.test(out) && !/^\s/.test(it.text)) out += ' ';
+    }
+    out += it.text;
+    prevEnd = it.x + it.width;
+  }
+  return out;
+}
+
+/** Cluster text items sharing a baseline into lines, ordered top→bottom. */
+export function groupLines(items: TextItem[], yTolRatio = 0.5): DocLine[] {
+  const valid = items.filter((it) => it.text.length > 0);
+  if (!valid.length) return [];
+  const medH = median(valid.map((i) => i.height).filter((h) => h > 0)) || 1;
+  const tol = medH * yTolRatio;
+
+  const sorted = [...valid].sort((a, b) => a.y - b.y || a.x - b.x);
+  const groups: TextItem[][] = [];
+  for (const it of sorted) {
+    const last = groups[groups.length - 1];
+    const lastY = last ? last.reduce((s, g) => s + g.y, 0) / last.length : 0;
+    if (last && Math.abs(it.y - lastY) <= tol) last.push(it);
+    else groups.push([it]);
+  }
+
+  return groups
+    .map((group) => {
+      const g = [...group].sort((a, b) => a.x - b.x);
+      return {
+        text: joinItems(g).trim(),
+        x: Math.min(...g.map((i) => i.x)),
+        y: g.reduce((s, i) => s + i.y, 0) / g.length,
+        height: Math.max(...g.map((i) => i.height)),
+      };
+    })
+    .filter((l) => l.text.length > 0);
+}
+
+/** Merge lines into paragraphs, promoting noticeably larger lines to headings. */
+export function paragraphsFromLines(lines: DocLine[]): DocParagraph[] {
+  if (!lines.length) return [];
+  const sorted = [...lines].sort((a, b) => a.y - b.y);
+  const medH = median(sorted.map((l) => l.height)) || 1;
+
+  const paras: DocParagraph[] = [];
+  let cur: { texts: string[]; heading: 0 | 1 | 2 } | null = null;
+  let prevY: number | null = null;
+
+  const flush = () => {
+    if (cur) paras.push({ text: cur.texts.join(' ').replace(/\s+/g, ' ').trim(), heading: cur.heading });
+    cur = null;
+  };
+
+  for (const line of sorted) {
+    const heading: 0 | 1 | 2 = line.height > medH * 1.9 ? 1 : line.height > medH * 1.35 ? 2 : 0;
+    const gap = prevY === null ? 0 : line.y - prevY;
+    // A heading is always its own paragraph; body lines join until a large gap.
+    const newPara = cur === null || heading !== 0 || cur.heading !== 0 || gap > medH * 1.7;
+    if (newPara) {
+      flush();
+      cur = { texts: [line.text], heading };
+    } else if (cur) {
+      cur.texts.push(line.text);
+    }
+    prevY = line.y;
+  }
+  flush();
+  return paras.filter((p) => p.text.length > 0);
+}
+
+/** Positioned text items → structured paragraphs (the full reconstruction). */
+export function reconstruct(items: TextItem[]): DocParagraph[] {
+  return paragraphsFromLines(groupLines(items));
+}
+
+/** Count of non-whitespace characters — used to decide if a page needs OCR. */
+export function textDensity(items: TextItem[]): number {
+  return items.reduce((n, it) => n + it.text.replace(/\s/g, '').length, 0);
+}


### PR DESCRIPTION
## What
New **PDF to Word (DOCX)** converter — turns a PDF into an **editable** `.docx` entirely client-side, with on-device **OCR** for scanned pages. Nothing is uploaded.

## How
- **pdf.js** extracts positioned text per page → a pure **reconstruction lib** rebuilds real **paragraphs and headings** (line grouping by baseline, paragraph splitting by vertical gap, heading detection by font size).
- Pages with little/no selectable text auto-fall back to **on-device OCR** (PaddleOCR, reused from the OCR tool). A **Force OCR** toggle runs OCR on every page (scanned docs).
- The **`docx`** library (MIT) generates the Word file in-browser; per-page progress; page breaks between pages.

## Honest limits (surfaced in the UI)
PDF stores positioned glyphs, not paragraphs — so the output is **editable, reflowable text**, not a pixel-perfect copy. Exact layout, tables and multi-column pages are reconstructed heuristically and may need cleanup. Faithful table/column reconstruction needs a server-side/ML engine, which would break the client-side promise.

## Details
- `src/tools/documents/pdf-docx.lib.ts` — pure `groupLines`/`paragraphsFromLines`/`reconstruct`/`textDensity`; 8 unit tests
- `src/islands/documents/PdfToDocx.tsx` — pdf.js extraction + OCR fallback + docx generation; full worker/page cleanup
- New dep: `docx` 9.7.1 (MIT, audit-clean). Registered `pdf-to-docx` (beta); EN + ID SEO + OG
- 712 tests pass · 0 lint errors · `tsc --noEmit` clean for touched files · build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)