### PR TITLE
fix(maps): blank map after detect-my-location / flyTo

### DIFF
--- a/src/islands/maps/MapExplorer.tsx
+++ b/src/islands/maps/MapExplorer.tsx
@@ -125,6 +125,10 @@ export default function MapExplorer({ lang = 'en' }: { lang?: Lang }) {
       map.on('click', e => handleClick(e.lngLat.lat, e.lngLat.lng));
       map.on('style.load', () => { ensureMeasureLayer(); refreshMeasureLine(); });
       map.on('load', () => map.resize());
+      // After any pan/zoom animation (flyTo, GeolocateControl, etc.) revalidate the
+      // canvas size — without this, MapLibre reports stale dimensions and tiles don't
+      // fill the viewport, leaving the map blank.
+      map.on('moveend', () => map.resize());
       // The container is mounted via a dynamically-imported island, so it can be
       // laid out after the map is created — resize once it (or its size) settles,
       // otherwise the map renders blank at 0×0.


### PR DESCRIPTION
## Summary
- After any pan/zoom animation (GeolocateControl click, custom Locate button, search flyTo), MapLibre reported stale canvas dimensions and rendered tiles only for the old viewport — leaving the rest blank.
- Fix: `map.on('moveend', () => map.resize())` revalidates on every animation end.

## Test plan
- [ ] Click the Locate Fixed button → map flies to your location → tiles fill the full viewport
- [ ] Click the built-in GeolocateControl (map top-right) → same result, no blank
- [ ] Search a place → flyTo → full tiles visible
- [ ] Measure tool, style switcher — no regression