### PR TITLE
feat(dev): QRIS Decoder

### DIFF
--- a/docs/superpowers/plans/2026-08-14-qris-decoder.md
+++ b/docs/superpowers/plans/2026-08-14-qris-decoder.md
@@ -1,0 +1,57 @@
+# QRIS Decoder Implementation Plan
+
+> **For agentic workers:** implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship a client-side QRIS (EMVCo) decoder: paste payload or QR image → summary + full TLV tree.
+
+**Architecture:** Pure lib `qris.lib.ts` (CRC + TLV parse + summary); thin island `QrisDecoder.tsx` (jsQR image decode + render); registry + EN/ID SEO. No new deps.
+
+**Tech Stack:** Astro + React island, Vitest, native JS, `jsqr` (already installed) for the image path.
+
+## Global Constraints
+
+- 100% client-side; parser is pure JS; image decode via already-installed `jsqr` (dynamic import).
+- New tool `status: 'beta'`; Dev category; icon `Wallet`.
+- SEO REQUIRED in EN + ID with `howTo`; Bahasa "tool" loanword, technical terms kept.
+- Commit under personal noreply identity; no AI-attribution trailers; no absolute machine paths.
+
+---
+
+### Task 1: Pure lib `qris.lib.ts` (TDD)
+
+**Files:** Create `src/tools/dev/qris.lib.ts`, Test `src/tools/dev/qris.lib.test.ts`.
+
+**Interfaces produced:**
+- `crc16(input: string): string`
+- `Tlv = { id: string; length: number; value: string; name: string; children?: Tlv[] }`
+- `parseTlv(s: string): Tlv[]`
+- `parseQris(payload: string): { summary: QrisSummary; tree: Tlv[] }`
+- `QrisSummary` (fields per spec)
+
+- [ ] Failing tests: `crc16('123456789')==='29B1'`; `parseTlv('000201')` → one `{id:'00',length:2,value:'01'}`; nested tag 26 → children; malformed (`'0002'` truncated / bad len) → throws; `parseQris(<hand-built ASCII QRIS>)` → merchantName 'TOKO BUDI', city 'JAKARTA', nmid 'ID1020012345678', amount '12345', mcc '5411', currency '360', initiationMethod 'static', crcValid true; tampered last char → crcValid false; `parseQris('garbage!!')` → throws.
+- [ ] Run — confirm fail.
+- [ ] Implement lib (CRC-16/CCITT-FALSE; recursive TLV with nested templates 26–51/62/64; summary extraction incl. NMID from merchant-account sub-tag 02).
+- [ ] Run — confirm pass.
+
+### Task 2: Island `QrisDecoder.tsx`
+
+**Files:** Create `src/islands/dev/QrisDecoder.tsx`.
+
+- [ ] `TextArea` payload + `Dropzone` image + `usePasteImage`. Image → canvas → `getImageData` → `await import('jsqr')` → `.data` → setPayload. `useMemo` parse → result/error. Summary rows + CRC badge + `CopyButton`. Recursive TLV tree (indented children). i18n TR en+id. SSR-safe.
+
+### Task 3: Register + SEO
+
+**Files:** Modify `src/registry/tools.ts`, `src/registry/tool-seo.ts`.
+
+- [ ] Import `Wallet`; add ToolDef.
+- [ ] Add EN + ID `qris-decoder` SEO entries (title/description/intro/howTo/faqs).
+
+### Task 4: Verify loop
+
+- [ ] `npx vitest run` green · `npm run lint` 0 errors · `npm run build` succeeds; `/tools/qris-decoder` + `/id/…` built.
+- [ ] Hand review: parser rejects malformed without hanging; CRC path; SSR; empty/partial payload; reference-identity of derived props.
+
+### Task 5: Ship dev → prod
+
+- [ ] Commit on `feat/qris-decoder`, PR → develop, CI green, merge.
+- [ ] Promote develop → main (`--admin`), confirm Cloudflare prod build, verify live URL.

--- a/docs/superpowers/specs/2026-08-14-qris-decoder-design.md
+++ b/docs/superpowers/specs/2026-08-14-qris-decoder-design.md
@@ -1,0 +1,81 @@
+# QRIS Decoder — Design
+
+**Date:** 2026-08-14
+**Category:** Dev
+**Tool id:** `qris-decoder`
+
+## Goal
+
+Decode an Indonesian QRIS code (EMVCo Merchant-Presented Mode QR) entirely in the browser and show the human-readable fields: merchant name, **NMID** (National Merchant ID), merchant city, amount, MCC, currency, static vs dynamic, acquirer, and **CRC validity** — plus a full tag-by-tag TLV breakdown. Nothing is uploaded.
+
+## Input (confirmed with user)
+
+- **Paste the payload string** (`00020101...`), OR
+- **Drop / paste a QRIS QR image** → decode to the payload with `jsQR` (already a dependency; same engine as the existing QR Code Reader), then parse.
+
+## Detail level (confirmed)
+
+- **Summary** card of the key fields, plus an **expandable full TLV tree** (nested merchant-account template 26–51, additional-data template 62, language template 64).
+
+## EMVCo / QRIS parsing (the core knowledge)
+
+The payload is EMVCo TLV: each object is `ID(2) + LEN(2, decimal) + VALUE(LEN)`, concatenated. Root tags:
+- `00` Payload Format Indicator · `01` Point of Initiation Method (`11`=static, `12`=dynamic)
+- `26`–`51` Merchant Account Information (nested) — for QRIS: sub `00`=Globally Unique Identifier (e.g. `ID.CO.QRIS.WWW`), `01`=Merchant PAN, `02`=**NMID**, `03`=Merchant Criteria (UMI/UKE/UBE/URE)
+- `52` MCC · `53` Currency (`360`=IDR) · `54` Amount · `55`–`57` tip/convenience
+- `58` Country · `59` Merchant Name · `60` Merchant City · `61` Postal Code
+- `62` Additional Data (nested: `01` bill, `05` reference, `07` terminal, …)
+- `63` CRC · `64` Merchant Info — Language Template (nested)
+
+**CRC** is CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`) over the whole payload up to and including the CRC tag+length (`6304`), compared to the trailing 4 hex chars. Pinned by the standard check vector: `crc16('123456789') === '29B1'`.
+
+## Architecture
+
+### Pure lib — `src/tools/dev/qris.lib.ts` (framework-free, unit-tested)
+
+- `crc16(input: string): string` — CRC-16/CCITT-FALSE, 4 upper-hex chars.
+- `parseTlv(s: string): Tlv[]` — flat parse; throws on malformed (bad length / overrun). Nested templates parsed recursively (best-effort; a value that isn't clean TLV stays a leaf).
+- `TAG_NAMES`, `SUBTAG_NAMES` — dictionaries; `Tlv = { id, length, value, name, children? }`.
+- `parseQris(payload: string): { summary: QrisSummary; tree: Tlv[] }` — trims input, builds the tree, derives the summary, validates CRC. **Throws only on structurally invalid TLV**; a bad CRC is reported (`crcValid: false`), not thrown.
+- `QrisSummary = { payloadFormat?, initiationMethod: 'static'|'dynamic'|'unknown', merchantName?, merchantCity?, postalCode?, countryCode?, currency?, amount?, mcc?, nmid?, merchantPan?, merchantCriteria?, acquirer?, crc?, crcValid }`.
+
+### Island — `src/islands/dev/QrisDecoder.tsx` (default export)
+
+- `TextArea` for the payload + `Dropzone accept="image/*"` (and `usePasteImage`) → canvas → `getImageData` → `await import('jsqr')` → `jsQR(...).data` → set payload. (Mirrors `QrRead.tsx`.)
+- `useMemo` parse on the trimmed payload → result or error (`Alert`).
+- **Summary** rendered as label→value rows (merchant, NMID, city, amount+currency, MCC, static/dynamic, acquirer) with a green/red **CRC valid** badge, plus a `CopyButton` for the payload.
+- **Full TLV tree**: recursive labeled rows (`id · name` → value), children indented — modeled on `CronExplainer`'s labeled field boxes.
+- i18n `TR` en + id (Bahasa: "tool" loanword, technical terms QRIS/NMID/MCC/CRC kept as-is). Signature `export default function QrisDecoder({ lang = 'en' }: { lang?: Lang })`. SSR-safe (jsQR + canvas only in handlers).
+
+### Registry — `src/registry/tools.ts`
+
+```ts
+{
+  id: 'qris-decoder',
+  name: 'QRIS Decoder',
+  category: 'Dev',
+  route: '/tools/qris-decoder',
+  keywords: ['qris', 'qr', 'emvco', 'payment', 'decode', 'nmid', 'merchant', 'indonesia', 'tlv'],
+  icon: Wallet,
+  summary: 'Decode a QRIS payment code — merchant, NMID, city, amount',
+  load: () => import('@/islands/dev/QrisDecoder'),
+  status: 'beta'
+},
+```
+`Wallet` imported from `lucide-react` (exists).
+
+### SEO — `src/registry/tool-seo.ts` (REQUIRED, both locales)
+
+EN + ID `qris-decoder` with title/description/intro/**howTo**/faqs. Keywords: "QRIS decoder", "cek QRIS", "decode QRIS", "NMID QRIS", "baca QRIS". Bahasa uses "tool" loanword.
+
+### No new dependency, no globIgnores change
+
+`jsQR` is already installed and dynamic-imported; the parser is pure JS.
+
+## Testing
+
+`src/tools/dev/qris.lib.test.ts` — `crc16('123456789')==='29B1'`; `parseTlv` flat + nested + malformed-throws; `parseQris` on a hand-built ASCII QRIS (assert merchantName/city/nmid/amount/mcc/currency/initiationMethod, `crcValid: true`), tampered CRC → `crcValid: false`, garbage → throws. Island covered by build + manual smoke (jsQR/canvas can't run in jsdom).
+
+## Definition of done
+
+Spec+plan committed · `qris.lib.ts` unit-tested · EN + ID SEO with howTo · vitest + lint + build green · `/tools/qris-decoder` + `/id/…` built · merged to develop · promoted to main · Cloudflare prod build green · live URL verified · user told about PWA hard-refresh.

--- a/src/islands/dev/QrisDecoder.tsx
+++ b/src/islands/dev/QrisDecoder.tsx
@@ -1,0 +1,276 @@
+import { useMemo, useState } from 'react';
+import jsQR from 'jsqr';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { TextArea } from '@/components/ui/TextArea';
+import { Alert } from '@/components/ui/Alert';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { parseQris, crc16, type Tlv, type QrisResult } from '@/tools/dev/qris.lib';
+import type { Lang } from '@/i18n/config';
+
+// A syntactically valid sample QRIS with a correct trailing CRC.
+const EXAMPLE_BASE =
+  '000201' +
+  '010211' +
+  '2644' + '0014ID.CO.QRIS.WWW' + '0215ID1020012345678' + '0303UMI' +
+  '52045411' +
+  '5303360' +
+  '540512345' +
+  '5802ID' +
+  '5909TOKO BUDI' +
+  '6007JAKARTA' +
+  '610512190' +
+  '62070703A01' +
+  '6304';
+const EXAMPLE = EXAMPLE_BASE + crc16(EXAMPLE_BASE);
+
+async function decodeImage(file: File): Promise<string | null> {
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.drawImage(bitmap, 0, 0);
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return jsQR(img.data, img.width, img.height)?.data ?? null;
+}
+
+const TR: Record<Lang, {
+  intro: string;
+  dropPrompt: string;
+  dropSub: string;
+  payload: string;
+  placeholder: string;
+  loadExample: string;
+  noQrFound: string;
+  cannotRead: string;
+  summary: string;
+  merchant: string;
+  nmid: string;
+  city: string;
+  amount: string;
+  currency: string;
+  mcc: string;
+  type: string;
+  staticL: string;
+  dynamicL: string;
+  unknownL: string;
+  acquirer: string;
+  criteria: string;
+  postal: string;
+  country: string;
+  crc: string;
+  valid: string;
+  invalid: string;
+  breakdown: string;
+  parseError: string;
+}> = {
+  en: {
+    intro: 'Decode an Indonesian QRIS code: paste the payload text or drop a QR image, and see the merchant, NMID, city, amount and every EMVCo field. Everything runs in your browser — nothing is uploaded.',
+    dropPrompt: 'Drop a QRIS image or click to browse',
+    dropSub: 'Decoded on your device · or paste an image (⌘V)',
+    payload: 'QRIS payload',
+    placeholder: 'Paste the QRIS string (starts with 00020101…) or drop an image above',
+    loadExample: 'Load example',
+    noQrFound: 'No QR code found in this image.',
+    cannotRead: 'Could not read the image file.',
+    summary: 'Summary',
+    merchant: 'Merchant name',
+    nmid: 'NMID',
+    city: 'Merchant city',
+    amount: 'Amount',
+    currency: 'Currency',
+    mcc: 'Category (MCC)',
+    type: 'Type',
+    staticL: 'Static',
+    dynamicL: 'Dynamic',
+    unknownL: 'Unknown',
+    acquirer: 'Acquirer / GUI',
+    criteria: 'Merchant criteria',
+    postal: 'Postal code',
+    country: 'Country',
+    crc: 'Checksum (CRC)',
+    valid: 'Valid',
+    invalid: 'Invalid',
+    breakdown: 'Full TLV breakdown',
+    parseError: 'This does not look like a valid QRIS / EMVCo payload.',
+  },
+  id: {
+    intro: 'Dekode kode QRIS Indonesia: tempel teks payload atau letakkan gambar QR, lalu lihat merchant, NMID, kota, nominal, dan seluruh field EMVCo. Semuanya berjalan di browser Anda — tidak ada yang diunggah.',
+    dropPrompt: 'Letakkan gambar QRIS atau klik untuk memilih',
+    dropSub: 'Didekode di perangkat Anda · atau tempel gambar (⌘V)',
+    payload: 'Payload QRIS',
+    placeholder: 'Tempel teks QRIS (diawali 00020101…) atau letakkan gambar di atas',
+    loadExample: 'Muat contoh',
+    noQrFound: 'Tidak ada kode QR yang ditemukan pada gambar ini.',
+    cannotRead: 'Tidak dapat membaca file gambar.',
+    summary: 'Ringkasan',
+    merchant: 'Nama merchant',
+    nmid: 'NMID',
+    city: 'Kota merchant',
+    amount: 'Nominal',
+    currency: 'Mata uang',
+    mcc: 'Kategori (MCC)',
+    type: 'Tipe',
+    staticL: 'Statis',
+    dynamicL: 'Dinamis',
+    unknownL: 'Tidak diketahui',
+    acquirer: 'Acquirer / GUI',
+    criteria: 'Kriteria merchant',
+    postal: 'Kode pos',
+    country: 'Negara',
+    crc: 'Checksum (CRC)',
+    valid: 'Valid',
+    invalid: 'Tidak valid',
+    breakdown: 'Rincian TLV lengkap',
+    parseError: 'Ini sepertinya bukan payload QRIS / EMVCo yang valid.',
+  },
+};
+
+function TlvRows({ nodes, depth = 0 }: { nodes: Tlv[]; depth?: number }) {
+  return (
+    <>
+      {nodes.map((n, i) => (
+        <div key={`${depth}-${i}-${n.id}`}>
+          <div
+            className="flex flex-wrap items-baseline gap-x-2 border-b border-border py-1 text-sm"
+            style={{ paddingLeft: `${depth * 1.25}rem` }}
+          >
+            <span className="font-mono font-bold">{n.id}</span>
+            <span className="text-muted-foreground">{n.name}</span>
+            {!n.children && <span className="ml-auto break-all font-mono">{n.value || '∅'}</span>}
+          </div>
+          {n.children && <TlvRows nodes={n.children} depth={depth + 1} />}
+        </div>
+      ))}
+    </>
+  );
+}
+
+export default function QrisDecoder({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [payload, setPayload] = useState('');
+  const [imgError, setImgError] = useState('');
+
+  const parsed = useMemo<{ result?: QrisResult; error?: boolean }>(() => {
+    const clean = payload.trim();
+    if (!clean) return {};
+    try {
+      return { result: parseQris(clean) };
+    } catch {
+      return { error: true };
+    }
+  }, [payload]);
+
+  const handleFile = async (files: File[]) => {
+    setImgError('');
+    if (files.length === 0) return;
+    try {
+      const decoded = await decodeImage(files[0]);
+      if (decoded) setPayload(decoded);
+      else setImgError(t.noQrFound);
+    } catch {
+      setImgError(t.cannotRead);
+    }
+  };
+
+  usePasteImage(file => handleFile([file]));
+
+  const s = parsed.result?.summary;
+  const typeLabel = s
+    ? s.initiationMethod === 'static' ? t.staticL : s.initiationMethod === 'dynamic' ? t.dynamicL : t.unknownL
+    : '';
+
+  const rows: { label: string; value?: string }[] = s
+    ? [
+        { label: t.merchant, value: s.merchantName },
+        { label: t.nmid, value: s.nmid },
+        { label: t.city, value: s.merchantCity },
+        { label: t.amount, value: s.amount },
+        { label: t.currency, value: s.currency },
+        { label: t.mcc, value: s.mcc },
+        { label: t.acquirer, value: s.acquirer },
+        { label: t.criteria, value: s.merchantCriteria },
+        { label: t.postal, value: s.postalCode },
+        { label: t.country, value: s.countryCode },
+        { label: t.type, value: typeLabel },
+      ].filter(r => r.value)
+    : [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <Dropzone onDrop={handleFile} accept="image/*" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">{t.dropPrompt}</p>
+          <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+        </div>
+      </Dropzone>
+
+      {imgError && <Alert variant="error">{imgError}</Alert>}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold">{t.payload}</span>
+          <button
+            type="button"
+            onClick={() => setPayload(EXAMPLE)}
+            className="text-sm text-accent underline"
+          >
+            {t.loadExample}
+          </button>
+        </div>
+        <TextArea
+          value={payload}
+          onChange={e => setPayload(e.target.value)}
+          rows={4}
+          spellCheck={false}
+          placeholder={t.placeholder}
+        />
+      </div>
+
+      {parsed.error && <Alert variant="error">{t.parseError}</Alert>}
+
+      {s && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold">{t.summary}</span>
+              <CopyButton value={payload.trim()} />
+            </div>
+            <div className="divide-y divide-border border-2 border-border">
+              {rows.map(r => (
+                <div key={r.label} className="flex flex-wrap items-baseline gap-x-3 px-3 py-2 text-sm">
+                  <span className="w-40 shrink-0 font-medium text-muted-foreground">{r.label}</span>
+                  <span className="break-all font-mono">{r.value}</span>
+                </div>
+              ))}
+              <div className="flex items-center gap-x-3 px-3 py-2 text-sm">
+                <span className="w-40 shrink-0 font-medium text-muted-foreground">{t.crc}</span>
+                <span className="font-mono">{s.crc}</span>
+                <span
+                  className={`ml-1 border-2 px-2 py-0.5 text-xs font-bold ${
+                    s.crcValid
+                      ? 'border-green-600 text-green-700 dark:border-green-400 dark:text-green-400'
+                      : 'border-red-500 text-red-600 dark:text-red-400'
+                  }`}
+                >
+                  {s.crcValid ? t.valid : t.invalid}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <span className="text-sm font-semibold">{t.breakdown}</span>
+            <div className="border-2 border-border px-3 py-1">
+              <TlvRows nodes={parsed.result!.tree} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -59,6 +59,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it show capture groups?', a: 'Yes. Each match lists its numbered capture groups ($1, $2, …) and any named groups, along with the match position in the text.' },
     ],
   },
+  'qris-decoder': {
+    title: 'Free QRIS Decoder — Read Merchant, NMID, City & Amount',
+    description: 'Decode an Indonesian QRIS (EMVCo) code online: paste the payload or drop a QR image to see the merchant name, NMID, city, amount, MCC and CRC. Runs in your browser — nothing is uploaded.',
+    intro: 'This free QRIS decoder reads the EMVCo QR Code payload behind an Indonesian QRIS and shows what it contains: the merchant name, National Merchant ID (NMID), merchant city, transaction amount, category (MCC), currency, whether it is a static or dynamic code, and whether the CRC checksum is valid. Paste the payload text or drop a QR image — decoding happens entirely on your device, so the code is never uploaded.',
+    howTo: [
+      'Paste the QRIS payload (it starts with 00020101…), or drop/paste a QR image to decode it.',
+      'Read the summary: merchant name, NMID, city, amount, category and code type.',
+      'Check the CRC badge to confirm the code’s checksum is valid.',
+      'Expand the full TLV breakdown to inspect every EMVCo tag and nested field.',
+    ],
+    faqs: [
+      { q: 'What is NMID in a QRIS code?', a: 'NMID (National Merchant ID) is the unique national identifier assigned to a QRIS merchant. It lives inside the merchant-account template of the EMVCo payload, and this tool extracts and labels it for you.' },
+      { q: 'Is my QRIS code uploaded anywhere?', a: 'No. Both the QR image decoding and the payload parsing run entirely in your browser, so your QRIS code never leaves your device.' },
+      { q: 'What does the CRC check tell me?', a: 'QRIS codes end with a CRC-16 checksum. The tool recomputes it from the payload and compares — a valid CRC means the code was read correctly and has not been altered.' },
+      { q: 'Can it read the QR from a photo or screenshot?', a: 'Yes. Drop or paste a QRIS QR image and the tool decodes it to the payload first, then parses the fields — no need to type the string by hand.' },
+      { q: 'What is the difference between a static and dynamic QRIS?', a: 'A static QRIS (initiation method 11) has no fixed amount — the payer types it in. A dynamic QRIS (12) encodes a specific amount, usually generated per transaction. The decoder shows which one you have.' },
+    ],
+  },
   'compare-lists': {
     title: 'Compare Two Lists — Merge, Dedupe & Diff Lines',
     description: 'Compare two lists of lines online: merge and remove duplicates, subtract one list from another, or find common lines. Free, private and instant — nothing is uploaded.',
@@ -1618,6 +1636,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah pola atau data uji saya dikirim ke server?', a: 'Tidak. Semuanya berjalan lokal di browser Anda, jadi aman untuk menguji log, email, atau teks sensitif lainnya.' },
       { q: 'Apa arti flag-nya?', a: 'g = global (cari semua), i = abaikan huruf besar/kecil, m = multiline (^ dan $ per baris), s = dotall (titik mencocokkan baris baru), u = unicode, y = sticky. Aktifkan dan sorotan langsung diperbarui.' },
       { q: 'Apakah menampilkan capture group?', a: 'Ya. Setiap kecocokan menampilkan capture group bernomor ($1, $2, …) dan grup bernama, beserta posisi kecocokan dalam teks.' },
+    ],
+  },
+  'qris-decoder': {
+    title: 'Tool Decode QRIS Gratis — Baca Merchant, NMID, Kota & Nominal',
+    description: 'Decode kode QRIS (EMVCo) Indonesia online: tempel payload atau letakkan gambar QR untuk melihat nama merchant, NMID, kota, nominal, MCC, dan CRC. Berjalan di browser Anda — tidak ada yang diunggah.',
+    intro: 'Tool decode QRIS gratis ini membaca payload EMVCo QR Code di balik QRIS Indonesia dan menampilkan isinya: nama merchant, National Merchant ID (NMID), kota merchant, nominal transaksi, kategori (MCC), mata uang, apakah kode bersifat statis atau dinamis, serta apakah checksum CRC valid. Tempel teks payload atau letakkan gambar QR — proses decode terjadi sepenuhnya di perangkat Anda, jadi kode tidak pernah diunggah.',
+    howTo: [
+      'Tempel payload QRIS (diawali 00020101…), atau letakkan/tempel gambar QR untuk mendekodenya.',
+      'Baca ringkasan: nama merchant, NMID, kota, nominal, kategori, dan tipe kode.',
+      'Periksa badge CRC untuk memastikan checksum kode valid.',
+      'Buka rincian TLV lengkap untuk memeriksa setiap tag EMVCo dan field bersarang.',
+    ],
+    faqs: [
+      { q: 'Apa itu NMID pada kode QRIS?', a: 'NMID (National Merchant ID) adalah identitas nasional unik yang diberikan kepada merchant QRIS. NMID berada di dalam template merchant-account pada payload EMVCo, dan tool ini mengekstrak serta memberi labelnya untuk Anda.' },
+      { q: 'Apakah kode QRIS saya diunggah?', a: 'Tidak. Baik decode gambar QR maupun parsing payload berjalan sepenuhnya di browser Anda, jadi kode QRIS Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Apa arti pemeriksaan CRC?', a: 'Kode QRIS diakhiri checksum CRC-16. Tool menghitung ulang dari payload lalu membandingkannya — CRC yang valid berarti kode terbaca dengan benar dan tidak diubah.' },
+      { q: 'Bisakah membaca QR dari foto atau tangkapan layar?', a: 'Ya. Letakkan atau tempel gambar QR QRIS dan tool akan mendekodenya menjadi payload terlebih dahulu, lalu mem-parsing field-nya — tanpa perlu mengetik string secara manual.' },
+      { q: 'Apa beda QRIS statis dan dinamis?', a: 'QRIS statis (metode inisiasi 11) tidak memiliki nominal tetap — pembayar mengetiknya sendiri. QRIS dinamis (12) memuat nominal tertentu, biasanya dibuat per transaksi. Decoder menunjukkan tipe yang Anda miliki.' },
     ],
   },
   'compare-lists': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -199,6 +199,17 @@ export const tools: ToolDef[] = [
     icon: Regex,
     summary: 'Test regular expressions with live highlighting and per-language code',
     load: () => import('@/islands/dev/RegexTester'),
+    status: 'beta'
+  },
+  {
+    id: 'qris-decoder',
+    name: 'QRIS Decoder',
+    category: 'Dev',
+    route: '/tools/qris-decoder',
+    keywords: ['qris', 'qr', 'emvco', 'payment', 'decode', 'nmid', 'merchant', 'indonesia', 'tlv'],
+    icon: Wallet,
+    summary: 'Decode a QRIS payment code — merchant, NMID, city, amount',
+    load: () => import('@/islands/dev/QrisDecoder'),
     status: 'beta'
   },
   {

--- a/src/tools/dev/qris.lib.test.ts
+++ b/src/tools/dev/qris.lib.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { crc16, parseTlv, parseQris } from './qris.lib';
+
+/** Build a valid QRIS payload from body objects, appending a correct CRC. */
+function withCrc(body: string): string {
+  const base = body + '6304';
+  return base + crc16(base);
+}
+
+const MERCHANT_26 =
+  '26' + '44' + '0014ID.CO.QRIS.WWW' + '0215ID1020012345678' + '0303UMI';
+
+const BODY = [
+  '000201',
+  '010211', // static
+  MERCHANT_26,
+  '52045411', // MCC
+  '5303360', // currency IDR
+  '540512345', // amount
+  '5802ID',
+  '5909TOKO BUDI',
+  '6007JAKARTA',
+  '610512190',
+  '62070703A01', // additional data: terminal A01
+].join('');
+
+const PAYLOAD = withCrc(BODY);
+
+describe('crc16', () => {
+  it('matches the CRC-16/CCITT-FALSE check vector', () => {
+    expect(crc16('123456789')).toBe('29B1');
+  });
+});
+
+describe('parseTlv', () => {
+  it('parses a single object', () => {
+    expect(parseTlv('000201')).toEqual([
+      { id: '00', length: 2, value: '01', name: expect.any(String) },
+    ]);
+  });
+
+  it('parses a nested merchant-account template into children', () => {
+    const tree = parseTlv(MERCHANT_26);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe('26');
+    expect(tree[0].children).toBeDefined();
+    const nmid = tree[0].children!.find(c => c.id === '02');
+    expect(nmid?.value).toBe('ID1020012345678');
+  });
+
+  it('throws on a malformed / truncated payload', () => {
+    expect(() => parseTlv('0002')).toThrow();
+    expect(() => parseTlv('0099AB')).toThrow(); // length overruns the string
+  });
+});
+
+describe('parseQris', () => {
+  const { summary } = parseQris(PAYLOAD);
+
+  it('extracts the merchant fields', () => {
+    expect(summary.merchantName).toBe('TOKO BUDI');
+    expect(summary.merchantCity).toBe('JAKARTA');
+    expect(summary.postalCode).toBe('12190');
+    expect(summary.countryCode).toBe('ID');
+  });
+
+  it('extracts NMID, acquirer and criteria from the merchant template', () => {
+    expect(summary.nmid).toBe('ID1020012345678');
+    expect(summary.acquirer).toBe('ID.CO.QRIS.WWW');
+    expect(summary.merchantCriteria).toBe('UMI');
+  });
+
+  it('extracts amount, MCC and currency', () => {
+    expect(summary.amount).toBe('12345');
+    expect(summary.mcc).toBe('5411');
+    expect(summary.currency).toBe('360');
+  });
+
+  it('detects a static code', () => {
+    expect(summary.initiationMethod).toBe('static');
+  });
+
+  it('validates a correct CRC', () => {
+    expect(summary.crcValid).toBe(true);
+  });
+
+  it('flags a tampered CRC as invalid without throwing', () => {
+    const tampered = PAYLOAD.slice(0, -1) + (PAYLOAD.slice(-1) === '0' ? '1' : '0');
+    const r = parseQris(tampered);
+    expect(r.summary.crcValid).toBe(false);
+  });
+
+  it('throws on structurally invalid input', () => {
+    expect(() => parseQris('garbage!!')).toThrow();
+  });
+});

--- a/src/tools/dev/qris.lib.ts
+++ b/src/tools/dev/qris.lib.ts
@@ -1,0 +1,213 @@
+/**
+ * QRIS / EMVCo Merchant-Presented-Mode QR decoder — pure, framework-free.
+ *
+ * The payload is a run of TLV objects: ID(2) + LEN(2, decimal) + VALUE(LEN).
+ * Merchant-account (26–51), additional-data (62) and language (64) templates
+ * nest more TLV objects. `parseQris` builds the tree, derives a friendly
+ * summary, and validates the CRC-16/CCITT-FALSE checksum in tag 63.
+ */
+
+export interface Tlv {
+  id: string;
+  length: number;
+  value: string;
+  name: string;
+  children?: Tlv[];
+}
+
+export interface QrisSummary {
+  payloadFormat?: string;
+  initiationMethod: 'static' | 'dynamic' | 'unknown';
+  merchantName?: string;
+  merchantCity?: string;
+  postalCode?: string;
+  countryCode?: string;
+  currency?: string;
+  amount?: string;
+  mcc?: string;
+  nmid?: string;
+  merchantPan?: string;
+  merchantCriteria?: string;
+  acquirer?: string;
+  crc?: string;
+  crcValid: boolean;
+}
+
+export interface QrisResult {
+  summary: QrisSummary;
+  tree: Tlv[];
+}
+
+/** CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF) → 4 upper-hex chars. */
+export function crc16(input: string): string {
+  let crc = 0xffff;
+  for (let i = 0; i < input.length; i++) {
+    crc ^= input.charCodeAt(i) << 8;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 0x8000 ? (crc << 1) ^ 0x1021 : crc << 1;
+      crc &= 0xffff;
+    }
+  }
+  return crc.toString(16).toUpperCase().padStart(4, '0');
+}
+
+const ROOT_NAMES: Record<string, string> = {
+  '00': 'Payload Format Indicator',
+  '01': 'Point of Initiation Method',
+  '52': 'Merchant Category Code',
+  '53': 'Transaction Currency',
+  '54': 'Transaction Amount',
+  '55': 'Tip or Convenience Indicator',
+  '56': 'Value of Convenience Fee (Fixed)',
+  '57': 'Value of Convenience Fee (Percentage)',
+  '58': 'Country Code',
+  '59': 'Merchant Name',
+  '60': 'Merchant City',
+  '61': 'Postal Code',
+  '62': 'Additional Data Field Template',
+  '63': 'CRC',
+  '64': 'Merchant Information — Language Template',
+};
+
+const MERCHANT_SUBTAG: Record<string, string> = {
+  '00': 'Globally Unique Identifier',
+  '01': 'Merchant PAN',
+  '02': 'Merchant ID (NMID)',
+  '03': 'Merchant Criteria',
+};
+
+const ADDITIONAL_SUBTAG: Record<string, string> = {
+  '01': 'Bill Number',
+  '02': 'Mobile Number',
+  '03': 'Store Label',
+  '04': 'Loyalty Number',
+  '05': 'Reference Label',
+  '06': 'Customer Label',
+  '07': 'Terminal Label',
+  '08': 'Purpose of Transaction',
+  '09': 'Additional Consumer Data Request',
+};
+
+const LANGUAGE_SUBTAG: Record<string, string> = {
+  '00': 'Language Preference',
+  '01': 'Merchant Name — Alternate Language',
+  '02': 'Merchant City — Alternate Language',
+};
+
+function isMerchantAccount(id: string): boolean {
+  const n = Number(id);
+  return n >= 26 && n <= 51;
+}
+
+function isNested(id: string): boolean {
+  return isMerchantAccount(id) || id === '62' || id === '64';
+}
+
+function nameFor(parentId: string | null, id: string): string {
+  if (parentId === null) {
+    if (ROOT_NAMES[id]) return ROOT_NAMES[id];
+    if (isMerchantAccount(id)) return 'Merchant Account Information';
+    return 'Reserved';
+  }
+  if (isMerchantAccount(parentId)) return MERCHANT_SUBTAG[id] ?? 'Data';
+  if (parentId === '62') return ADDITIONAL_SUBTAG[id] ?? 'Data';
+  if (parentId === '64') return LANGUAGE_SUBTAG[id] ?? 'Data';
+  return 'Data';
+}
+
+interface RawTlv {
+  id: string;
+  length: number;
+  value: string;
+}
+
+/** Flat TLV scan; throws on malformed length or overrun. */
+function scan(s: string): RawTlv[] {
+  const out: RawTlv[] = [];
+  let i = 0;
+  while (i < s.length) {
+    if (i + 4 > s.length) throw new Error(`Truncated tag at position ${i}`);
+    const id = s.slice(i, i + 2);
+    const lenStr = s.slice(i + 2, i + 4);
+    if (!/^\d{2}$/.test(id) || !/^\d{2}$/.test(lenStr)) {
+      throw new Error(`Invalid TLV header "${id}${lenStr}" at position ${i}`);
+    }
+    const length = Number(lenStr);
+    const value = s.slice(i + 4, i + 4 + length);
+    if (value.length < length) throw new Error(`Length overrun at tag ${id}`);
+    out.push({ id, length, value });
+    i += 4 + length;
+  }
+  if (out.length === 0) throw new Error('No TLV objects found');
+  return out;
+}
+
+function build(objs: RawTlv[], parentId: string | null): Tlv[] {
+  return objs.map(({ id, length, value }) => {
+    const node: Tlv = { id, length, value, name: nameFor(parentId, id) };
+    if (isNested(id)) {
+      try {
+        node.children = build(scan(value), id);
+      } catch {
+        // Not clean nested TLV — keep it as a leaf.
+      }
+    }
+    return node;
+  });
+}
+
+/** Parse a payload into a TLV tree. Throws on structurally invalid input. */
+export function parseTlv(s: string): Tlv[] {
+  return build(scan(s), null);
+}
+
+function findMerchantTemplate(tree: Tlv[]): Tlv | undefined {
+  const templates = tree.filter(t => isMerchantAccount(t.id) && t.children);
+  const qris = templates.find(t =>
+    (t.children!.find(c => c.id === '00')?.value ?? '').toUpperCase().includes('ID.CO.QRIS'),
+  );
+  return qris ?? templates[0];
+}
+
+/** Decode a QRIS payload into a summary + full TLV tree. */
+export function parseQris(payload: string): QrisResult {
+  const clean = payload.trim();
+  const tree = parseTlv(clean);
+  const root = (id: string) => tree.find(t => t.id === id)?.value;
+
+  const initRaw = root('01');
+  const initiationMethod: QrisSummary['initiationMethod'] =
+    initRaw === '11' ? 'static' : initRaw === '12' ? 'dynamic' : 'unknown';
+
+  const merchant = findMerchantTemplate(tree);
+  const sub = (id: string) => merchant?.children?.find(c => c.id === id)?.value;
+
+  // CRC covers everything up to and including the "6304" tag+length.
+  let crcValid = false;
+  let crc = tree.find(t => t.id === '63')?.value;
+  if (clean.length >= 8 && clean.slice(-8, -4) === '6304') {
+    const provided = clean.slice(-4).toUpperCase();
+    crc = provided;
+    crcValid = crc16(clean.slice(0, -4)) === provided;
+  }
+
+  const summary: QrisSummary = {
+    payloadFormat: root('00'),
+    initiationMethod,
+    merchantName: root('59'),
+    merchantCity: root('60'),
+    postalCode: root('61'),
+    countryCode: root('58'),
+    currency: root('53'),
+    amount: root('54'),
+    mcc: root('52'),
+    acquirer: sub('00'),
+    merchantPan: sub('01'),
+    nmid: sub('02'),
+    merchantCriteria: sub('03'),
+    crc,
+    crcValid,
+  };
+
+  return { summary, tree };
+}


### PR DESCRIPTION
Adds a client-side **QRIS Decoder** (`/tools/qris-decoder`).

- Parses the **EMVCo TLV** payload of an Indonesian QRIS code → merchant name, **NMID**, city, amount, MCC, currency, static/dynamic, acquirer, and **CRC-16 validity**.
- Input: **paste the payload** OR **drop/paste a QR image** (decoded via the already-installed `jsQR`).
- Shows a friendly summary **plus a full tag-by-tag TLV breakdown** (nested merchant-account / additional-data / language templates).
- Pure lib `qris.lib.ts` unit-tested (11 cases incl. the CRC check vector 0x29B1). No new dependency.
- EN + ID SEO with how-to + FAQs. Full suite + lint + build green.