### PR TITLE
fix(maps): stack overflow from map.resize() inside moveend handler

### DIFF
--- a/src/islands/maps/MapExplorer.tsx
+++ b/src/islands/maps/MapExplorer.tsx
@@ -128,7 +128,15 @@ export default function MapExplorer({ lang = 'en' }: { lang?: Lang }) {
       // After any pan/zoom animation (flyTo, GeolocateControl, etc.) revalidate the
       // canvas size — without this, MapLibre reports stale dimensions and tiles don't
       // fill the viewport, leaving the map blank.
-      map.on('moveend', () => map.resize());
+      // Guard + rAF: calling map.resize() synchronously inside moveend causes MapLibre
+      // to fire moveend again from within constrainInternal → stack overflow. Deferring
+      // to the next animation frame breaks the synchronous recursion.
+      let resizePending = false;
+      map.on('moveend', () => {
+        if (resizePending) return;
+        resizePending = true;
+        requestAnimationFrame(() => { resizePending = false; map.resize(); });
+      });
       // The container is mounted via a dynamically-imported island, so it can be
       // laid out after the map is created — resize once it (or its size) settles,
       // otherwise the map renders blank at 0×0.


### PR DESCRIPTION
## Root cause
Previous fix (PR #158) called `map.resize()` synchronously inside `moveend`. MapLibre calls `constrainInternal` during resize, which re-fires `moveend` within the same call stack → `RangeError: Maximum call stack size exceeded`.

## Fix
Guard flag + `requestAnimationFrame`: resize deferred to the next frame, breaking the synchronous recursion. Flag prevents queuing more than one resize at a time.

## Test plan
- [ ] Open Map Explorer — no stack overflow in console
- [ ] Click Locate button → map flies to location → tiles fill viewport (blank-map fix still works)
- [ ] Click GeolocateControl → same result
- [ ] Search a place → flyTo → full tiles, no error