### PR TITLE
feat(api-client): REST API client with Postman/Insomnia/Swagger import

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -674,6 +674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1131,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1782,8 +1788,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1805,9 +1813,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1964,6 +1974,7 @@ dependencies = [
  "image",
  "lazy_static",
  "objc",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -2168,6 +2179,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2826,6 +2838,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "malloc_buf"
@@ -3936,6 +3954,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4075,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rav1e"
@@ -4164,6 +4247,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4318,6 +4439,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4364,6 +4486,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4591,6 +4719,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5052,7 +5192,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5260,7 +5400,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -6169,6 +6309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,6 +6379,15 @@ name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 chrono = "0.4"
 lazy_static = "1.5"
 image = "0.25"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1029,3 +1029,64 @@ mod tests {
         assert_eq!(out.get_pixel(3, 3), &image::Rgba([5, 5, 0, 255]));
     }
 }
+
+// ---- HTTP request proxy (used by the API Client tool) ----
+
+#[derive(serde::Serialize)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub headers: std::collections::HashMap<String, String>,
+    pub body: String,
+    pub duration_ms: u64,
+}
+
+#[tauri::command]
+pub async fn http_request(
+    method: String,
+    url: String,
+    headers: std::collections::HashMap<String, String>,
+    body: Option<String>,
+) -> Result<HttpResponse, String> {
+    let start = std::time::Instant::now();
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(false)
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let method_parsed = reqwest::Method::from_bytes(method.to_uppercase().as_bytes())
+        .map_err(|e| e.to_string())?;
+
+    let mut builder = client.request(method_parsed, &url);
+    for (k, v) in &headers {
+        if let (Ok(name), Ok(val)) = (
+            reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+            reqwest::header::HeaderValue::from_str(v),
+        ) {
+            builder = builder.header(name, val);
+        }
+    }
+    if let Some(b) = body {
+        builder = builder.body(b);
+    }
+
+    let res = builder.send().await.map_err(|e| e.to_string())?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+    let status = res.status().as_u16();
+    let status_text = res.status().canonical_reason().unwrap_or("").to_string();
+    let mut resp_headers = std::collections::HashMap::new();
+    for (k, v) in res.headers() {
+        if let Ok(val) = v.to_str() {
+            resp_headers.insert(k.as_str().to_string(), val.to_string());
+        }
+    }
+    let body_str = res.text().await.map_err(|e| e.to_string())?;
+    Ok(HttpResponse {
+        status,
+        status_text,
+        headers: resp_headers,
+        body: body_str,
+        duration_ms,
+    })
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
             commands::check_permissions,
             commands::mark_first_run_complete,
             commands::open_system_preferences,
+            commands::http_request,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/islands/dev/ApiClient.tsx
+++ b/src/islands/dev/ApiClient.tsx
@@ -9,7 +9,7 @@ import { exportPostman, exportWorkspace } from '@/tools/dev/api-client-export.li
 import { downloadService } from '@/services/download';
 import { Button } from '@/components/ui/Button';
 import { Alert } from '@/components/ui/Alert';
-import type { Workspace, RequestDef, Collection, Folder as FolderType, Environment, ResponseSnapshot, HistoryEntry } from '@/tools/dev/api-client.types';
+import type { Workspace, RequestDef, Collection, Folder as FolderType, Environment, HistoryEntry } from '@/tools/dev/api-client.types';
 import { SAVE_INTERVAL } from '@/tools/dev/api-client.types';
 
 // ---- helpers ----
@@ -107,8 +107,7 @@ export default function ApiClient() {
       window.removeEventListener('pagehide', flushSave);
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const activeEnv = workspace.envs.find(e => e.id === workspace.activeEnvId) ?? null;
   const envVars = activeEnv?.vars ?? {};
@@ -285,7 +284,7 @@ function ApiSidebar({
 
   const toggleCol = (id: string) => setOpenCols(prev => {
     const s = new Set(prev);
-    s.has(id) ? s.delete(id) : s.add(id);
+    if (s.has(id)) s.delete(id); else s.add(id);
     return s;
   });
 
@@ -425,7 +424,7 @@ function RequestTree({ requests, folders, onSelect, depth }: {
       ))}
       {folders.map(f => (
         <div key={f.id}>
-          <button onClick={() => setOpenFolders(prev => { const s = new Set(prev); s.has(f.id) ? s.delete(f.id) : s.add(f.id); return s; })}
+          <button onClick={() => setOpenFolders(prev => { const s = new Set(prev); if (s.has(f.id)) s.delete(f.id); else s.add(f.id); return s; })}
             className={`flex w-full items-center gap-1 ${pl} pr-2 py-0.5 text-left text-xs font-bold text-muted-foreground hover:bg-muted`}>
             {openFolders.has(f.id) ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
             <Folder className="h-3 w-3 shrink-0" />{f.name}

--- a/src/islands/dev/ApiClient.tsx
+++ b/src/islands/dev/ApiClient.tsx
@@ -1,0 +1,691 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Upload, Download, Plus, Folder, History, Key, Trash2, ChevronDown, ChevronRight, Send, RefreshCw, X } from 'lucide-react';
+import { isTauri } from '@/services/platform';
+import { loadWorkspace, saveWorkspace, defaultRequestDef, pushResponseToRequest, addToHistory } from '@/tools/dev/api-client-store.lib';
+import { substituteRequest, applyCapture } from '@/tools/dev/api-client-env.lib';
+import { executeRequest } from '@/tools/dev/api-client-request.lib';
+import { detectAndParse } from '@/tools/dev/api-client-import.lib';
+import { exportPostman, exportWorkspace } from '@/tools/dev/api-client-export.lib';
+import { downloadService } from '@/services/download';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import type { Workspace, RequestDef, Collection, Folder as FolderType, Environment, ResponseSnapshot, HistoryEntry } from '@/tools/dev/api-client.types';
+import { SAVE_INTERVAL } from '@/tools/dev/api-client.types';
+
+// ---- helpers ----
+
+function findRequest(col: { requests: RequestDef[]; folders: FolderType[] }, id: string): RequestDef | null {
+  for (const r of col.requests) { if (r.id === id) return r; }
+  for (const f of col.folders) {
+    const found = findRequest(f, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function allRequestsInCol(col: { requests: RequestDef[]; folders: FolderType[] }): RequestDef[] {
+  return [...col.requests, ...col.folders.flatMap(f => allRequestsInCol(f))];
+}
+
+function allRequests(w: Workspace): RequestDef[] {
+  return w.collections.flatMap(c => allRequestsInCol(c));
+}
+
+function updateReqInCol(col: Collection, updated: RequestDef): Collection {
+  return {
+    ...col,
+    requests: col.requests.map(r => r.id === updated.id ? updated : r),
+    folders: col.folders.map(f => ({
+      ...f,
+      requests: f.requests.map(r => r.id === updated.id ? updated : r),
+      folders: f.folders.map(sf => ({ ...sf, requests: sf.requests.map(r => r.id === updated.id ? updated : r) })),
+    })),
+  };
+}
+
+function updateRequestInWorkspace(w: Workspace, updated: RequestDef): Workspace {
+  return { ...w, collections: w.collections.map(c => updateReqInCol(c, updated)) };
+}
+
+function addRequestToCollection(w: Workspace, colId: string, req: RequestDef): Workspace {
+  return {
+    ...w,
+    collections: w.collections.map(c => c.id === colId ? { ...c, requests: [...c.requests, req] } : c),
+    activeRequestId: req.id,
+  };
+}
+
+// ---- Main island ----
+
+export default function ApiClient() {
+  const [workspace, setWorkspace] = useState<Workspace>(() => {
+    if (typeof window === 'undefined') {
+      return { collections: [], envs: [], activeEnvId: null, activeCollectionId: null, activeRequestId: null, lastResponse: null, history: [] };
+    }
+    return loadWorkspace();
+  });
+
+  const [countdown, setCountdown] = useState(0);
+  const dirty = useRef(false);
+  const latestWorkspace = useRef<Workspace>(workspace);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const isDesktop = typeof window !== 'undefined' && isTauri();
+
+  const mutate = (updater: (w: Workspace) => Workspace) => {
+    setWorkspace(prev => {
+      const next = updater(prev);
+      latestWorkspace.current = next;
+      if (!dirty.current) { dirty.current = true; setCountdown(SAVE_INTERVAL); }
+      return next;
+    });
+  };
+
+  const flushSave = () => {
+    if (!dirty.current) return;
+    dirty.current = false;
+    setCountdown(0);
+    saveWorkspace(latestWorkspace.current);
+  };
+
+  useEffect(() => {
+    const tick = setInterval(() => {
+      if (!dirty.current) return;
+      setCountdown(c => {
+        if (c <= 1) { flushSave(); return 0; }
+        return c - 1;
+      });
+    }, 1000);
+    const onHide = () => { if (document.visibilityState === 'hidden') flushSave(); };
+    const onBeforeUnload = (e: BeforeUnloadEvent) => { if (dirty.current) { e.preventDefault(); e.returnValue = ''; } };
+    document.addEventListener('visibilitychange', onHide);
+    window.addEventListener('pagehide', flushSave);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      clearInterval(tick);
+      document.removeEventListener('visibilitychange', onHide);
+      window.removeEventListener('pagehide', flushSave);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const activeEnv = workspace.envs.find(e => e.id === workspace.activeEnvId) ?? null;
+  const envVars = activeEnv?.vars ?? {};
+
+  const activeRequest: RequestDef | null = (() => {
+    if (!workspace.activeRequestId) return null;
+    for (const col of workspace.collections) {
+      const found = findRequest(col, workspace.activeRequestId);
+      if (found) return found;
+    }
+    return null;
+  })();
+
+  const handleImport = async (file: File) => {
+    try {
+      const text = await file.text();
+      const col = detectAndParse(text, file.name);
+      mutate(w => ({ ...w, collections: [...w.collections, col], activeCollectionId: col.id }));
+    } catch (err) {
+      setSendError(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!activeRequest) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      const allReqs = allRequests(workspace);
+      const substituted = substituteRequest(activeRequest, allReqs, envVars);
+      const res = await executeRequest(substituted);
+      mutate(w => {
+        const updatedReq = pushResponseToRequest(activeRequest, res);
+        let updatedW = updateRequestInWorkspace(w, updatedReq);
+        if (activeRequest.capture && activeEnv) {
+          const newVars = applyCapture(activeRequest.capture, res.body, envVars);
+          updatedW = { ...updatedW, envs: updatedW.envs.map(e => e.id === activeEnv.id ? { ...e, vars: newVars } : e) };
+        }
+        const entry: HistoryEntry = { id: crypto.randomUUID(), ts: Date.now(), req: substituted, res };
+        return addToHistory({ ...updatedW, lastResponse: res }, entry);
+      });
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const statusChip = countdown > 0
+    ? (
+      <button onClick={flushSave} className="flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-amber-600 underline underline-offset-2 hover:text-amber-700">
+        <span className="inline-block h-2 w-2 rounded-full bg-amber-500" />
+        Unsaved · save now ({countdown}s)
+      </button>
+    ) : (
+      <span className="flex items-center gap-1 text-xs font-bold uppercase tracking-wide text-muted-foreground">
+        <Check className="h-3.5 w-3.5" /> Saved
+      </span>
+    );
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <ImportButton onImport={handleImport} />
+        <Button variant="secondary" onClick={() => {
+          const blob = new Blob([exportWorkspace(workspace)], { type: 'application/json' });
+          downloadService.download(blob, 'api-client-workspace.json');
+        }}>
+          <Download className="h-4 w-4" /> Export workspace
+        </Button>
+        <div className="ml-auto flex items-center gap-3">
+          {!isDesktop && (
+            <span className="rounded border border-amber-400 bg-amber-50 px-2 py-0.5 text-xs text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+              Browser mode — CORS restrictions apply. Desktop app bypasses CORS.
+            </span>
+          )}
+          {statusChip}
+        </div>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex h-[78vh] min-h-0 border-2 border-border">
+        <ApiSidebar
+          workspace={workspace}
+          onSelectRequest={id => mutate(w => ({ ...w, activeRequestId: id }))}
+          onNewRequest={() => {
+            const req = defaultRequestDef();
+            mutate(w => {
+              if (!w.activeCollectionId) {
+                // Create a default collection if none exists
+                const col = { id: crypto.randomUUID(), name: 'My Collection', folders: [], requests: [req] };
+                return { ...w, collections: [...w.collections, col], activeCollectionId: col.id, activeRequestId: req.id };
+              }
+              return addRequestToCollection(w, w.activeCollectionId, req);
+            });
+          }}
+          onSelectCollection={id => mutate(w => ({ ...w, activeCollectionId: id }))}
+          onSelectEnv={id => mutate(w => ({ ...w, activeEnvId: id || null }))}
+          onDeleteCollection={id => mutate(w => ({
+            ...w,
+            collections: w.collections.filter(c => c.id !== id),
+            activeCollectionId: w.activeCollectionId === id ? null : w.activeCollectionId,
+          }))}
+          onExportCollection={(col) => {
+            const blob = new Blob([exportPostman(col, workspace.envs)], { type: 'application/json' });
+            downloadService.download(blob, `${col.name.replace(/\s+/g, '-')}-postman.json`);
+          }}
+          onAddEnv={() => {
+            const env: Environment = { id: crypto.randomUUID(), name: 'New Environment', vars: {} };
+            mutate(w => ({ ...w, envs: [...w.envs, env], activeEnvId: env.id }));
+          }}
+          onUpdateEnvVars={(id, vars) => mutate(w => ({ ...w, envs: w.envs.map(e => e.id === id ? { ...e, vars } : e) }))}
+        />
+
+        {/* Right pane */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {activeRequest ? (
+            <ApiRequestPane
+              request={activeRequest}
+              sending={sending}
+              onSend={handleSend}
+              onUpdate={req => mutate(w => updateRequestInWorkspace(w, req))}
+              sendError={sendError}
+              allReqs={allRequests(workspace)}
+              envVars={envVars}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+              Import a collection or click "+ New request" to get started.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- ImportButton ----
+
+function ImportButton({ onImport }: { onImport: (f: File) => void }) {
+  const ref = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input ref={ref} type="file" accept=".json,.yaml,.yml,.har" className="hidden"
+        onChange={e => { const f = e.target.files?.[0]; if (f) { onImport(f); e.target.value = ''; } }} />
+      <Button variant="secondary" onClick={() => ref.current?.click()}>
+        <Upload className="h-4 w-4" /> Import
+      </Button>
+    </>
+  );
+}
+
+// ---- ApiSidebar ----
+
+function ApiSidebar({
+  workspace, onSelectRequest, onNewRequest, onSelectCollection,
+  onSelectEnv, onDeleteCollection, onExportCollection, onAddEnv, onUpdateEnvVars,
+}: {
+  workspace: Workspace;
+  onSelectRequest: (id: string) => void;
+  onNewRequest: () => void;
+  onSelectCollection: (id: string) => void;
+  onSelectEnv: (id: string) => void;
+  onDeleteCollection: (id: string) => void;
+  onExportCollection: (col: Collection) => void;
+  onAddEnv: () => void;
+  onUpdateEnvVars: (id: string, vars: Record<string, string>) => void;
+}) {
+  const [tab, setTab] = useState<'collections' | 'history'>('collections');
+  const [openCols, setOpenCols] = useState<Set<string>>(new Set());
+  const [editingEnvId, setEditingEnvId] = useState<string | null>(null);
+  const [envDraft, setEnvDraft] = useState('');
+
+  const toggleCol = (id: string) => setOpenCols(prev => {
+    const s = new Set(prev);
+    s.has(id) ? s.delete(id) : s.add(id);
+    return s;
+  });
+
+  const activeEnv = workspace.envs.find(e => e.id === workspace.activeEnvId);
+
+  const startEditEnv = () => {
+    if (!activeEnv) return;
+    setEnvDraft(Object.entries(activeEnv.vars).map(([k, v]) => `${k}=${v}`).join('\n'));
+    setEditingEnvId(activeEnv.id);
+  };
+
+  const saveEnvDraft = () => {
+    if (!editingEnvId) return;
+    const vars: Record<string, string> = {};
+    envDraft.split('\n').forEach(line => {
+      const eq = line.indexOf('=');
+      if (eq > 0) vars[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    });
+    onUpdateEnvVars(editingEnvId, vars);
+    setEditingEnvId(null);
+  };
+
+  return (
+    <div className="flex w-60 shrink-0 flex-col border-r-2 border-border text-sm">
+      {/* Tabs */}
+      <div className="flex border-b-2 border-border">
+        {(['collections', 'history'] as const).map(t => (
+          <button key={t} onClick={() => setTab(t)}
+            className={`flex flex-1 items-center justify-center gap-1 py-1.5 text-xs font-bold uppercase tracking-wide ${tab === t ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-muted'}`}>
+            {t === 'collections' ? <><Folder className="h-3 w-3" /> Cols</> : <><History className="h-3 w-3" /> History</>}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'collections' && (
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <div className="flex items-center border-b border-border px-2 py-1">
+            <button onClick={onNewRequest} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+              <Plus className="h-3.5 w-3.5" /> New request
+            </button>
+          </div>
+          {workspace.collections.length === 0 && (
+            <p className="p-3 text-xs text-muted-foreground">Import a collection to get started.</p>
+          )}
+          {workspace.collections.map(col => (
+            <div key={col.id}>
+              <div className="flex cursor-pointer items-center gap-1 px-2 py-1 font-bold hover:bg-muted"
+                onClick={() => { toggleCol(col.id); onSelectCollection(col.id); }}>
+                {openCols.has(col.id) ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />}
+                <span className="min-w-0 flex-1 truncate text-xs">{col.name}</span>
+                <button title="Export as Postman" onClick={e => { e.stopPropagation(); onExportCollection(col); }}
+                  className="text-muted-foreground hover:text-foreground"><Download className="h-3 w-3" /></button>
+                <button title="Delete" onClick={e => { e.stopPropagation(); onDeleteCollection(col.id); }}
+                  className="text-muted-foreground hover:text-destructive"><Trash2 className="h-3 w-3" /></button>
+              </div>
+              {openCols.has(col.id) && (
+                <RequestTree requests={col.requests} folders={col.folders} onSelect={onSelectRequest} depth={1} />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tab === 'history' && (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {workspace.history.length === 0
+            ? <p className="p-3 text-xs text-muted-foreground">No requests sent yet.</p>
+            : workspace.history.map(entry => (
+              <button key={entry.id} onClick={() => onSelectRequest(entry.req.id)}
+                className="flex w-full flex-col gap-0.5 border-b border-border px-2 py-1 text-left hover:bg-muted">
+                <span className="flex items-center gap-1 text-xs">
+                  <span className="font-bold">{entry.req.method}</span>
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">{entry.req.url}</span>
+                </span>
+                <span className={`text-xs font-bold ${entry.res.status < 400 ? 'text-green-600' : 'text-red-600'}`}>
+                  {entry.res.status} · {entry.res.durationMs}ms
+                </span>
+              </button>
+            ))}
+        </div>
+      )}
+
+      {/* Environment panel */}
+      <div className="border-t-2 border-border p-2">
+        <div className="mb-1 flex items-center gap-1 text-xs font-bold uppercase tracking-wide text-muted-foreground">
+          <Key className="h-3.5 w-3.5" /> Env
+        </div>
+        <div className="flex gap-1">
+          <select value={workspace.activeEnvId ?? ''} onChange={e => onSelectEnv(e.target.value)}
+            className="flex-1 border border-border bg-muted px-1.5 py-1 text-xs">
+            <option value="">None</option>
+            {workspace.envs.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
+          </select>
+          <button onClick={onAddEnv} title="Add environment" className="text-muted-foreground hover:text-foreground">
+            <Plus className="h-4 w-4" />
+          </button>
+          {activeEnv && (
+            <button onClick={startEditEnv} title="Edit variables" className="text-xs text-muted-foreground hover:text-foreground underline">
+              Edit
+            </button>
+          )}
+        </div>
+        {editingEnvId && activeEnv && (
+          <div className="mt-1 flex flex-col gap-1">
+            <p className="text-xs text-muted-foreground">One KEY=value per line</p>
+            <textarea value={envDraft} onChange={e => setEnvDraft(e.target.value)}
+              className="h-24 w-full resize-none border border-border bg-muted p-1 font-mono text-xs outline-none" />
+            <div className="flex gap-1">
+              <Button variant="primary" onClick={saveEnvDraft} className="text-xs py-0.5 px-2">Save</Button>
+              <Button variant="secondary" onClick={() => setEditingEnvId(null)} className="text-xs py-0.5 px-2">Cancel</Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- RequestTree (recursive) ----
+
+function RequestTree({ requests, folders, onSelect, depth }: {
+  requests: RequestDef[];
+  folders: FolderType[];
+  onSelect: (id: string) => void;
+  depth: number;
+}) {
+  const [openFolders, setOpenFolders] = useState<Set<string>>(new Set());
+  const pl = `pl-${Math.min(depth * 3, 12)}`;
+  return (
+    <div>
+      {requests.map(r => (
+        <button key={r.id} onClick={() => onSelect(r.id)}
+          className={`flex w-full items-center gap-1.5 ${pl} pr-2 py-0.5 text-left hover:bg-muted`}>
+          <span className={`w-10 shrink-0 text-xs font-bold ${methodColor(r.method)}`}>{r.method}</span>
+          <span className="min-w-0 flex-1 truncate text-xs">{r.name}</span>
+        </button>
+      ))}
+      {folders.map(f => (
+        <div key={f.id}>
+          <button onClick={() => setOpenFolders(prev => { const s = new Set(prev); s.has(f.id) ? s.delete(f.id) : s.add(f.id); return s; })}
+            className={`flex w-full items-center gap-1 ${pl} pr-2 py-0.5 text-left text-xs font-bold text-muted-foreground hover:bg-muted`}>
+            {openFolders.has(f.id) ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
+            <Folder className="h-3 w-3 shrink-0" />{f.name}
+          </button>
+          {openFolders.has(f.id) && (
+            <RequestTree requests={f.requests} folders={f.folders} onSelect={onSelect} depth={depth + 1} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---- ApiRequestPane ----
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const;
+
+function methodColor(m: string): string {
+  const map: Record<string, string> = { GET: 'text-green-600', POST: 'text-blue-600', PUT: 'text-amber-600', PATCH: 'text-purple-600', DELETE: 'text-red-600' };
+  return map[m] ?? 'text-muted-foreground';
+}
+
+function ApiRequestPane({ request, sending, onSend, onUpdate, sendError, allReqs, envVars }: {
+  request: RequestDef;
+  sending: boolean;
+  onSend: () => void;
+  onUpdate: (r: RequestDef) => void;
+  sendError: string | null;
+  allReqs: RequestDef[];
+  envVars: Record<string, string>;
+}) {
+  const [reqTab, setReqTab] = useState<'params' | 'headers' | 'body' | 'auth'>('body');
+  const [resTab, setResTab] = useState<'body' | 'headers' | 'history'>('body');
+  const [splitPct, setSplitPct] = useState(45);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  const onMouseDown = () => { dragging.current = true; };
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!dragging.current || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const pct = Math.max(20, Math.min(80, ((e.clientY - rect.top) / rect.height) * 100));
+    setSplitPct(pct);
+  };
+  const onMouseUp = () => { dragging.current = false; };
+
+  const response = request.responseHistory[0] ?? null;
+  const prettyBody = (s: string) => { try { return JSON.stringify(JSON.parse(s), null, 2); } catch { return s; } };
+  const statusColor = (s: number) => s < 300 ? 'text-green-600' : s < 400 ? 'text-amber-600' : 'text-red-600';
+
+  return (
+    <div ref={containerRef} className="flex flex-1 flex-col" style={{ userSelect: dragging.current ? 'none' : undefined }}
+      onMouseMove={onMouseMove} onMouseUp={onMouseUp} onMouseLeave={onMouseUp}>
+
+      {/* URL bar */}
+      <div className="flex items-center gap-2 border-b-2 border-border p-2">
+        <select value={request.method} onChange={e => onUpdate({ ...request, method: e.target.value as RequestDef['method'] })}
+          className={`border border-border bg-muted px-2 py-1.5 text-sm font-bold ${methodColor(request.method)}`}>
+          {HTTP_METHODS.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+        <input value={request.url}
+          onChange={e => onUpdate({ ...request, url: e.target.value })}
+          onKeyDown={e => { if (e.key === 'Enter' && request.url) onSend(); }}
+          placeholder="https://api.example.com/endpoint"
+          className="flex-1 border border-border bg-muted px-2 py-1.5 font-mono text-sm outline-none focus:shadow-brutal-sm" />
+        <Button onClick={onSend} disabled={sending || !request.url}>
+          {sending ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          {sending ? 'Sending…' : 'Send'}
+        </Button>
+      </div>
+
+      {/* Request name */}
+      <div className="border-b border-border px-3 py-1">
+        <input value={request.name} onChange={e => onUpdate({ ...request, name: e.target.value })}
+          className="w-full bg-transparent text-sm font-bold outline-none" placeholder="Request name" />
+      </div>
+
+      {/* Request editor */}
+      <div style={{ height: `${splitPct}%` }} className="flex min-h-0 flex-col overflow-hidden">
+        <div className="flex border-b border-border">
+          {(['params', 'headers', 'body', 'auth'] as const).map(t => (
+            <button key={t} onClick={() => setReqTab(t)}
+              className={`px-3 py-1 text-xs font-bold uppercase tracking-wide ${reqTab === t ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-muted'}`}>
+              {t}
+            </button>
+          ))}
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto p-2">
+          {reqTab === 'params' && (
+            <KVEditor rows={request.params} onChange={rows => onUpdate({ ...request, params: rows })} placeholder="param" />
+          )}
+          {reqTab === 'headers' && (
+            <KVEditor rows={request.headers} onChange={rows => onUpdate({ ...request, headers: rows })} placeholder="header" />
+          )}
+          {reqTab === 'body' && (
+            <div className="flex flex-col gap-2">
+              <select value={request.body.mode} onChange={e => {
+                const mode = e.target.value as RequestDef['body']['mode'];
+                const body = mode === 'json' ? { mode: 'json' as const, content: '' }
+                  : mode === 'form' ? { mode: 'form' as const, fields: [] }
+                  : mode === 'raw' ? { mode: 'raw' as const, content: '', contentType: 'text/plain' }
+                  : { mode: 'none' as const };
+                onUpdate({ ...request, body });
+              }} className="w-32 border border-border bg-muted px-2 py-1 text-xs">
+                <option value="none">None</option>
+                <option value="json">JSON</option>
+                <option value="form">Form</option>
+                <option value="raw">Raw</option>
+              </select>
+              {(request.body.mode === 'json' || request.body.mode === 'raw') && (
+                <textarea value={request.body.content}
+                  onChange={e => onUpdate({ ...request, body: { ...request.body, content: e.target.value } as RequestDef['body'] })}
+                  className="h-36 w-full resize-none border border-border bg-muted p-2 font-mono text-xs outline-none"
+                  placeholder='{"key": "value"}' />
+              )}
+              {request.body.mode === 'form' && (
+                <KVEditor rows={request.body.fields} onChange={fields => onUpdate({ ...request, body: { mode: 'form', fields } })} placeholder="field" />
+              )}
+            </div>
+          )}
+          {reqTab === 'auth' && (
+            <div className="flex flex-col gap-2">
+              <select value={request.auth.type} onChange={e => {
+                const type = e.target.value as RequestDef['auth']['type'];
+                const auth = type === 'bearer' ? { type: 'bearer' as const, token: '' }
+                  : type === 'basic' ? { type: 'basic' as const, username: '', password: '' }
+                  : type === 'api-key' ? { type: 'api-key' as const, header: 'X-API-Key', value: '' }
+                  : { type: 'none' as const };
+                onUpdate({ ...request, auth });
+              }} className="w-40 border border-border bg-muted px-2 py-1 text-xs">
+                <option value="none">No auth</option>
+                <option value="bearer">Bearer token</option>
+                <option value="basic">Basic auth</option>
+                <option value="api-key">API key</option>
+              </select>
+              {request.auth.type === 'bearer' && (
+                <input value={request.auth.token}
+                  onChange={e => onUpdate({ ...request, auth: { type: 'bearer', token: e.target.value } })}
+                  placeholder="Token" className="border border-border bg-muted px-2 py-1.5 font-mono text-sm outline-none" />
+              )}
+              {request.auth.type === 'basic' && (
+                <div className="flex gap-2">
+                  <input value={request.auth.username}
+                    onChange={e => onUpdate({ ...request, auth: { type: 'basic', username: e.target.value, password: (request.auth as Extract<RequestDef['auth'], { type: 'basic' }>).password } })}
+                    placeholder="Username" className="flex-1 border border-border bg-muted px-2 py-1.5 text-sm outline-none" />
+                  <input type="password" value={request.auth.password}
+                    onChange={e => onUpdate({ ...request, auth: { type: 'basic', username: (request.auth as Extract<RequestDef['auth'], { type: 'basic' }>).username, password: e.target.value } })}
+                    placeholder="Password" className="flex-1 border border-border bg-muted px-2 py-1.5 text-sm outline-none" />
+                </div>
+              )}
+              {request.auth.type === 'api-key' && (
+                <div className="flex gap-2">
+                  <input value={request.auth.header}
+                    onChange={e => onUpdate({ ...request, auth: { type: 'api-key', header: e.target.value, value: (request.auth as Extract<RequestDef['auth'], { type: 'api-key' }>).value } })}
+                    placeholder="Header name" className="w-40 border border-border bg-muted px-2 py-1.5 text-sm outline-none" />
+                  <input value={request.auth.value}
+                    onChange={e => onUpdate({ ...request, auth: { type: 'api-key', header: (request.auth as Extract<RequestDef['auth'], { type: 'api-key' }>).header, value: e.target.value } })}
+                    placeholder="Value" className="flex-1 border border-border bg-muted px-2 py-1.5 font-mono text-sm outline-none" />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Drag handle */}
+      <div onMouseDown={onMouseDown}
+        className="flex h-2 cursor-row-resize items-center justify-center border-y-2 border-border bg-muted hover:bg-accent select-none">
+        <div className="h-0.5 w-8 rounded bg-border" />
+      </div>
+
+      {/* Response panel */}
+      <div style={{ height: `${100 - splitPct}%` }} className="flex min-h-0 flex-col overflow-hidden">
+        {sendError && <Alert variant="error">{sendError}</Alert>}
+        {response ? (
+          <>
+            <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-1">
+              <span className={`text-sm font-bold ${statusColor(response.status)}`}>{response.status} {response.statusText}</span>
+              <span className="text-xs text-muted-foreground">{response.durationMs}ms</span>
+              <span className="text-xs text-muted-foreground">{(new TextEncoder().encode(response.body).byteLength / 1024).toFixed(1)} KB</span>
+              <div className="ml-auto flex">
+                {(['body', 'headers', 'history'] as const).map(t => (
+                  <button key={t} onClick={() => setResTab(t)}
+                    className={`px-2 py-1 text-xs font-bold uppercase tracking-wide ${resTab === t ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-muted'}`}>
+                    {t}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto p-2">
+              {resTab === 'body' && (
+                <pre className="whitespace-pre-wrap break-all font-mono text-xs">{prettyBody(response.body)}</pre>
+              )}
+              {resTab === 'headers' && (
+                <table className="w-full text-xs">
+                  <tbody>
+                    {Object.entries(response.headers).map(([k, v]) => (
+                      <tr key={k} className="border-b border-border">
+                        <td className="py-0.5 pr-3 font-bold text-muted-foreground">{k}</td>
+                        <td className="break-all py-0.5 font-mono">{v}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+              {resTab === 'history' && (
+                request.responseHistory.length === 0
+                  ? <p className="text-xs text-muted-foreground">No response history yet.</p>
+                  : request.responseHistory.map((snap, i) => (
+                    <div key={i} className="mb-2 rounded border border-border p-2">
+                      <div className="mb-1 flex items-center gap-2 text-xs">
+                        <span className={`font-bold ${statusColor(snap.status)}`}>{snap.status}</span>
+                        <span className="text-muted-foreground">{snap.durationMs}ms</span>
+                        {i === 0 && <span className="ml-auto text-muted-foreground italic">latest</span>}
+                      </div>
+                      <pre className="max-h-24 overflow-auto whitespace-pre-wrap font-mono text-xs">{prettyBody(snap.body).slice(0, 300)}</pre>
+                    </div>
+                  ))
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+            Response will appear here after sending.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- KVEditor ----
+
+function KVEditor({ rows, onChange, placeholder }: {
+  rows: { key: string; value: string; enabled: boolean }[];
+  onChange: (rows: { key: string; value: string; enabled: boolean }[]) => void;
+  placeholder: string;
+}) {
+  const add = () => onChange([...rows, { key: '', value: '', enabled: true }]);
+  const remove = (i: number) => onChange(rows.filter((_, idx) => idx !== i));
+  const update = (i: number, field: 'key' | 'value' | 'enabled', val: string | boolean) =>
+    onChange(rows.map((r, idx) => idx === i ? { ...r, [field]: val } : r));
+
+  return (
+    <div className="flex flex-col gap-1">
+      {rows.map((row, i) => (
+        <div key={i} className="flex items-center gap-1">
+          <input type="checkbox" checked={row.enabled} onChange={e => update(i, 'enabled', e.target.checked)} className="h-3.5 w-3.5 shrink-0" />
+          <input value={row.key} onChange={e => update(i, 'key', e.target.value)} placeholder={`${placeholder} name`}
+            className="w-32 border border-border bg-muted px-1.5 py-1 font-mono text-xs outline-none" />
+          <input value={row.value} onChange={e => update(i, 'value', e.target.value)} placeholder="value"
+            className="flex-1 border border-border bg-muted px-1.5 py-1 font-mono text-xs outline-none" />
+          <button onClick={() => remove(i)} className="shrink-0 text-muted-foreground hover:text-destructive">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button onClick={add} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+        <Plus className="h-3.5 w-3.5" /> Add {placeholder}
+      </button>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1492,6 +1492,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'What if my chosen shortcut is already taken?', a: 'The tool reports whether registration succeeds or fails. If a system shortcut or another app already holds the combination, registration will fail and you will see an error — choose a different combination.' },
     ],
   },
+  'api-client': {
+    title: 'Free API Client Tool — Import Postman, Insomnia & Swagger',
+    description: 'A free browser-based REST API client. Import Postman collections, Insomnia workspaces, Swagger/OpenAPI specs or HAR files and fire requests instantly — no account, no install, no vendor lock-in.',
+    intro: 'This free API Client lets you import your existing Postman collections, Insomnia workspaces, Swagger/OpenAPI specs or browser HAR archives and execute REST API requests directly in your browser — or with full CORS bypass in the GoodWebTools desktop app. Environment variables, cross-request token chaining, and per-request response history are all included. Your workspace auto-saves locally and never leaves your device.',
+    howTo: [
+      'Click "Import" and select a Postman JSON, Insomnia JSON, OpenAPI YAML/JSON, or HAR file — the collection populates instantly.',
+      'Click any request in the sidebar to open it. Edit the URL, method, headers, body, or auth as needed.',
+      'Set an environment (e.g. "dev" with base_url and token variables) and reference them with {{variable_name}} anywhere in the request.',
+      'Click "Send". The response appears below with status, timing, headers, and formatted body. Right-click a collection to export back to Postman, Insomnia, or OpenAPI.',
+    ],
+    faqs: [
+      { q: 'Is my API data uploaded to a server?', a: 'No. All request execution, collection parsing, and workspace storage happen locally in your browser or desktop app. Your API keys, tokens, and payloads never leave your device.' },
+      { q: 'Why does it say "Browser mode — CORS restrictions apply"?', a: 'Browsers block cross-origin requests to APIs that don\'t explicitly allow them — this is a browser security policy called CORS. Install the GoodWebTools desktop app to send requests to any API without CORS restrictions, exactly like Postman or Insomnia.' },
+      { q: 'Which import formats are supported?', a: 'Postman Collection v2.1 (JSON), Insomnia Export v4 (JSON), OpenAPI/Swagger 2.0 and 3.x (JSON or YAML), and HAR (HTTP Archive from browser DevTools). Collections are auto-detected — just drop the file.' },
+      { q: 'Can I export my work back to Postman or Insomnia?', a: 'Yes. Click the download icon on any collection in the sidebar to export it as Postman v2.1. Use "Export workspace" in the toolbar to save everything as a GWT Workspace JSON for full backup.' },
+      { q: 'How does auto-save work?', a: 'Your workspace is saved to your browser\'s localStorage automatically — 30 seconds after your last change. An amber "Unsaved" chip appears while changes are pending; click it to save immediately. Your work is restored exactly as you left it when you return.' },
+    ],
+  },
 };
 
 const id: Record<string, ToolSeoContent> = {
@@ -2978,6 +2996,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah hotkey terdaftar secara permanen?', a: 'Tidak. Hotkey hanya aktif saat Anda berada di halaman ini di dalam aplikasi desktop. Hotkey otomatis dibatalkan pendaftarannya saat Anda berpindah halaman.' },
       { q: 'Modifier apa saja yang didukung?', a: 'Ctrl, Shift, Alt, dan Meta (tombol Windows / Cmd) semuanya didukung dalam kombinasi apa pun, beserta huruf, angka, atau tombol fungsi apa pun.' },
       { q: 'Bagaimana jika pintasan yang saya pilih sudah digunakan?', a: 'Tool melaporkan apakah pendaftaran berhasil atau gagal. Jika pintasan sistem atau aplikasi lain sudah menggunakan kombinasi tersebut, pendaftaran akan gagal dan Anda akan melihat pesan error — pilih kombinasi yang berbeda.' },
+    ],
+  },
+  'api-client': {
+    title: 'Tool API Client Gratis — Import Postman, Insomnia & Swagger',
+    description: 'Tool REST API client gratis berbasis browser. Import koleksi Postman, workspace Insomnia, spesifikasi Swagger/OpenAPI, atau berkas HAR dan kirim request seketika — tanpa akun, tanpa instalasi, tanpa vendor lock-in.',
+    intro: 'Tool API Client gratis ini memungkinkan Anda mengimpor koleksi Postman, workspace Insomnia, spesifikasi Swagger/OpenAPI, atau arsip HAR browser dan menjalankan REST API request langsung di browser — atau dengan bypass CORS penuh di aplikasi desktop GoodWebTools. Variabel environment, token chaining antar request, dan riwayat respons per-request semuanya tersedia. Workspace Anda tersimpan otomatis secara lokal dan tidak pernah meninggalkan perangkat Anda.',
+    howTo: [
+      'Klik "Import" dan pilih berkas Postman JSON, Insomnia JSON, OpenAPI YAML/JSON, atau HAR — koleksi langsung tampil.',
+      'Klik request mana pun di sidebar untuk membukanya. Edit URL, method, header, body, atau auth sesuai kebutuhan.',
+      'Buat environment (mis. "dev" dengan variabel base_url dan token) dan referensikan dengan {{nama_variabel}} di mana saja dalam request.',
+      'Klik "Send". Respons muncul di bawah dengan status, waktu, header, dan body terformat. Klik ikon unduh di koleksi untuk mengekspor kembali ke Postman, Insomnia, atau OpenAPI.',
+    ],
+    faqs: [
+      { q: 'Apakah data API saya diunggah ke server?', a: 'Tidak. Semua eksekusi request, parsing koleksi, dan penyimpanan workspace terjadi secara lokal di browser atau aplikasi desktop Anda. API key, token, dan payload Anda tidak pernah meninggalkan perangkat Anda.' },
+      { q: 'Mengapa ada tulisan "Browser mode — CORS restrictions apply"?', a: 'Browser memblokir request lintas-origin ke API yang tidak mengizinkannya secara eksplisit — ini adalah kebijakan keamanan browser bernama CORS. Instal aplikasi desktop GoodWebTools untuk mengirim request ke API mana pun tanpa batasan CORS, persis seperti Postman atau Insomnia.' },
+      { q: 'Format import apa saja yang didukung?', a: 'Postman Collection v2.1 (JSON), Insomnia Export v4 (JSON), OpenAPI/Swagger 2.0 dan 3.x (JSON atau YAML), dan HAR (HTTP Archive dari DevTools browser). Koleksi dideteksi otomatis — cukup pilih berkasnya.' },
+      { q: 'Bisakah saya mengekspor pekerjaan kembali ke Postman atau Insomnia?', a: 'Ya. Klik ikon unduh pada koleksi di sidebar untuk mengekspornya sebagai Postman v2.1. Gunakan "Export workspace" di toolbar untuk menyimpan semuanya sebagai GWT Workspace JSON untuk backup lengkap.' },
+      { q: 'Bagaimana auto-save bekerja?', a: 'Workspace Anda disimpan ke localStorage browser secara otomatis — 30 detik setelah perubahan terakhir. Chip amber "Unsaved" muncul selama perubahan belum tersimpan; klik untuk menyimpan seketika. Pekerjaan Anda dipulihkan persis seperti yang Anda tinggalkan saat kembali.' },
     ],
   },
 };

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -101,6 +101,17 @@ export const tools: ToolDef[] = [
     load: () => import('@/islands/dev/HotkeyTest'),
     status: 'beta',
     desktopOnly: true
+  },
+  {
+    id: 'api-client',
+    name: 'API Client',
+    category: 'Dev',
+    route: '/tools/api-client',
+    keywords: ['postman', 'insomnia', 'swagger', 'openapi', 'rest', 'http', 'api', 'debug', 'request', 'har', 'export', 'import'],
+    icon: PlugZap,
+    summary: 'REST API client — import Postman, Insomnia, Swagger or HAR and fire requests in your browser.',
+    load: () => import('@/islands/dev/ApiClient'),
+    status: 'beta'
   },
   {
     id: 'csv-json',

--- a/src/tools/dev/api-client-env.lib.test.ts
+++ b/src/tools/dev/api-client-env.lib.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { substituteVars, evaluateJsonPath, resolveBinding, applyCapture, substituteRequest } from './api-client-env.lib';
+import { defaultRequestDef } from './api-client-store.lib';
+import type { VarBinding, RequestDef } from './api-client.types';
+
+describe('substituteVars', () => {
+  it('replaces {{var}} with env value', () => {
+    expect(substituteVars('Bearer {{token}}', { token: 'abc123' })).toBe('Bearer abc123');
+  });
+  it('leaves unknown vars unreplaced', () => {
+    expect(substituteVars('{{unknown}}', {})).toBe('{{unknown}}');
+  });
+  it('replaces multiple occurrences', () => {
+    expect(substituteVars('{{a}}-{{a}}', { a: 'x' })).toBe('x-x');
+  });
+});
+
+describe('evaluateJsonPath', () => {
+  const body = JSON.stringify({ data: { token: 'mytoken', nested: { val: 42 } }, items: ['a', 'b'] });
+  it('extracts nested field', () => {
+    expect(evaluateJsonPath(body, '$.data.token')).toBe('mytoken');
+  });
+  it('extracts deeply nested', () => {
+    expect(evaluateJsonPath(body, '$.data.nested.val')).toBe('42');
+  });
+  it('extracts array element', () => {
+    expect(evaluateJsonPath(body, '$.items[0]')).toBe('a');
+  });
+  it('returns undefined for missing path', () => {
+    expect(evaluateJsonPath(body, '$.missing.field')).toBeUndefined();
+  });
+  it('returns undefined on invalid JSON', () => {
+    expect(evaluateJsonPath('not-json', '$.a')).toBeUndefined();
+  });
+});
+
+describe('resolveBinding', () => {
+  const saved: RequestDef = {
+    ...defaultRequestDef(), id: 'req-login',
+    responseHistory: [{ status: 200, statusText: 'OK', headers: {}, body: JSON.stringify({ token: 'saved-token' }), durationMs: 50 }],
+  };
+
+  it('resolves env binding', () => {
+    const bindings: VarBinding[] = [{ name: 'token', source: { type: 'env', varName: 'token' } }];
+    expect(resolveBinding('token', bindings, [], { token: 'env-token' })).toBe('env-token');
+  });
+
+  it('resolves response binding from saved request', () => {
+    const bindings: VarBinding[] = [{ name: 'token', source: { type: 'response', requestId: 'req-login', jsonPath: '$.token' } }];
+    expect(resolveBinding('token', bindings, [saved], {})).toBe('saved-token');
+  });
+
+  it('falls back to env var when no binding defined', () => {
+    expect(resolveBinding('token', [], [], { token: 'fallback' })).toBe('fallback');
+  });
+
+  it('returns undefined when nothing found', () => {
+    expect(resolveBinding('missing', [], [], {})).toBeUndefined();
+  });
+});
+
+describe('applyCapture', () => {
+  it('writes captured value into vars copy', () => {
+    const body = JSON.stringify({ access_token: 'newtoken' });
+    const result = applyCapture({ jsonPath: '$.access_token', intoVar: 'token' }, body, { existing: 'val' });
+    expect(result.token).toBe('newtoken');
+    expect(result.existing).toBe('val');
+  });
+  it('leaves vars unchanged when jsonPath misses', () => {
+    const result = applyCapture({ jsonPath: '$.missing', intoVar: 'token' }, '{}', {});
+    expect(result.token).toBeUndefined();
+  });
+});
+
+describe('substituteRequest', () => {
+  it('substitutes {{var}} in URL and header value', () => {
+    const req: RequestDef = {
+      ...defaultRequestDef(),
+      url: 'https://{{host}}/users',
+      headers: [{ key: 'Authorization', value: 'Bearer {{token}}', enabled: true }],
+    };
+    const result = substituteRequest(req, [], { host: 'api.example.com', token: 'abc' });
+    expect(result.url).toBe('https://api.example.com/users');
+    expect(result.headers[0].value).toBe('Bearer abc');
+  });
+});

--- a/src/tools/dev/api-client-env.lib.ts
+++ b/src/tools/dev/api-client-env.lib.ts
@@ -1,0 +1,78 @@
+import type { RequestDef, VarBinding, CaptureRule } from './api-client.types';
+
+export function substituteVars(text: string, vars: Record<string, string>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (_, name) => vars[name] ?? `{{${name}}}`);
+}
+
+export function evaluateJsonPath(body: string, path: string): string | undefined {
+  try {
+    let obj: unknown = JSON.parse(body);
+    const parts = path.replace(/^\$\.?/, '').split('.');
+    for (const part of parts) {
+      if (obj === null || obj === undefined) return undefined;
+      const arrMatch = part.match(/^(\w+)\[(\d+)\]$/);
+      if (arrMatch) {
+        obj = (obj as Record<string, unknown>)[arrMatch[1]];
+        obj = (obj as unknown[])[Number(arrMatch[2])];
+      } else {
+        obj = (obj as Record<string, unknown>)[part];
+      }
+    }
+    return obj !== undefined && obj !== null ? String(obj) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveBinding(
+  name: string,
+  bindings: VarBinding[],
+  allRequests: RequestDef[],
+  envVars: Record<string, string>,
+): string | undefined {
+  const binding = bindings.find(b => b.name === name);
+  if (binding) {
+    if (binding.source.type === 'env') return envVars[binding.source.varName];
+    if (binding.source.type === 'response') {
+      const src = binding.source as { type: 'response'; requestId: string; jsonPath: string };
+      const req = allRequests.find(r => r.id === src.requestId);
+      const snapshot = req?.responseHistory[0];
+      if (snapshot) return evaluateJsonPath(snapshot.body, src.jsonPath);
+    }
+  }
+  return envVars[name];
+}
+
+export function applyCapture(
+  rule: CaptureRule,
+  responseBody: string,
+  vars: Record<string, string>,
+): Record<string, string> {
+  const value = evaluateJsonPath(responseBody, rule.jsonPath);
+  if (value === undefined) return vars;
+  return { ...vars, [rule.intoVar]: value };
+}
+
+export function substituteRequest(
+  req: RequestDef,
+  allRequests: RequestDef[],
+  envVars: Record<string, string>,
+): RequestDef {
+  const resolve = (text: string) =>
+    text.replace(/\{\{(\w+)\}\}/g, (_, name) => resolveBinding(name, req.bindings, allRequests, envVars) ?? `{{${name}}}`);
+
+  return {
+    ...req,
+    url: resolve(req.url),
+    params: req.params.map(p => ({ ...p, value: resolve(p.value) })),
+    headers: req.headers.map(h => ({ ...h, value: resolve(h.value) })),
+    body: req.body.mode === 'json' ? { ...req.body, content: resolve(req.body.content) } :
+          req.body.mode === 'raw'  ? { ...req.body, content: resolve(req.body.content) } :
+          req.body.mode === 'form' ? { ...req.body, fields: req.body.fields.map(f => ({ ...f, value: resolve(f.value) })) } :
+          req.body,
+    auth: req.auth.type === 'bearer'  ? { ...req.auth, token: resolve(req.auth.token) } :
+          req.auth.type === 'basic'   ? { ...req.auth, username: resolve(req.auth.username), password: resolve(req.auth.password) } :
+          req.auth.type === 'api-key' ? { ...req.auth, value: resolve(req.auth.value) } :
+          req.auth,
+  };
+}

--- a/src/tools/dev/api-client-export.lib.test.ts
+++ b/src/tools/dev/api-client-export.lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { exportPostman, exportInsomnia, exportOpenApi2, exportOpenApi3, exportWorkspace } from './api-client-export.lib';
+import { defaultRequestDef, defaultWorkspace } from './api-client-store.lib';
+import type { Collection, Environment, Workspace } from './api-client.types';
+
+function makeCollection(): Collection {
+  const req = {
+    ...defaultRequestDef(),
+    id: 'r1', name: 'Login', method: 'POST' as const,
+    url: 'https://api.example.com/login',
+    headers: [{ key: 'Content-Type', value: 'application/json', enabled: true }],
+    body: { mode: 'json' as const, content: '{"email":"{{email}}"}' },
+  };
+  return { id: 'c1', name: 'My API', folders: [], requests: [req] };
+}
+
+describe('exportPostman', () => {
+  it('produces valid Postman v2.1 JSON', () => {
+    const json = exportPostman(makeCollection());
+    const parsed = JSON.parse(json);
+    expect(parsed.info.schema).toContain('v2.1');
+    expect(parsed.item[0].name).toBe('Login');
+    expect(parsed.item[0].request.method).toBe('POST');
+    expect(parsed.item[0].request.url.raw).toBe('https://api.example.com/login');
+  });
+  it('includes environment as variables', () => {
+    const env: Environment = { id: 'e1', name: 'dev', vars: { email: 'test@example.com' } };
+    const json = exportPostman(makeCollection(), [env]);
+    const parsed = JSON.parse(json);
+    expect(parsed.variable).toEqual(expect.arrayContaining([expect.objectContaining({ key: 'email' })]));
+  });
+});
+
+describe('exportInsomnia', () => {
+  it('produces valid Insomnia v4 JSON', () => {
+    const json = exportInsomnia(makeCollection());
+    const parsed = JSON.parse(json);
+    expect(parsed.__export_format).toBe(4);
+    const req = parsed.resources.find((r: Record<string, unknown>) => r._type === 'request');
+    expect(req.method).toBe('POST');
+    expect(req.url).toBe('https://api.example.com/login');
+  });
+});
+
+describe('exportOpenApi2', () => {
+  it('produces swagger 2.0 document', () => {
+    const json = exportOpenApi2(makeCollection());
+    const parsed = JSON.parse(json);
+    expect(parsed.swagger).toBe('2.0');
+    expect(parsed.paths['/login']).toBeDefined();
+  });
+});
+
+describe('exportOpenApi3', () => {
+  it('produces openapi 3.1.0 document', () => {
+    const json = exportOpenApi3(makeCollection());
+    const parsed = JSON.parse(json);
+    expect(parsed.openapi).toBe('3.1.0');
+    expect(parsed.paths['/login']).toBeDefined();
+  });
+});
+
+describe('exportWorkspace', () => {
+  it('round-trips a workspace', () => {
+    const w: Workspace = { ...defaultWorkspace(), envs: [{ id: 'e1', name: 'dev', vars: { token: 'abc' } }] };
+    const json = exportWorkspace(w);
+    const parsed = JSON.parse(json) as Workspace;
+    expect(parsed.envs[0].vars.token).toBe('abc');
+  });
+});

--- a/src/tools/dev/api-client-export.lib.ts
+++ b/src/tools/dev/api-client-export.lib.ts
@@ -1,0 +1,142 @@
+import type { Collection, Environment, Folder, RequestDef, Workspace } from './api-client.types';
+
+function allRequests(c: Collection | Folder): RequestDef[] {
+  return [...c.requests, ...c.folders.flatMap(f => allRequests(f))];
+}
+
+function urlPath(url: string): string {
+  try { return new URL(url).pathname; } catch { return url; }
+}
+
+function urlHost(url: string): string {
+  try { const u = new URL(url); return u.host; } catch { return 'example.com'; }
+}
+
+// ---- Postman v2.1 ----
+
+function reqToPostmanItem(req: RequestDef): Record<string, unknown> {
+  return {
+    name: req.name,
+    request: {
+      method: req.method,
+      url: { raw: req.url, host: [urlHost(req.url)], path: urlPath(req.url).split('/').filter(Boolean) },
+      header: req.headers.map(h => ({ key: h.key, value: h.value, disabled: !h.enabled })),
+      body: req.body.mode === 'json' ? { mode: 'raw', raw: req.body.content } :
+            req.body.mode === 'form' ? { mode: 'urlencoded', urlencoded: req.body.fields.map(f => ({ key: f.key, value: f.value, disabled: !f.enabled })) } :
+            undefined,
+    },
+    response: [],
+  };
+}
+
+function folderToPostmanItem(folder: Folder): Record<string, unknown> {
+  return {
+    name: folder.name,
+    item: [
+      ...folder.folders.map(f => folderToPostmanItem(f)),
+      ...folder.requests.map(r => reqToPostmanItem(r)),
+    ],
+  };
+}
+
+export function exportPostman(c: Collection, envs: Environment[] = []): string {
+  const variables = envs.flatMap(e =>
+    Object.entries(e.vars).map(([key, value]) => ({ key, value, type: 'string' }))
+  );
+  const doc = {
+    info: { name: c.name, schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+    item: [
+      ...c.folders.map(f => folderToPostmanItem(f)),
+      ...c.requests.map(r => reqToPostmanItem(r)),
+    ],
+    variable: variables.length > 0 ? variables : undefined,
+  };
+  return JSON.stringify(doc, null, 2);
+}
+
+// ---- Insomnia v4 ----
+
+export function exportInsomnia(c: Collection, envs: Environment[] = []): string {
+  const wrkId = `wrk_${c.id}`;
+  const resources: Record<string, unknown>[] = [
+    { _id: wrkId, _type: 'workspace', name: c.name, parentId: null, modified: Date.now(), created: Date.now() },
+  ];
+
+  function addFolder(f: Folder, parentId: string) {
+    const fId = `fld_${f.id}`;
+    resources.push({ _id: fId, _type: 'request_group', name: f.name, parentId, modified: Date.now(), created: Date.now() });
+    f.folders.forEach(sub => addFolder(sub, fId));
+    f.requests.forEach(r => addReq(r, fId));
+  }
+
+  function addReq(req: RequestDef, parentId: string) {
+    resources.push({
+      _id: `req_${req.id}`, _type: 'request',
+      name: req.name, method: req.method, url: req.url, parentId,
+      headers: req.headers.map(h => ({ name: h.key, value: h.value })),
+      body: req.body.mode === 'json' ? { mimeType: 'application/json', text: req.body.content } :
+            req.body.mode === 'form' ? { mimeType: 'application/x-www-form-urlencoded', params: req.body.fields.map(f => ({ name: f.key, value: f.value })) } :
+            {},
+      modified: Date.now(), created: Date.now(),
+    });
+  }
+
+  c.folders.forEach(f => addFolder(f, wrkId));
+  c.requests.forEach(r => addReq(r, wrkId));
+
+  envs.forEach(env => {
+    resources.push({ _id: `env_${env.id}`, _type: 'environment', name: env.name, parentId: wrkId, data: env.vars, modified: Date.now(), created: Date.now() });
+  });
+
+  return JSON.stringify({ __export_format: 4, __export_date: new Date().toISOString(), __export_source: 'goodwebtools', resources }, null, 2);
+}
+
+// ---- OpenAPI 2 ----
+
+export function exportOpenApi2(c: Collection): string {
+  const reqs = allRequests(c);
+  const host = reqs.length > 0 ? urlHost(reqs[0].url) : 'example.com';
+  const paths: Record<string, Record<string, unknown>> = {};
+  for (const req of reqs) {
+    const path = urlPath(req.url) || '/';
+    const method = req.method.toLowerCase();
+    if (!paths[path]) paths[path] = {};
+    paths[path][method] = {
+      summary: req.name,
+      operationId: req.name.replace(/\s+/g, '_').toLowerCase(),
+      parameters: req.params.filter(p => p.enabled).map(p => ({ in: 'query', name: p.key, type: 'string' })),
+      responses: { '200': { description: 'OK' } },
+    };
+  }
+  return JSON.stringify({ swagger: '2.0', info: { title: c.name, version: '1.0.0' }, host, basePath: '/', paths }, null, 2);
+}
+
+// ---- OpenAPI 3.1 ----
+
+export function exportOpenApi3(c: Collection): string {
+  const reqs = allRequests(c);
+  const base = reqs.length > 0 ? (() => { try { const u = new URL(reqs[0].url); return `${u.protocol}//${u.host}`; } catch { return 'https://example.com'; } })() : 'https://example.com';
+  const paths: Record<string, Record<string, unknown>> = {};
+  for (const req of reqs) {
+    const path = urlPath(req.url) || '/';
+    const method = req.method.toLowerCase();
+    if (!paths[path]) paths[path] = {};
+    const op: Record<string, unknown> = {
+      summary: req.name,
+      operationId: req.name.replace(/\s+/g, '_').toLowerCase(),
+      parameters: req.params.filter(p => p.enabled).map(p => ({ in: 'query', name: p.key, schema: { type: 'string' } })),
+      responses: { '200': { description: 'OK' } },
+    };
+    if (req.body.mode === 'json') {
+      op.requestBody = { content: { 'application/json': { schema: { type: 'object' } } } };
+    }
+    paths[path][method] = op;
+  }
+  return JSON.stringify({ openapi: '3.1.0', info: { title: c.name, version: '1.0.0' }, servers: [{ url: base }], paths }, null, 2);
+}
+
+// ---- GWT Workspace ----
+
+export function exportWorkspace(w: Workspace): string {
+  return JSON.stringify(w, null, 2);
+}

--- a/src/tools/dev/api-client-import.lib.test.ts
+++ b/src/tools/dev/api-client-import.lib.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { detectAndParse } from './api-client-import.lib';
+
+const postmanV21 = JSON.stringify({
+  info: { name: 'My API', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+  item: [
+    { name: 'Login', request: { method: 'POST', url: { raw: 'https://api.example.com/login' }, header: [{ key: 'Content-Type', value: 'application/json', disabled: false }], body: { mode: 'raw', raw: '{"email":"{{email}}"}' } } },
+    { name: 'Users', item: [
+      { name: 'List Users', request: { method: 'GET', url: 'https://api.example.com/users', header: [] } },
+    ]},
+  ],
+});
+
+const insomniaV4 = JSON.stringify({
+  __export_format: 4,
+  resources: [
+    { _id: 'wrk_1', _type: 'workspace', name: 'My Workspace' },
+    { _id: 'fld_1', _type: 'request_group', parentId: 'wrk_1', name: 'Auth' },
+    { _id: 'req_1', _type: 'request', parentId: 'fld_1', name: 'Login', method: 'POST', url: 'https://api.example.com/login', headers: [{ name: 'Content-Type', value: 'application/json' }], body: { mimeType: 'application/json', text: '{"email":"test"}' } },
+  ],
+});
+
+const openApi2 = JSON.stringify({
+  swagger: '2.0', info: { title: 'My API', version: '1.0' },
+  host: 'api.example.com', basePath: '/v1',
+  paths: {
+    '/users': { get: { operationId: 'listUsers', summary: 'List users', parameters: [] } },
+    '/users/{id}': { delete: { operationId: 'deleteUser', summary: 'Delete user', parameters: [] } },
+  },
+});
+
+const openApi3 = JSON.stringify({
+  openapi: '3.0.0', info: { title: 'My API', version: '1.0' },
+  servers: [{ url: 'https://api.example.com/v1' }],
+  paths: {
+    '/items': { post: { operationId: 'createItem', summary: 'Create item', requestBody: { content: { 'application/json': { schema: {} } } } } },
+  },
+});
+
+const har = JSON.stringify({
+  log: {
+    version: '1.2',
+    entries: [
+      { request: { method: 'GET', url: 'https://api.example.com/users', headers: [{ name: 'Authorization', value: 'Bearer token' }], postData: null } },
+      { request: { method: 'POST', url: 'https://api.example.com/users', headers: [], postData: { mimeType: 'application/json', text: '{"name":"Alice"}' } } },
+    ],
+  },
+});
+
+describe('detectAndParse — Postman v2.1', () => {
+  it('parses flat requests', () => {
+    const col = detectAndParse(postmanV21, 'collection.json');
+    expect(col.requests.find(r => r.name === 'Login')?.method).toBe('POST');
+    expect(col.requests.find(r => r.name === 'Login')?.url).toBe('https://api.example.com/login');
+    expect(col.requests.find(r => r.name === 'Login')?.headers[0].key).toBe('Content-Type');
+  });
+  it('parses nested folder', () => {
+    const col = detectAndParse(postmanV21, 'collection.json');
+    const folder = col.folders.find(f => f.name === 'Users');
+    expect(folder?.requests[0].name).toBe('List Users');
+  });
+});
+
+describe('detectAndParse — Insomnia v4', () => {
+  it('parses request inside group', () => {
+    const col = detectAndParse(insomniaV4, 'insomnia.json');
+    const folder = col.folders.find(f => f.name === 'Auth');
+    expect(folder?.requests[0].method).toBe('POST');
+    expect(folder?.requests[0].url).toBe('https://api.example.com/login');
+  });
+});
+
+describe('detectAndParse — OpenAPI 2', () => {
+  it('generates one request per operation', () => {
+    const col = detectAndParse(openApi2, 'swagger.json');
+    const all = [...col.requests, ...col.folders.flatMap(f => f.requests)];
+    expect(all.length).toBe(2);
+    const list = all.find(r => r.method === 'GET');
+    expect(list?.url).toContain('api.example.com');
+  });
+});
+
+describe('detectAndParse — OpenAPI 3', () => {
+  it('uses servers[0].url as base', () => {
+    const col = detectAndParse(openApi3, 'openapi.json');
+    const all = [...col.requests, ...col.folders.flatMap(f => f.requests)];
+    expect(all[0].url).toContain('api.example.com/v1/items');
+  });
+});
+
+describe('detectAndParse — HAR', () => {
+  it('imports all entries as requests', () => {
+    const col = detectAndParse(har, 'archive.har');
+    expect(col.requests.length).toBe(2);
+    expect(col.requests[1].body).toMatchObject({ mode: 'json' });
+  });
+  it('maps HAR headers', () => {
+    const col = detectAndParse(har, 'archive.har');
+    expect(col.requests[0].headers[0]).toMatchObject({ key: 'Authorization', value: 'Bearer token', enabled: true });
+  });
+});
+
+describe('detectAndParse — YAML OpenAPI 3', () => {
+  it('parses yaml extension as OpenAPI 3', () => {
+    const yamlStr = `openapi: "3.0.0"\ninfo:\n  title: My API\n  version: "1"\nservers:\n  - url: https://api.example.com\npaths:\n  /ping:\n    get:\n      operationId: ping\n      summary: Ping\n`;
+    const col = detectAndParse(yamlStr, 'openapi.yaml');
+    expect(col.requests[0].url).toContain('/ping');
+  });
+});

--- a/src/tools/dev/api-client-import.lib.ts
+++ b/src/tools/dev/api-client-import.lib.ts
@@ -1,0 +1,228 @@
+import { parse as parseYaml } from 'yaml';
+import { defaultRequestDef } from './api-client-store.lib';
+import type { Collection, Folder, RequestDef, KV, BodyDef } from './api-client.types';
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+function kv(key: string, value: string, enabled = true): KV {
+  return { key, value, enabled };
+}
+
+// ---- Postman v2.1 ----
+
+function postmanUrl(url: unknown): string {
+  if (typeof url === 'string') return url;
+  if (url && typeof url === 'object' && 'raw' in url) return (url as { raw: string }).raw;
+  return '';
+}
+
+function postmanBody(body: unknown): BodyDef {
+  if (!body || typeof body !== 'object') return { mode: 'none' };
+  const b = body as Record<string, unknown>;
+  if (b.mode === 'raw') return { mode: 'json', content: String(b.raw ?? '') };
+  if (b.mode === 'urlencoded') {
+    const fields = Array.isArray(b.urlencoded)
+      ? (b.urlencoded as Array<{ key: string; value: string; disabled?: boolean }>).map(f => kv(f.key, f.value, !f.disabled))
+      : [];
+    return { mode: 'form', fields };
+  }
+  return { mode: 'none' };
+}
+
+function parsePostmanItem(item: unknown): { requests: RequestDef[]; folders: Folder[] } {
+  const requests: RequestDef[] = [];
+  const folders: Folder[] = [];
+  if (!Array.isArray(item)) return { requests, folders };
+  for (const entry of item) {
+    const e = entry as Record<string, unknown>;
+    if (Array.isArray(e.item)) {
+      const sub = parsePostmanItem(e.item);
+      folders.push({ id: uuid(), name: String(e.name ?? 'Folder'), folders: sub.folders, requests: sub.requests });
+    } else if (e.request && typeof e.request === 'object') {
+      const req = e.request as Record<string, unknown>;
+      const headers = Array.isArray(req.header)
+        ? (req.header as Array<{ key: string; value: string; disabled?: boolean }>).map(h => kv(h.key, h.value, !h.disabled))
+        : [];
+      requests.push({
+        ...defaultRequestDef(),
+        id: uuid(),
+        name: String(e.name ?? 'Request'),
+        method: String(req.method ?? 'GET').toUpperCase() as RequestDef['method'],
+        url: postmanUrl(req.url),
+        headers,
+        body: postmanBody(req.body),
+      });
+    }
+  }
+  return { requests, folders };
+}
+
+function parsePostman(data: unknown): Collection {
+  const d = data as Record<string, unknown>;
+  const name = String((d.info as Record<string, unknown>)?.name ?? 'Postman Collection');
+  const { requests, folders } = parsePostmanItem(d.item);
+  return { id: uuid(), name, folders, requests };
+}
+
+// ---- Insomnia v4 ----
+
+function parseInsomnia(data: unknown): Collection {
+  const d = data as Record<string, unknown>;
+  const resources = Array.isArray(d.resources) ? (d.resources as Array<Record<string, unknown>>) : [];
+  const workspace = resources.find(r => r._type === 'workspace');
+  const name = String(workspace?.name ?? 'Insomnia Workspace');
+
+  const groupMap = new Map<string, Folder>();
+  const rootRequests: RequestDef[] = [];
+
+  for (const r of resources) {
+    if (r._type === 'request_group') {
+      groupMap.set(String(r._id), { id: uuid(), name: String(r.name ?? 'Folder'), folders: [], requests: [] });
+    }
+  }
+
+  for (const r of resources) {
+    if (r._type !== 'request') continue;
+    const headers = Array.isArray(r.headers)
+      ? (r.headers as Array<{ name: string; value: string }>).map(h => kv(h.name, h.value))
+      : [];
+    const bodyRaw = r.body as Record<string, unknown> | undefined;
+    let body: BodyDef = { mode: 'none' };
+    if (bodyRaw?.mimeType === 'application/json' && bodyRaw.text) {
+      body = { mode: 'json', content: String(bodyRaw.text) };
+    } else if (bodyRaw?.mimeType === 'application/x-www-form-urlencoded') {
+      const fields = Array.isArray(bodyRaw.params)
+        ? (bodyRaw.params as Array<{ name: string; value: string }>).map(p => kv(p.name, p.value))
+        : [];
+      body = { mode: 'form', fields };
+    }
+    const def: RequestDef = {
+      ...defaultRequestDef(),
+      id: uuid(), name: String(r.name ?? 'Request'),
+      method: String(r.method ?? 'GET').toUpperCase() as RequestDef['method'],
+      url: String(r.url ?? ''), headers, body,
+    };
+    const parentId = String(r.parentId ?? '');
+    const folder = groupMap.get(parentId);
+    if (folder) folder.requests.push(def);
+    else rootRequests.push(def);
+  }
+
+  return { id: uuid(), name, folders: Array.from(groupMap.values()), requests: rootRequests };
+}
+
+// ---- OpenAPI 2 ----
+
+function parseOpenApi2(data: unknown): Collection {
+  const d = data as Record<string, unknown>;
+  const info = d.info as Record<string, unknown>;
+  const name = String(info?.title ?? 'Swagger Collection');
+  const base = `https://${d.host ?? 'example.com'}${d.basePath ?? ''}`;
+  const paths = (d.paths ?? {}) as Record<string, Record<string, unknown>>;
+  const requests: RequestDef[] = [];
+  for (const [path, methods] of Object.entries(paths)) {
+    for (const [method, op] of Object.entries(methods)) {
+      const operation = op as Record<string, unknown>;
+      requests.push({
+        ...defaultRequestDef(),
+        id: uuid(),
+        name: String(operation.summary ?? operation.operationId ?? `${method.toUpperCase()} ${path}`),
+        method: method.toUpperCase() as RequestDef['method'],
+        url: base + path,
+      });
+    }
+  }
+  return { id: uuid(), name, folders: [], requests };
+}
+
+// ---- OpenAPI 3 ----
+
+function parseOpenApi3(data: unknown): Collection {
+  const d = data as Record<string, unknown>;
+  const info = d.info as Record<string, unknown>;
+  const name = String(info?.title ?? 'OpenAPI Collection');
+  const servers = Array.isArray(d.servers) ? (d.servers as Array<{ url: string }>) : [];
+  const base = servers[0]?.url ?? '';
+  const paths = (d.paths ?? {}) as Record<string, Record<string, unknown>>;
+  const requests: RequestDef[] = [];
+  for (const [path, methods] of Object.entries(paths)) {
+    for (const [method, op] of Object.entries(methods)) {
+      const operation = op as Record<string, unknown>;
+      const hasBody = ['post', 'put', 'patch'].includes(method.toLowerCase());
+      const body: BodyDef = hasBody ? { mode: 'json', content: '{}' } : { mode: 'none' };
+      requests.push({
+        ...defaultRequestDef(),
+        id: uuid(),
+        name: String(operation.summary ?? operation.operationId ?? `${method.toUpperCase()} ${path}`),
+        method: method.toUpperCase() as RequestDef['method'],
+        url: base + path,
+        body,
+      });
+    }
+  }
+  return { id: uuid(), name, folders: [], requests };
+}
+
+// ---- HAR ----
+
+function parseHar(data: unknown): Collection {
+  const d = data as Record<string, unknown>;
+  const log = d.log as Record<string, unknown>;
+  const entries = Array.isArray(log?.entries) ? (log.entries as Array<Record<string, unknown>>) : [];
+  const requests: RequestDef[] = entries.map(entry => {
+    const req = entry.request as Record<string, unknown>;
+    const headers = Array.isArray(req.headers)
+      ? (req.headers as Array<{ name: string; value: string }>).map(h => kv(h.name, h.value))
+      : [];
+    const pd = req.postData as Record<string, unknown> | null | undefined;
+    let body: BodyDef = { mode: 'none' };
+    if (pd?.text) {
+      const mime = String(pd.mimeType ?? '');
+      if (mime.includes('json')) body = { mode: 'json', content: String(pd.text) };
+      else if (mime.includes('form')) {
+        const fields = Array.isArray(pd.params)
+          ? (pd.params as Array<{ name: string; value: string }>).map(p => kv(p.name, p.value))
+          : [];
+        body = { mode: 'form', fields };
+      } else {
+        body = { mode: 'raw', content: String(pd.text), contentType: mime };
+      }
+    }
+    const rawUrl = String(req.url ?? '');
+    const urlObj = (() => { try { return new URL(rawUrl); } catch { return null; } })();
+    const params: KV[] = urlObj
+      ? Array.from(urlObj.searchParams.entries()).map(([k, v]) => kv(k, v))
+      : [];
+    return {
+      ...defaultRequestDef(),
+      id: uuid(),
+      name: `${String(req.method ?? 'GET')} ${rawUrl.split('?')[0].split('/').pop() ?? rawUrl}`,
+      method: String(req.method ?? 'GET').toUpperCase() as RequestDef['method'],
+      url: urlObj ? `${urlObj.origin}${urlObj.pathname}` : rawUrl,
+      params, headers, body,
+    };
+  });
+  return { id: uuid(), name: 'HAR Archive', folders: [], requests };
+}
+
+// ---- Auto-detect ----
+
+export function detectAndParse(raw: string, filename: string): Collection {
+  const lower = filename.toLowerCase();
+  let data: unknown;
+  if (lower.endsWith('.yaml') || lower.endsWith('.yml')) {
+    data = parseYaml(raw);
+  } else {
+    data = JSON.parse(raw);
+  }
+  const d = data as Record<string, unknown>;
+  if (typeof d.swagger === 'string' && d.swagger.startsWith('2')) return parseOpenApi2(d);
+  if (typeof d.openapi === 'string' && d.openapi.startsWith('3')) return parseOpenApi3(d);
+  if (d.__export_format === 4) return parseInsomnia(d);
+  if (typeof (d.info as Record<string, unknown>)?.schema === 'string' &&
+      String((d.info as Record<string, unknown>).schema).includes('v2.1')) return parsePostman(d);
+  if (d.log && typeof (d.log as Record<string, unknown>).version === 'string') return parseHar(d);
+  throw new Error(`Unrecognised collection format in "${filename}"`);
+}

--- a/src/tools/dev/api-client-request.lib.test.ts
+++ b/src/tools/dev/api-client-request.lib.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildFetchInit } from './api-client-request.lib';
+import { defaultRequestDef } from './api-client-store.lib';
+import type { RequestDef } from './api-client.types';
+
+describe('buildFetchInit', () => {
+  it('builds GET with no body', () => {
+    const req: RequestDef = { ...defaultRequestDef(), method: 'GET', url: 'https://api.example.com/users' };
+    const { url, init } = buildFetchInit(req);
+    expect(url).toBe('https://api.example.com/users');
+    expect(init.method).toBe('GET');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('appends enabled query params to URL', () => {
+    const req: RequestDef = {
+      ...defaultRequestDef(), method: 'GET', url: 'https://api.example.com/users',
+      params: [{ key: 'page', value: '1', enabled: true }, { key: 'skip', value: '0', enabled: false }],
+    };
+    const { url } = buildFetchInit(req);
+    expect(url).toContain('page=1');
+    expect(url).not.toContain('skip');
+  });
+
+  it('sets Content-Type for JSON body', () => {
+    const req: RequestDef = {
+      ...defaultRequestDef(), method: 'POST', url: 'https://api.example.com/login',
+      body: { mode: 'json', content: '{"email":"test"}' },
+    };
+    const { init } = buildFetchInit(req);
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(init.body).toBe('{"email":"test"}');
+  });
+
+  it('sets Authorization header for bearer auth', () => {
+    const req: RequestDef = {
+      ...defaultRequestDef(), method: 'GET', url: 'https://api.example.com/',
+      auth: { type: 'bearer', token: 'mytoken' },
+    };
+    const { init } = buildFetchInit(req);
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer mytoken');
+  });
+
+  it('sets Authorization header for basic auth', () => {
+    const req: RequestDef = {
+      ...defaultRequestDef(), method: 'GET', url: 'https://api.example.com/',
+      auth: { type: 'basic', username: 'user', password: 'pass' },
+    };
+    const { init } = buildFetchInit(req);
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Basic /);
+  });
+});

--- a/src/tools/dev/api-client-request.lib.ts
+++ b/src/tools/dev/api-client-request.lib.ts
@@ -1,0 +1,80 @@
+import { isTauri } from '@/services/platform';
+import type { RequestDef, ResponseSnapshot } from './api-client.types';
+
+export function buildFetchInit(req: RequestDef): { url: string; init: RequestInit } {
+  const headers: Record<string, string> = {};
+
+  for (const h of req.headers) {
+    if (h.enabled) headers[h.key] = h.value;
+  }
+
+  if (req.auth.type === 'bearer') {
+    headers['Authorization'] = `Bearer ${req.auth.token}`;
+  } else if (req.auth.type === 'basic') {
+    const encoded = btoa(`${req.auth.username}:${req.auth.password}`);
+    headers['Authorization'] = `Basic ${encoded}`;
+  } else if (req.auth.type === 'api-key') {
+    headers[req.auth.header] = req.auth.value;
+  }
+
+  let url = req.url;
+  const enabledParams = req.params.filter(p => p.enabled);
+  if (enabledParams.length > 0) {
+    const sep = url.includes('?') ? '&' : '?';
+    url += sep + enabledParams.map(p => `${encodeURIComponent(p.key)}=${encodeURIComponent(p.value)}`).join('&');
+  }
+
+  let body: BodyInit | undefined;
+  if (req.body.mode === 'json') {
+    headers['Content-Type'] = 'application/json';
+    body = req.body.content;
+  } else if (req.body.mode === 'form') {
+    const form = new URLSearchParams();
+    req.body.fields.filter(f => f.enabled).forEach(f => form.append(f.key, f.value));
+    body = form.toString();
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+  } else if (req.body.mode === 'raw') {
+    body = req.body.content;
+    if (req.body.contentType) headers['Content-Type'] = req.body.contentType;
+  }
+
+  return { url, init: { method: req.method, headers, body } };
+}
+
+export async function executeRequest(req: RequestDef): Promise<ResponseSnapshot> {
+  const { url, init } = buildFetchInit(req);
+  const start = performance.now();
+
+  if (isTauri()) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const result = await invoke<{
+      status: number; status_text: string;
+      headers: Record<string, string>; body: string; duration_ms: number;
+    }>('http_request', {
+      method: req.method,
+      url,
+      headers: init.headers as Record<string, string>,
+      body: init.body ? String(init.body) : null,
+    });
+    return {
+      status: result.status,
+      statusText: result.status_text,
+      headers: result.headers,
+      body: result.body,
+      durationMs: result.duration_ms,
+    };
+  }
+
+  const res = await fetch(url, init);
+  const durationMs = Math.round(performance.now() - start);
+  const responseHeaders: Record<string, string> = {};
+  res.headers.forEach((value, key) => { responseHeaders[key] = value; });
+  const body = await res.text();
+  return {
+    status: res.status,
+    statusText: res.statusText,
+    headers: responseHeaders,
+    body,
+    durationMs,
+  };
+}

--- a/src/tools/dev/api-client-store.lib.test.ts
+++ b/src/tools/dev/api-client-store.lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  defaultWorkspace, defaultRequestDef,
+  pushResponseToRequest, addToHistory,
+  loadWorkspace, saveWorkspace, STORAGE_KEY,
+} from './api-client-store.lib';
+import type { ResponseSnapshot, HistoryEntry } from './api-client.types';
+import { MAX_REQUEST_RESPONSES, MAX_HISTORY } from './api-client.types';
+
+const snap = (status: number): ResponseSnapshot => ({
+  status, statusText: 'OK', headers: {}, body: '{}', durationMs: 10,
+});
+
+describe('pushResponseToRequest', () => {
+  it('prepends response and keeps newest at index 0', () => {
+    const req = defaultRequestDef();
+    const r1 = pushResponseToRequest(req, snap(200));
+    expect(r1.responseHistory[0].status).toBe(200);
+    const r2 = pushResponseToRequest(r1, snap(201));
+    expect(r2.responseHistory[0].status).toBe(201);
+    expect(r2.responseHistory[1].status).toBe(200);
+  });
+
+  it(`caps at MAX_REQUEST_RESPONSES (${MAX_REQUEST_RESPONSES})`, () => {
+    let req = defaultRequestDef();
+    for (let i = 0; i < MAX_REQUEST_RESPONSES + 2; i++) {
+      req = pushResponseToRequest(req, snap(200 + i));
+    }
+    expect(req.responseHistory.length).toBe(MAX_REQUEST_RESPONSES);
+  });
+});
+
+describe('addToHistory', () => {
+  it('prepends entry and caps at MAX_HISTORY', () => {
+    let w = defaultWorkspace();
+    const req = defaultRequestDef();
+    for (let i = 0; i < MAX_HISTORY + 5; i++) {
+      const entry: HistoryEntry = { id: String(i), ts: i, req, res: snap(200) };
+      w = addToHistory(w, entry);
+    }
+    expect(w.history.length).toBe(MAX_HISTORY);
+    expect(w.history[0].id).toBe(String(MAX_HISTORY + 4));
+  });
+});
+
+describe('loadWorkspace / saveWorkspace', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it('returns default workspace when nothing stored', () => {
+    const w = loadWorkspace();
+    expect(w.collections).toEqual([]);
+    expect(w.history).toEqual([]);
+  });
+
+  it('round-trips through localStorage', () => {
+    const w = defaultWorkspace();
+    w.envs.push({ id: 'e1', name: 'dev', vars: { token: 'abc' } });
+    saveWorkspace(w);
+    const loaded = loadWorkspace();
+    expect(loaded.envs[0].vars.token).toBe('abc');
+  });
+
+  it('returns default on corrupted localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json{{{');
+    const w = loadWorkspace();
+    expect(w.collections).toEqual([]);
+  });
+});

--- a/src/tools/dev/api-client-store.lib.ts
+++ b/src/tools/dev/api-client-store.lib.ts
@@ -1,0 +1,62 @@
+import type { RequestDef, Workspace, ResponseSnapshot, HistoryEntry } from './api-client.types';
+import { MAX_REQUEST_RESPONSES, MAX_HISTORY } from './api-client.types';
+
+export const STORAGE_KEY = 'gwt.api-client';
+
+export function defaultRequestDef(): RequestDef {
+  return {
+    id: crypto.randomUUID(),
+    name: 'New Request',
+    method: 'GET',
+    url: '',
+    params: [],
+    headers: [],
+    body: { mode: 'none' },
+    auth: { type: 'none' },
+    capture: null,
+    bindings: [],
+    responseHistory: [],
+  };
+}
+
+export function defaultWorkspace(): Workspace {
+  return {
+    collections: [],
+    envs: [],
+    activeEnvId: null,
+    activeCollectionId: null,
+    activeRequestId: null,
+    lastResponse: null,
+    history: [],
+  };
+}
+
+export function pushResponseToRequest(req: RequestDef, res: ResponseSnapshot): RequestDef {
+  return {
+    ...req,
+    responseHistory: [res, ...req.responseHistory].slice(0, MAX_REQUEST_RESPONSES),
+  };
+}
+
+export function addToHistory(w: Workspace, entry: HistoryEntry): Workspace {
+  return {
+    ...w,
+    history: [entry, ...w.history].slice(0, MAX_HISTORY),
+  };
+}
+
+export function loadWorkspace(): Workspace {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultWorkspace();
+    return JSON.parse(raw) as Workspace;
+  } catch {
+    return defaultWorkspace();
+  }
+}
+
+export function saveWorkspace(w: Workspace): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(w));
+  } catch { /* quota exceeded */ }
+}

--- a/src/tools/dev/api-client.types.ts
+++ b/src/tools/dev/api-client.types.ts
@@ -1,0 +1,86 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export type KV = { key: string; value: string; enabled: boolean };
+
+export type AuthDef =
+  | { type: 'none' }
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | { type: 'api-key'; header: string; value: string };
+
+export type BodyDef =
+  | { mode: 'none' }
+  | { mode: 'json'; content: string }
+  | { mode: 'form'; fields: KV[] }
+  | { mode: 'raw'; content: string; contentType: string };
+
+export type CaptureRule = { jsonPath: string; intoVar: string };
+
+export type VarSource =
+  | { type: 'env'; varName: string }
+  | { type: 'response'; requestId: string; jsonPath: string };
+
+export type VarBinding = { name: string; source: VarSource };
+
+export type ResponseSnapshot = {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  durationMs: number;
+};
+
+export const MAX_REQUEST_RESPONSES = 5;
+export const MAX_HISTORY = 50;
+export const SAVE_INTERVAL = 30;
+
+export type RequestDef = {
+  id: string;
+  name: string;
+  method: HttpMethod;
+  url: string;
+  params: KV[];
+  headers: KV[];
+  body: BodyDef;
+  auth: AuthDef;
+  capture: CaptureRule | null;
+  bindings: VarBinding[];
+  responseHistory: ResponseSnapshot[];
+};
+
+export type Folder = {
+  id: string;
+  name: string;
+  folders: Folder[];
+  requests: RequestDef[];
+};
+
+export type Collection = {
+  id: string;
+  name: string;
+  folders: Folder[];
+  requests: RequestDef[];
+};
+
+export type Environment = {
+  id: string;
+  name: string;
+  vars: Record<string, string>;
+};
+
+export type HistoryEntry = {
+  id: string;
+  ts: number;
+  req: RequestDef;
+  res: ResponseSnapshot;
+};
+
+export type Workspace = {
+  collections: Collection[];
+  envs: Environment[];
+  activeEnvId: string | null;
+  activeCollectionId: string | null;
+  activeRequestId: string | null;
+  lastResponse: ResponseSnapshot | null;
+  history: HistoryEntry[];
+};


### PR DESCRIPTION
## Summary

- **API Client tool** (`/tools/api-client`) — browser-based REST debugger, no vendor lock-in, no account required
- Imports Postman v2.1, Insomnia v4, OpenAPI 2/3 (JSON+YAML), and HAR files with auto-detection
- Exports back to Postman v2.1 + full workspace backup JSON
- Environment variables with `{{var}}` syntax; cross-request token chaining via `VarSource` (JSONPath from another request's saved response)
- Per-request response history ring (max 5, newest first); global history ring (max 50)
- Auto-save to localStorage — exact whiteboard countdown pattern (30s, amber chip, flush on visibility/pagehide/unload)
- Desktop: native HTTP via Tauri `http_request` command (reqwest, no CORS); Web: `fetch()` fallback with amber CORS warning banner
- Two-column layout with drag-resizable request/response split
- Bilingual SEO content (EN + ID)

## New files

| File | Purpose |
|------|---------|
| `src/tools/dev/api-client.types.ts` | Shared TypeScript types |
| `src/tools/dev/api-client-store.lib.ts` | localStorage CRUD + ring buffers |
| `src/tools/dev/api-client-import.lib.ts` | 5-format import parsers |
| `src/tools/dev/api-client-export.lib.ts` | 4-format exporters |
| `src/tools/dev/api-client-env.lib.ts` | `{{var}}` substitution, JSONPath, capture |
| `src/tools/dev/api-client-request.lib.ts` | `executeRequest()` with Tauri/fetch dispatch |
| `src/islands/dev/ApiClient.tsx` | Main island UI |
| `src-tauri/src/commands.rs` | `http_request` Rust command (reqwest) |

## Test plan

- [ ] `npx vitest run` — 915 tests, 0 failures
- [ ] `npm run lint` — 0 errors
- [ ] `npm run build` — completes, `/tools/api-client/index.html` present
- [ ] Import a Postman collection → requests appear in sidebar
- [ ] Import an OpenAPI YAML → requests generated from paths
- [ ] Send a GET request (web, CORS-friendly API like `httpbin.org`) → response shown
- [ ] Add env variable, reference with `{{var}}` in URL → substituted on send
- [ ] Edit request, wait 30s → amber chip counts down → auto-saves
- [ ] Click amber chip → saves immediately, chip → "✓ Saved"
- [ ] Reload page → workspace restored
- [ ] Export collection → valid Postman JSON downloaded
- [ ] Desktop app: send to any API → no CORS banner, full response

🤖 Generated with [Claude Code](https://claude.com/claude-code)