### PR TITLE
feat(dev): Regex Tester

### DIFF
--- a/docs/superpowers/plans/2026-08-13-regex-tester.md
+++ b/docs/superpowers/plans/2026-08-13-regex-tester.md
@@ -1,0 +1,61 @@
+# Regex Tester Implementation Plan
+
+> **For agentic workers:** implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship a client-side regex tester with live highlighting, capture groups, flags, and per-language code snippets + flavor warnings.
+
+**Architecture:** Pure lib `regex.lib.ts` (run + highlight + snippet + warnings); thin island `RegexTester.tsx`; registry + SEO. Native `RegExp` only — no new deps.
+
+**Tech Stack:** Astro + React island, Vitest, native JS `RegExp`.
+
+## Global Constraints
+
+- 100% client-side; matching on native `RegExp`.
+- New tool `status: 'beta'`; Dev category.
+- Bahasa copy uses "tool" loanword, never "alat".
+- Commit under the personal noreply identity; no AI-attribution trailers; no absolute machine paths in committed files.
+
+---
+
+### Task 1: Pure lib `regex.lib.ts` (TDD)
+
+**Files:** Create `src/tools/dev/regex.lib.ts`, Test `src/tools/dev/regex.lib.test.ts`.
+
+**Interfaces produced:**
+- `runRegex(pattern, flags, subject): { matches: RegexMatch[]; error?: string; truncated?: boolean }`
+- `RegexMatch = { index: number; value: string; groups: (string|undefined)[]; named: Record<string,string|undefined> }`
+- `escapeHtml(s): string`
+- `highlightHtml(subject, matches): string`
+- `codeSnippet(lang, pattern, flags): string`
+- `flavorWarnings(pattern, flags, lang): string[]`
+- `FLAGS`, `LANGUAGES`, type `RegexLang`
+
+- [ ] Write failing tests covering: match/no-match, numbered + named groups, flags g/i/m/s, global iteration + zero-width guard, invalid pattern → error; `highlightHtml` escaping + `<mark>`; `codeSnippet` for each of the 7 langs (pattern encoding + flag map) via `it.each`; `flavorWarnings` (Go lookbehind → warns, Go backref → warns, Python named group → warns, Ruby `s`-flag swap → warns, plain pattern → no warnings).
+- [ ] Run — confirm fail (module not found).
+- [ ] Implement lib.
+- [ ] Run — confirm pass.
+
+### Task 2: Island `RegexTester.tsx`
+
+**Files:** Create `src/islands/dev/RegexTester.tsx`.
+
+- [ ] Pattern `TextArea`, flag toggle-chips (segmented), subject `TextArea`. `useMemo` results on `[pattern, flags, subject]`. Highlighted `<pre>` via `dangerouslySetInnerHTML(highlightHtml)`. Match list (count, index, value, groups, named). Language `<select>` → `codeSnippet` in read-only block + `CopyButton`; `flavorWarnings` shown. i18n TR en+id. Error/empty/no-match states. SSR-safe.
+
+### Task 3: Register + SEO
+
+**Files:** Modify `src/registry/tools.ts`, `src/registry/tool-seo.ts`.
+
+- [ ] Import `Regex` icon; add the ToolDef.
+- [ ] Add EN + ID `regex-tester` SEO entries.
+
+### Task 4: Verify loop
+
+- [ ] `npx vitest run` green.
+- [ ] `npm run lint` 0 errors.
+- [ ] `npm run build` succeeds; `/tools/regex-tester` built (EN + ID).
+- [ ] Hand review: dangerouslySetInnerHTML input is always escaped first; zero-width/global infinite-loop guard; huge-input cap; reference-identity of derived props; error/empty paths.
+
+### Task 5: Ship dev → prod
+
+- [ ] Commit on `feat/regex-tester`, PR → develop, CI green, merge.
+- [ ] Promote develop → main (`--admin`), confirm Cloudflare prod build, verify live URL.

--- a/docs/superpowers/specs/2026-08-13-regex-tester-design.md
+++ b/docs/superpowers/specs/2026-08-13-regex-tester-design.md
@@ -1,0 +1,83 @@
+# Regex Tester — Design
+
+**Date:** 2026-08-13
+**Category:** Dev
+**Tool id:** `regex-tester`
+
+## Goal
+
+A live regular-expression tester: type a pattern + flags, test it against sample text, see matches highlighted inline, inspect capture groups (numbered + named), and get the **equivalent code snippet** for the language you actually use — plus honest warnings when your pattern relies on syntax that behaves differently in that language.
+
+## Honest engine model (decided with user)
+
+Browsers can only natively execute **JavaScript's `RegExp`**. Rather than pretend otherwise, matching always runs on the JS engine (zero deps, instant, private). The multi-language value comes from two pure, deterministic features layered on top:
+
+1. **Code-snippet generation** — render idiomatic "find all matches" code for the chosen language, embedding the user's pattern + mapped flags.
+2. **Flavor warnings** — detect pattern/flag constructs whose semantics differ in the target language and warn precisely (e.g. Go/RE2 has no lookbehind or backreferences; Python/Go name groups with `(?P<…>)`; Ruby's `m` flag means dotall, not multiline).
+
+Languages covered: **JavaScript, Python, PHP (PCRE), Java, Go, C#/.NET, Ruby.**
+
+Everything is client-side. Nothing is uploaded.
+
+## Architecture
+
+Mirrors the `sql-format` Dev tool (text input + option controls + live derived output, pure logic in a lib).
+
+### Pure lib — `src/tools/dev/regex.lib.ts`
+
+- `runRegex(pattern: string, flags: string, subject: string): RegexResult`
+  - `RegexResult = { matches: RegexMatch[]; error?: string; truncated?: boolean }`
+  - `RegexMatch = { index: number; value: string; groups: (string | undefined)[]; named: Record<string, string | undefined> }`
+  - `new RegExp(pattern, flags)` in try/catch → `{ matches: [], error }` on invalid pattern/flags.
+  - Global/sticky (`g`/`y`): iterate `exec`; guard zero-width matches by advancing `lastIndex`. Cap at `MAX_MATCHES = 10000` → set `truncated`.
+- `escapeHtml(s: string): string` — pure (`& < > "`).
+- `highlightHtml(subject: string, matches: RegexMatch[]): string` — escape subject, wrap non-zero-width match ranges in `<mark class="rx-hl">` / alternating `rx-hl-alt` for adjacent matches; injected via `dangerouslySetInnerHTML` in a `<pre>` (mirrors `CodeBlock`).
+- `FLAGS: { flag: string; label: string }[]` — g, i, m, s, u, y.
+- `LANGUAGES: { id: RegexLang; label: string }[]` — the 7 flavors.
+- `codeSnippet(lang: RegexLang, pattern: string, flags: string): string` — pure; per-language string-literal encoding (JS `/…/`, Python raw `r"…"`, PHP `/…/` with `/` escaped, Java double-quoted with `\`/`"` escaped, Go backtick raw with double-quoted fallback, C# verbatim `@"…"` with `"`→`""`, Ruby `/…/`) + flag mapping to each language's API.
+- `flavorWarnings(pattern: string, flags: string, lang: RegexLang): string[]` — pure heuristics: named-group syntax (Python/Go), lookbehind/lookahead + backreferences (Go/RE2), Ruby `m`/`s` flag-semantics swap, sticky `y` outside JS.
+
+All of the above are unit-tested.
+
+### Island — `src/islands/dev/RegexTester.tsx` (default export)
+
+- `TextArea` for pattern (single-ish line) + a segmented row of flag toggle-chips (`aria-pressed`) + `TextArea` for the test string.
+- Live results via `useMemo` on `[pattern, flags, subject]` (synchronous — no dynamic import needed).
+- **Highlighted subject** rendered from `highlightHtml` into a `<pre>` via `dangerouslySetInnerHTML`.
+- **Match list**: count, each match's index + value + numbered groups + named groups. Empty/error/ no-match states.
+- **Language panel**: native `<select>` (7 langs) → `codeSnippet` shown in a read-only block with `CopyButton`, plus any `flavorWarnings` as `Alert`s / muted notes.
+- i18n `TR: Record<Lang, {...}>`; signature `export default function RegexTester({ lang = 'en' }: { lang?: Lang })`.
+- SSR-safe (RegExp only touched inside `useMemo`/handlers, which is fine, but no module-scope DOM access).
+
+### Registry — `src/registry/tools.ts`
+
+```ts
+{
+  id: 'regex-tester',
+  name: 'Regex Tester',
+  category: 'Dev',
+  route: '/tools/regex-tester',
+  keywords: ['regex', 'regexp', 'regular expression', 'test', 'match', 'pattern', 'pcre', 'javascript', 'python', 'java', 'go'],
+  icon: Regex,
+  summary: 'Test regular expressions with live highlighting and per-language code',
+  load: () => import('@/islands/dev/RegexTester'),
+  status: 'beta'
+},
+```
+`Regex` imported from `lucide-react` (the icon exists; add to the import list).
+
+### SEO — `src/registry/tool-seo.ts`
+
+Add `regex-tester` to both the EN block (~line 9+) and the ID block (~line 1534+). Keyword targets: "regex tester", "test regular expression online", "regex match highlighter", "Python/Java/Go regex". Bahasa uses "tool" loanword, never "alat".
+
+### No new dependency, no globIgnores change
+
+Native `RegExp`; nothing heavy to code-split or exclude from the PWA precache.
+
+## Testing
+
+`src/tools/dev/regex.lib.test.ts` — `runRegex` (match, no-match, capture groups, named groups, each flag, global iteration, zero-width guard, invalid pattern → error), `highlightHtml` (escaping + mark wrapping), `codeSnippet` (per-language literal encoding + flag mapping, `it.each`), `flavorWarnings` (Go lookbehind/backref, Python/Go named groups, Ruby flag swap).
+
+## Definition of done
+
+Spec+plan committed · `regex.lib.ts` unit-tested · vitest + lint + build green · `/tools/regex-tester` builds (EN + ID) · merged to develop · promoted to main · Cloudflare prod build green · live URL verified · user told about PWA hard-refresh.

--- a/src/islands/dev/RegexTester.tsx
+++ b/src/islands/dev/RegexTester.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from 'react';
+import { TextArea } from '@/components/ui/TextArea';
+import { Alert } from '@/components/ui/Alert';
+import { CopyButton } from '@/components/ui/CopyButton';
+import {
+  runRegex,
+  highlightHtml,
+  codeSnippet,
+  flavorWarnings,
+  FLAGS,
+  LANGUAGES,
+  type RegexLang,
+} from '@/tools/dev/regex.lib';
+import type { Lang } from '@/i18n/config';
+
+const EXAMPLE_PATTERN = '(?<user>[\\w.]+)@(?<domain>[\\w.]+)';
+const EXAMPLE_SUBJECT =
+  'Contact: alice@example.com, bob@work.co.id\nSupport: team@goodwebtools.com\nInvalid: not-an-email @ nope';
+
+const TR: Record<Lang, {
+  intro: string;
+  pattern: string;
+  flags: string;
+  testString: string;
+  matchesN: (n: number) => string;
+  noMatches: string;
+  truncated: string;
+  groups: string;
+  named: string;
+  language: string;
+  equivalent: string;
+  notes: string;
+}> = {
+  en: {
+    intro: 'Test a regular expression against sample text with live match highlighting, then copy the equivalent code for your language. Everything runs in your browser.',
+    pattern: 'Regular expression',
+    flags: 'Flags',
+    testString: 'Test string',
+    matchesN: (n) => `${n} ${n === 1 ? 'match' : 'matches'}`,
+    noMatches: 'No matches.',
+    truncated: 'Showing the first 10,000 matches.',
+    groups: 'Groups',
+    named: 'Named',
+    language: 'Language',
+    equivalent: 'Equivalent code',
+    notes: 'Flavor notes',
+  },
+  id: {
+    intro: 'Uji ekspresi reguler terhadap teks contoh dengan sorotan kecocokan langsung, lalu salin kode setara untuk bahasa Anda. Semuanya berjalan di browser Anda.',
+    pattern: 'Ekspresi reguler',
+    flags: 'Flag',
+    testString: 'Teks uji',
+    matchesN: (n) => `${n} kecocokan`,
+    noMatches: 'Tidak ada kecocokan.',
+    truncated: 'Menampilkan 10.000 kecocokan pertama.',
+    groups: 'Grup',
+    named: 'Bernama',
+    language: 'Bahasa',
+    equivalent: 'Kode setara',
+    notes: 'Catatan flavor',
+  },
+};
+
+export default function RegexTester({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [pattern, setPattern] = useState(EXAMPLE_PATTERN);
+  const [flags, setFlags] = useState('g');
+  const [subject, setSubject] = useState(EXAMPLE_SUBJECT);
+  const [target, setTarget] = useState<RegexLang>('python');
+
+  const result = useMemo(() => runRegex(pattern, flags, subject), [pattern, flags, subject]);
+  const html = useMemo(() => highlightHtml(subject, result.matches), [subject, result]);
+  const snippet = useMemo(() => codeSnippet(target, pattern, flags), [target, pattern, flags]);
+  const warnings = useMemo(() => flavorWarnings(pattern, flags, target), [pattern, flags, target]);
+
+  const toggleFlag = (f: string) => {
+    setFlags(prev =>
+      prev.includes(f)
+        ? prev.replace(f, '')
+        : FLAGS.map(x => x.flag).filter(x => prev.includes(x) || x === f).join(''),
+    );
+  };
+
+  const chipClass = (active: boolean) =>
+    `border-2 px-3 py-1 font-mono text-sm font-medium transition-all ${
+      active
+        ? 'border-border bg-accent text-accent-foreground shadow-brutal'
+        : 'border-border hover:shadow-brutal'
+    }`;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="space-y-2">
+        <span className="block text-sm font-semibold">{t.pattern}</span>
+        <TextArea
+          value={pattern}
+          onChange={e => setPattern(e.target.value)}
+          rows={2}
+          spellCheck={false}
+          placeholder="\\d{4}-\\d{2}-\\d{2}"
+        />
+      </div>
+
+      <div className="space-y-1 text-sm">
+        <span className="block font-semibold">{t.flags}</span>
+        <div className="flex flex-wrap gap-1">
+          {FLAGS.map(({ flag, label }) => (
+            <button
+              key={flag}
+              type="button"
+              onClick={() => toggleFlag(flag)}
+              aria-pressed={flags.includes(flag)}
+              title={label}
+              className={chipClass(flags.includes(flag))}
+            >
+              {flag}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {result.error && <Alert variant="error">{result.error}</Alert>}
+
+      <div className="space-y-2">
+        <span className="block text-sm font-semibold">{t.testString}</span>
+        <TextArea
+          value={subject}
+          onChange={e => setSubject(e.target.value)}
+          rows={6}
+          spellCheck={false}
+        />
+      </div>
+
+      {subject && !result.error && (
+        <div className="space-y-2">
+          <span className="text-sm font-semibold">
+            {t.matchesN(result.matches.length)}
+            {result.truncated && ` · ${t.truncated}`}
+          </span>
+          <pre
+            className="overflow-x-auto whitespace-pre-wrap break-words border-2 border-border bg-muted p-3 font-mono text-sm [&_mark.rx-hl]:bg-accent [&_mark.rx-hl]:text-accent-foreground [&_mark.rx-hl-alt]:bg-yellow-300 [&_mark.rx-hl-alt]:dark:bg-yellow-500 [&_mark]:rounded-sm [&_mark]:px-0.5"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+      )}
+
+      {result.matches.length > 0 && (
+        <div className="max-h-64 space-y-2 overflow-y-auto border-2 border-border p-3">
+          {result.matches.map((m, i) => (
+            <div key={i} className="border-b border-border pb-2 text-sm last:border-0 last:pb-0">
+              <div className="flex flex-wrap items-baseline gap-x-3">
+                <span className="font-mono font-bold">#{i + 1}</span>
+                <span className="text-muted-foreground">@{m.index}</span>
+                <span className="font-mono">{m.value || '(empty)'}</span>
+              </div>
+              {m.groups.length > 0 && (
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {t.groups}: {m.groups.map((g, gi) => `$${gi + 1}=${g ?? '∅'}`).join('  ')}
+                </div>
+              )}
+              {Object.keys(m.named).length > 0 && (
+                <div className="text-xs text-muted-foreground">
+                  {t.named}: {Object.entries(m.named).map(([k, v]) => `${k}=${v ?? '∅'}`).join('  ')}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {subject && !result.error && result.matches.length === 0 && (
+        <p className="text-sm text-muted-foreground">{t.noMatches}</p>
+      )}
+
+      <div className="space-y-2 border-t-2 border-border pt-4">
+        <div className="flex flex-wrap items-end gap-x-6 gap-y-2">
+          <label className="space-y-1 text-sm">
+            <span className="block font-semibold">{t.language}</span>
+            <select
+              value={target}
+              onChange={e => setTarget(e.target.value as RegexLang)}
+              className="border-2 border-border bg-background px-2 py-1.5 text-sm"
+            >
+              {LANGUAGES.map(l => (
+                <option key={l.id} value={l.id}>{l.label}</option>
+              ))}
+            </select>
+          </label>
+          <span className="mr-auto text-sm font-semibold">{t.equivalent}</span>
+          <CopyButton value={snippet} />
+        </div>
+        <TextArea value={snippet} readOnly rows={8} spellCheck={false} />
+        {warnings.length > 0 && (
+          <div className="space-y-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t.notes}</span>
+            {warnings.map((warn, i) => (
+              <p key={i} className="text-sm text-amber-700 dark:text-amber-400">⚠ {warn}</p>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -41,6 +41,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it validate or run my query?', a: 'No. It only formats the text for readability; it does not execute, validate or connect to any database.' },
     ],
   },
+  'regex-tester': {
+    title: 'Free Regex Tester — Test Regular Expressions Online',
+    description: 'A free online regex tester with live match highlighting, capture groups and flags. Get the equivalent code for JavaScript, Python, PHP, Java, Go, C# and Ruby. Runs in your browser — nothing is uploaded.',
+    intro: 'This free regex tester lets you build and debug regular expressions against your own sample text, with matches highlighted live as you type. Inspect numbered and named capture groups, toggle flags, and copy the equivalent code for the language you actually use — JavaScript, Python, PHP (PCRE), Java, Go, C#/.NET or Ruby — with warnings when a pattern behaves differently in that flavor. Matching runs entirely on your device.',
+    howTo: [
+      'Type your regular expression and toggle the flags you need (g, i, m, s, u, y).',
+      'Paste the text you want to test against — matches highlight instantly.',
+      'Check the match list for capture groups, named groups and positions.',
+      'Pick a language to copy ready-to-use code, and read the flavor notes for cross-language gotchas.',
+    ],
+    faqs: [
+      { q: 'Which regex engine does the tester use?', a: 'Matching runs on your browser\'s native JavaScript regular-expression engine, so results are instant and your data never leaves your device. For other languages we generate the equivalent code and warn about syntax that behaves differently.' },
+      { q: 'Does it support Python, Java, Go and PHP regex?', a: 'Yes — pick your language to get an idiomatic code snippet (Python re, PHP PCRE, Java Pattern, Go regexp, C# Regex, Ruby) with the flags mapped correctly, plus notes on differences like Go\'s lack of lookbehind or Python\'s (?P<name>) group syntax.' },
+      { q: 'Are my patterns or test data sent to a server?', a: 'No. Everything runs locally in your browser, so it is safe to test against private logs, emails or other sensitive text.' },
+      { q: 'What do the flags mean?', a: 'g = global (find all), i = ignore case, m = multiline (^ and $ per line), s = dotall (dot matches newlines), u = unicode, y = sticky. Toggle them and the highlighting updates instantly.' },
+      { q: 'Does it show capture groups?', a: 'Yes. Each match lists its numbered capture groups ($1, $2, …) and any named groups, along with the match position in the text.' },
+    ],
+  },
   'compare-lists': {
     title: 'Compare Two Lists — Merge, Dedupe & Diff Lines',
     description: 'Compare two lists of lines online: merge and remove duplicates, subtract one list from another, or find common lines. Free, private and instant — nothing is uploaded.',
@@ -1564,6 +1582,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Dialek SQL apa saja yang didukung?', a: 'Standard SQL ditambah PostgreSQL, MySQL, MariaDB, SQLite, SQL Server (T-SQL), Oracle (PL/SQL), BigQuery, Snowflake, Redshift, Spark, DuckDB, ClickHouse, Db2, Hive, dan Trino.' },
       { q: 'Bisakah membuat kata kunci huruf besar atau kecil?', a: 'Ya — pilih BESAR untuk mengapitalkan kata kunci seperti SELECT dan FROM, kecil untuk membuatnya huruf kecil, atau Biarkan agar tetap seperti aslinya.' },
       { q: 'Apakah memvalidasi atau menjalankan kueri saya?', a: 'Tidak. Ini hanya memformat teks agar mudah dibaca; tidak menjalankan, memvalidasi, atau terhubung ke basis data apa pun.' },
+    ],
+  },
+  'regex-tester': {
+    title: 'Tool Regex Tester Gratis — Uji Regular Expression Online',
+    description: 'Tool regex tester online gratis dengan sorotan kecocokan langsung, capture group, dan flag. Dapatkan kode setara untuk JavaScript, Python, PHP, Java, Go, C#, dan Ruby. Berjalan di browser Anda — tidak ada yang diunggah.',
+    intro: 'Tool regex tester gratis ini membantu Anda menyusun dan men-debug ekspresi reguler terhadap teks contoh Anda sendiri, dengan kecocokan disorot langsung saat Anda mengetik. Periksa capture group bernomor dan bernama, aktifkan flag, dan salin kode setara untuk bahasa yang Anda pakai — JavaScript, Python, PHP (PCRE), Java, Go, C#/.NET, atau Ruby — lengkap dengan peringatan bila sebuah pola berperilaku berbeda di flavor tersebut. Pencocokan berjalan sepenuhnya di perangkat Anda.',
+    howTo: [
+      'Ketik ekspresi reguler Anda dan aktifkan flag yang diperlukan (g, i, m, s, u, y).',
+      'Tempel teks yang ingin diuji — kecocokan langsung tersorot.',
+      'Lihat daftar kecocokan untuk capture group, grup bernama, dan posisinya.',
+      'Pilih bahasa untuk menyalin kode siap pakai, dan baca catatan flavor untuk perbedaan antarbahasa.',
+    ],
+    faqs: [
+      { q: 'Mesin regex apa yang dipakai tool ini?', a: 'Pencocokan berjalan pada mesin ekspresi reguler JavaScript bawaan browser Anda, jadi hasilnya instan dan data Anda tidak pernah meninggalkan perangkat. Untuk bahasa lain, kami menghasilkan kode setara dan memperingatkan sintaks yang berperilaku berbeda.' },
+      { q: 'Apakah mendukung regex Python, Java, Go, dan PHP?', a: 'Ya — pilih bahasa Anda untuk mendapatkan snippet kode idiomatik (Python re, PHP PCRE, Java Pattern, Go regexp, C# Regex, Ruby) dengan flag yang dipetakan dengan benar, ditambah catatan perbedaan seperti Go yang tidak mendukung lookbehind atau sintaks grup (?P<name>) di Python.' },
+      { q: 'Apakah pola atau data uji saya dikirim ke server?', a: 'Tidak. Semuanya berjalan lokal di browser Anda, jadi aman untuk menguji log, email, atau teks sensitif lainnya.' },
+      { q: 'Apa arti flag-nya?', a: 'g = global (cari semua), i = abaikan huruf besar/kecil, m = multiline (^ dan $ per baris), s = dotall (titik mencocokkan baris baru), u = unicode, y = sticky. Aktifkan dan sorotan langsung diperbarui.' },
+      { q: 'Apakah menampilkan capture group?', a: 'Ya. Setiap kecocokan menampilkan capture group bernomor ($1, $2, …) dan grup bernama, beserta posisi kecocokan dalam teks.' },
     ],
   },
   'compare-lists': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -188,6 +188,17 @@ export const tools: ToolDef[] = [
     icon: Database,
     summary: 'Format and beautify SQL queries (PostgreSQL, MySQL, and more)',
     load: () => import('@/islands/dev/SqlFormat'),
+    status: 'beta'
+  },
+  {
+    id: 'regex-tester',
+    name: 'Regex Tester',
+    category: 'Dev',
+    route: '/tools/regex-tester',
+    keywords: ['regex', 'regexp', 'regular expression', 'test', 'match', 'pattern', 'pcre', 'javascript', 'python', 'java', 'go'],
+    icon: Regex,
+    summary: 'Test regular expressions with live highlighting and per-language code',
+    load: () => import('@/islands/dev/RegexTester'),
     status: 'beta'
   },
   {

--- a/src/tools/dev/regex.lib.test.ts
+++ b/src/tools/dev/regex.lib.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  runRegex,
+  escapeHtml,
+  highlightHtml,
+  codeSnippet,
+  flavorWarnings,
+} from './regex.lib';
+
+describe('runRegex', () => {
+  it('finds a single match with index and value', () => {
+    const r = runRegex('b(a)r', '', 'foo bar baz');
+    expect(r.error).toBeUndefined();
+    expect(r.matches).toHaveLength(1);
+    expect(r.matches[0].value).toBe('bar');
+    expect(r.matches[0].index).toBe(4);
+    expect(r.matches[0].groups).toEqual(['a']);
+  });
+
+  it('finds all matches with the global flag', () => {
+    const r = runRegex('\\d+', 'g', 'a1 b22 c333');
+    expect(r.matches.map(m => m.value)).toEqual(['1', '22', '333']);
+    expect(r.matches.map(m => m.index)).toEqual([1, 4, 8]);
+  });
+
+  it('captures named groups', () => {
+    const r = runRegex('(?<year>\\d{4})-(?<month>\\d{2})', '', '2026-08');
+    expect(r.matches[0].named).toEqual({ year: '2026', month: '08' });
+  });
+
+  it('honors the case-insensitive flag', () => {
+    expect(runRegex('abc', '', 'ABC').matches).toHaveLength(0);
+    expect(runRegex('abc', 'i', 'ABC').matches).toHaveLength(1);
+  });
+
+  it('does not infinite-loop on a zero-width global match', () => {
+    const r = runRegex('a*', 'g', 'aa b');
+    // Zero-width matches are allowed but the loop must terminate.
+    expect(r.error).toBeUndefined();
+    expect(r.matches.length).toBeGreaterThan(0);
+    expect(r.matches.length).toBeLessThan(50);
+  });
+
+  it('returns an error for an invalid pattern', () => {
+    const r = runRegex('(', '', 'x');
+    expect(r.matches).toHaveLength(0);
+    expect(r.error).toBeTruthy();
+  });
+
+  it('returns an error for an invalid flag', () => {
+    const r = runRegex('a', 'Z', 'a');
+    expect(r.error).toBeTruthy();
+  });
+
+  it('returns no matches for empty subject without error', () => {
+    const r = runRegex('a', 'g', '');
+    expect(r.error).toBeUndefined();
+    expect(r.matches).toHaveLength(0);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes the dangerous characters', () => {
+    expect(escapeHtml('<a href="x">&')).toBe('&lt;a href=&quot;x&quot;&gt;&amp;');
+  });
+});
+
+describe('highlightHtml', () => {
+  it('wraps matches in <mark> and escapes the rest', () => {
+    const r = runRegex('X', 'g', 'a<X>b');
+    const html = highlightHtml('a<X>b', r.matches);
+    expect(html).toContain('&lt;');
+    expect(html).toContain('<mark');
+    expect(html).toContain('>X</mark>');
+  });
+
+  it('returns escaped text with no marks when there are no matches', () => {
+    expect(highlightHtml('a&b', [])).toBe('a&amp;b');
+  });
+});
+
+describe('codeSnippet', () => {
+  it.each([
+    ['javascript', /\/\\d\+\/g|new RegExp/],
+    ['python', /import re|re\.compile/],
+    ['php', /preg_match_all/],
+    ['java', /Pattern\.compile/],
+    ['go', /regexp\.MustCompile/],
+    ['csharp', /new Regex/],
+    ['ruby', /scan|=~|\/\\d\+\//],
+  ] as const)('generates %s code containing the expected API', (lang, re) => {
+    const code = codeSnippet(lang, '\\d+', 'g');
+    expect(code).toMatch(re);
+  });
+
+  it('maps the case-insensitive flag per language', () => {
+    expect(codeSnippet('python', 'a', 'i')).toMatch(/IGNORECASE/);
+    expect(codeSnippet('java', 'a', 'i')).toMatch(/CASE_INSENSITIVE/);
+    expect(codeSnippet('csharp', 'a', 'i')).toMatch(/IgnoreCase/);
+  });
+});
+
+describe('flavorWarnings', () => {
+  it('warns that Go/RE2 has no lookbehind', () => {
+    expect(flavorWarnings('(?<=x)y', '', 'go').join(' ')).toMatch(/lookbehind|RE2/i);
+  });
+
+  it('warns that Go/RE2 has no backreferences', () => {
+    expect(flavorWarnings('(a)\\1', '', 'go').join(' ')).toMatch(/backreference/i);
+  });
+
+  it('warns Python uses (?P<name>) for named groups', () => {
+    expect(flavorWarnings('(?<name>x)', '', 'python').join(' ')).toMatch(/\(\?P<|named group/i);
+  });
+
+  it('warns about Ruby dotall flag semantics', () => {
+    expect(flavorWarnings('a.b', 's', 'ruby').join(' ')).toMatch(/dotall|multiline|Ruby/i);
+  });
+
+  it('returns no warnings for a plain pattern in its native language', () => {
+    expect(flavorWarnings('\\d+', 'g', 'javascript')).toEqual([]);
+  });
+});

--- a/src/tools/dev/regex.lib.ts
+++ b/src/tools/dev/regex.lib.ts
@@ -1,0 +1,263 @@
+/**
+ * Regex tester core — pure, framework-free logic.
+ *
+ * Matching runs on the native JavaScript `RegExp` engine (the only regex
+ * engine a browser can execute). The multi-language features are honest
+ * layers on top: `codeSnippet` renders idiomatic code for other languages,
+ * and `flavorWarnings` flags syntax whose meaning differs in that flavor.
+ */
+
+export type RegexLang = 'javascript' | 'python' | 'php' | 'java' | 'go' | 'csharp' | 'ruby';
+
+export interface RegexMatch {
+  index: number;
+  value: string;
+  /** Numbered capture groups (1..n); `undefined` for groups that didn't match. */
+  groups: (string | undefined)[];
+  /** Named capture groups. */
+  named: Record<string, string | undefined>;
+}
+
+export interface RegexResult {
+  matches: RegexMatch[];
+  error?: string;
+  /** Set when the match count hit the cap. */
+  truncated?: boolean;
+}
+
+const MAX_MATCHES = 10000;
+
+export const FLAGS: { flag: string; label: string }[] = [
+  { flag: 'g', label: 'global' },
+  { flag: 'i', label: 'ignore case' },
+  { flag: 'm', label: 'multiline' },
+  { flag: 's', label: 'dotall' },
+  { flag: 'u', label: 'unicode' },
+  { flag: 'y', label: 'sticky' },
+];
+
+export const LANGUAGES: { id: RegexLang; label: string }[] = [
+  { id: 'javascript', label: 'JavaScript' },
+  { id: 'python', label: 'Python' },
+  { id: 'php', label: 'PHP (PCRE)' },
+  { id: 'java', label: 'Java' },
+  { id: 'go', label: 'Go' },
+  { id: 'csharp', label: 'C# / .NET' },
+  { id: 'ruby', label: 'Ruby' },
+];
+
+/** Run `pattern`/`flags` against `subject`, returning matches or an error. */
+export function runRegex(pattern: string, flags: string, subject: string): RegexResult {
+  if (!pattern) return { matches: [] };
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern, flags);
+  } catch (e) {
+    return { matches: [], error: e instanceof Error ? e.message : 'Invalid regular expression' };
+  }
+
+  const matches: RegexMatch[] = [];
+  const global = re.global || re.sticky;
+
+  const push = (m: RegExpExecArray) => {
+    matches.push({
+      index: m.index,
+      value: m[0],
+      groups: m.slice(1),
+      named: m.groups ? { ...m.groups } : {},
+    });
+  };
+
+  try {
+    if (!global) {
+      const m = re.exec(subject);
+      if (m) push(m);
+      return { matches };
+    }
+    let m: RegExpExecArray | null;
+    let truncated = false;
+    while ((m = re.exec(subject)) !== null) {
+      push(m);
+      // Guard against zero-width matches looping forever.
+      if (m.index === re.lastIndex) re.lastIndex += 1;
+      if (matches.length >= MAX_MATCHES) {
+        truncated = true;
+        break;
+      }
+    }
+    return truncated ? { matches, truncated } : { matches };
+  } catch (e) {
+    return { matches, error: e instanceof Error ? e.message : 'Matching failed' };
+  }
+}
+
+/** Escape the five characters that matter inside HTML text/attribute content. */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Build HTML for the subject with each (non-zero-width) match wrapped in a
+ * `<mark>`. The subject is escaped first, so the result is safe to inject via
+ * `dangerouslySetInnerHTML`. Adjacent matches alternate class for contrast.
+ */
+export function highlightHtml(subject: string, matches: RegexMatch[]): string {
+  const ranges = matches
+    .filter(m => m.value.length > 0)
+    .map(m => ({ start: m.index, end: m.index + m.value.length }))
+    .sort((a, b) => a.start - b.start);
+
+  let html = '';
+  let cursor = 0;
+  let alt = false;
+  for (const { start, end } of ranges) {
+    if (start < cursor) continue; // skip overlaps
+    html += escapeHtml(subject.slice(cursor, start));
+    const cls = alt ? 'rx-hl rx-hl-alt' : 'rx-hl';
+    html += `<mark class="${cls}">${escapeHtml(subject.slice(start, end))}</mark>`;
+    cursor = end;
+    alt = !alt;
+  }
+  html += escapeHtml(subject.slice(cursor));
+  return html;
+}
+
+// --- Per-language string-literal encoders -------------------------------------
+
+/** Escape `/` that is not already backslash-escaped (respecting escape runs). */
+function escapeDelimiter(pattern: string, delim: string): string {
+  let out = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === '\\') {
+      out += c + (pattern[i + 1] ?? '');
+      i++;
+      continue;
+    }
+    out += c === delim ? '\\' + c : c;
+  }
+  return out;
+}
+
+/** Encode into a double-quoted literal (backslash + quote escaped). */
+function doubleQuoted(pattern: string): string {
+  return pattern.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// --- Flag mapping -------------------------------------------------------------
+
+function has(flags: string, f: string): boolean {
+  return flags.includes(f);
+}
+
+function mapFlags(flags: string, table: Record<string, string>, joiner: string): string {
+  const parts: string[] = [];
+  for (const f of Object.keys(table)) if (has(flags, f)) parts.push(table[f]);
+  return parts.join(joiner);
+}
+
+/** Inline-flag string for engines that take `(?ims)` prefixes (Go). */
+function inlineFlags(flags: string): string {
+  const s = ['i', 'm', 's'].filter(f => has(flags, f)).join('');
+  return s ? `(?${s})` : '';
+}
+
+// --- Code snippet generation --------------------------------------------------
+
+/** Generate an idiomatic "find all matches" snippet for `lang`. */
+export function codeSnippet(lang: RegexLang, pattern: string, flags: string): string {
+  const p = pattern || '';
+  switch (lang) {
+    case 'javascript': {
+      const f = flags || '';
+      const iter = has(f, 'g')
+        ? `for (const m of text.matchAll(re)) {\n  console.log(m[0], m.index, m.groups);\n}`
+        : `const m = re.exec(text);\nif (m) console.log(m[0], m.index, m.groups);`;
+      return `const re = /${escapeDelimiter(p, '/')}/${f};\n// text = your input string\n${iter}`;
+    }
+    case 'python': {
+      const opts = mapFlags(flags, { i: 're.IGNORECASE', m: 're.MULTILINE', s: 're.DOTALL', x: 're.VERBOSE' }, ' | ');
+      const arg = opts ? `, ${opts}` : '';
+      return `import re\n\npattern = re.compile(r"${p.replace(/"/g, '\\"')}"${arg})\nfor m in pattern.finditer(text):\n    print(m.group(), m.start(), m.groupdict())`;
+    }
+    case 'php': {
+      const mods = ['i', 'm', 's', 'u', 'x'].filter(f => has(flags, f)).join('');
+      return `<?php\npreg_match_all('/${escapeDelimiter(p, '/')}/${mods}', $text, $matches, PREG_OFFSET_CAPTURE);\nprint_r($matches);`;
+    }
+    case 'java': {
+      const opts = mapFlags(flags, {
+        i: 'Pattern.CASE_INSENSITIVE',
+        m: 'Pattern.MULTILINE',
+        s: 'Pattern.DOTALL',
+        u: 'Pattern.UNICODE_CASE',
+        x: 'Pattern.COMMENTS',
+      }, ' | ');
+      const arg = opts ? `, ${opts}` : '';
+      return `import java.util.regex.*;\n\nPattern p = Pattern.compile("${doubleQuoted(p)}"${arg});\nMatcher m = p.matcher(text);\nwhile (m.find()) {\n    System.out.println(m.group() + " @ " + m.start());\n}`;
+    }
+    case 'go': {
+      const prefix = inlineFlags(flags);
+      const body = prefix + p;
+      // Backtick raw literal unless the pattern contains a backtick.
+      const lit = body.includes('`') ? `"${doubleQuoted(body)}"` : '`' + body + '`';
+      return `package main\n\nimport (\n\t"fmt"\n\t"regexp"\n)\n\nfunc main() {\n\tre := regexp.MustCompile(${lit})\n\tfor _, m := range re.FindAllString(text, -1) {\n\t\tfmt.Println(m)\n\t}\n}`;
+    }
+    case 'csharp': {
+      const opts = mapFlags(flags, {
+        i: 'RegexOptions.IgnoreCase',
+        m: 'RegexOptions.Multiline',
+        s: 'RegexOptions.Singleline',
+        x: 'RegexOptions.IgnorePatternWhitespace',
+      }, ' | ');
+      const arg = opts ? `, ${opts}` : '';
+      return `using System.Text.RegularExpressions;\n\nvar re = new Regex(@"${p.replace(/"/g, '""')}"${arg});\nforeach (Match m in re.Matches(text))\n    Console.WriteLine($"{m.Value} @ {m.Index}");`;
+    }
+    case 'ruby': {
+      // Ruby: /m means dotall; JS `s` maps to Ruby `m`. JS `m` has no Ruby flag.
+      const mods = (has(flags, 'i') ? 'i' : '') + (has(flags, 's') ? 'm' : '') + (has(flags, 'x') ? 'x' : '');
+      return `re = /${escapeDelimiter(p, '/')}/${mods}\ntext.scan(re) { puts Regexp.last_match.inspect }`;
+    }
+  }
+}
+
+// --- Flavor warnings ----------------------------------------------------------
+
+const HAS_LOOKBEHIND = /\(\?<[=!]/;
+const HAS_LOOKAHEAD = /\(\?[=!]/;
+const HAS_NAMED_GROUP = /\(\?<[A-Za-z_]/;
+const HAS_BACKREF = /\\[1-9]|\\k</;
+
+/** Heuristic warnings about pattern/flag constructs that differ in `lang`. */
+export function flavorWarnings(pattern: string, flags: string, lang: RegexLang): string[] {
+  const w: string[] = [];
+  const namedGroup = HAS_NAMED_GROUP.test(pattern);
+  const lookbehind = HAS_LOOKBEHIND.test(pattern);
+  const lookahead = HAS_LOOKAHEAD.test(pattern);
+  const backref = HAS_BACKREF.test(pattern);
+
+  if (lang === 'go') {
+    if (lookbehind) w.push("Go's RE2 engine does not support lookbehind — this pattern will not compile as-is.");
+    if (lookahead) w.push("Go's RE2 engine does not support lookahead — this pattern will not compile as-is.");
+    if (backref) w.push('Go\'s RE2 engine does not support backreferences.');
+    if (namedGroup) w.push('Go names groups with (?P<name>…), not (?<name>…).');
+  }
+
+  if (lang === 'python') {
+    if (namedGroup) w.push('Python names groups with (?P<name>…), not (?<name>…).');
+  }
+
+  if (lang === 'ruby') {
+    if (has(flags, 's')) w.push('Ruby has no “dotall” flag — its /m flag makes the dot match newlines, so JS “s” maps to Ruby “m”.');
+    if (has(flags, 'm')) w.push('Ruby has no “multiline” flag; ^ and $ already match at line boundaries by default (JS “m” has no Ruby equivalent).');
+  }
+
+  if (has(flags, 'y') && lang !== 'javascript') {
+    w.push('The sticky (y) flag is JavaScript-specific; other languages anchor matches through their APIs instead.');
+  }
+
+  return w;
+}


### PR DESCRIPTION
Adds a client-side **Regex Tester** (`/tools/regex-tester`).

- Live match highlighting, capture groups (numbered + named), flag toggles (g/i/m/s/u/y) — runs on the native JS `RegExp` engine, nothing uploaded.
- **Multi-language code generation**: JavaScript, Python, PHP (PCRE), Java, Go, C#/.NET, Ruby — with correct flag mapping and **flavor warnings** (e.g. Go/RE2 has no lookbehind/backrefs; Python/Go use `(?P<name>)`; Ruby's `m` = dotall).
- Pure lib `regex.lib.ts` unit-tested (24 cases); full suite + lint + build green.
- EN + ID SEO entries.