### PR TITLE
feat(search,seo): stemmed tool search + richer category hub pages

### DIFF
--- a/docs/superpowers/plans/2026-08-16-search-and-category-seo.md
+++ b/docs/superpowers/plans/2026-08-16-search-and-category-seo.md
@@ -1,0 +1,16 @@
+# Search matching + Category-hub SEO
+
+**Date:** 2026-08-16.
+
+## 1. Search — surface all tools (fixes "signed" not finding Sign PDF)
+- `calculateScore` in `tools.ts` rewritten: tokenize query + fields, match by exact / prefix (either direction, min 3 chars) / crude English stem (signed→sign, images→image, converting→convert). Every query token must match somewhere (AND); bonuses for exact-name and whole-query substring. Unit-tested in `tools.test.ts`.
+- `CommandPalette` now sets `shouldFilter={false}` so cmdk no longer re-filters on `tool.name` and hide valid keyword/stem matches — `searchTools` is the sole authority.
+
+## 2. Category hub pages (e.g. /category/pdf) — best-effort SEO
+- `categoryFaqs(category, lang)` in `categories.ts` — 4 unique, keyword-aware FAQs per category, EN + ID.
+- Category page renders an accessible FAQ accordion + **FAQPage** JSON-LD (rich-result eligible), keeps the existing BreadcrumbList + ItemList schema.
+- Adds sibling-category internal links (crawlability), a category note (Network), and keyword-rich `<meta keywords>` that includes every tool name in the category.
+- New i18n key `category.other` (EN/ID); FAQ heading reuses `tool.faq`.
+
+## DoD
+search unit-tested (10) · full suite + lint + build green · FAQPage schema + FAQ + sibling links verified in built HTML (EN + ID) · ship develop→main→verify.

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -50,6 +50,7 @@ export function CommandPalette() {
     <div className="fixed inset-0 z-50 bg-black/60" onClick={() => setOpen(false)}>
       <div className="container mx-auto px-4 pt-[20vh]">
         <Command
+          shouldFilter={false}
           className="mx-auto max-w-2xl border-[3px] border-border bg-background shadow-brutal-lg"
           onClick={e => e.stopPropagation()}
         >

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -21,6 +21,7 @@ const en: Dict = {
   'category.heading': '{category} Tools',
   'category.freePrivate': '{category} Tools — Free & Private',
   'category.clickInfo': '{n} feature · click one to see its properties. ',
+  'category.other': 'Other tool categories',
   'lang.switch': 'Language',
 };
 
@@ -38,6 +39,7 @@ const id: Dict = {
   'category.heading': 'Tool {category}',
   'category.freePrivate': 'Tool {category} — Gratis & Privat',
   'category.clickInfo': '{n} fitur · klik salah satu untuk melihat propertinya. ',
+  'category.other': 'Kategori tool lainnya',
   'lang.switch': 'Bahasa',
 };
 

--- a/src/pages/[...locale]/category/[category].astro
+++ b/src/pages/[...locale]/category/[category].astro
@@ -2,7 +2,7 @@
 import { ChevronRight } from 'lucide-react';
 import Base from '@/layouts/Base.astro';
 import { tools } from '@/registry/tools';
-import { categories, categoryColors, catDescription, categorySlug } from '@/registry/categories';
+import { categories, categoryColors, catDescription, categorySlug, categoryFaqs, categoryNotes } from '@/registry/categories';
 import { SITE_URL, SITE_NAME } from '@/config';
 import type { Category } from '@/types/tool';
 import { LOCALES, localeParam, localizePath, type Lang } from '@/i18n/config';
@@ -43,13 +43,38 @@ const itemListJsonLd = {
     url: new URL(localizePath(t2.route, lang), SITE_URL).href,
   })),
 };
+
+const faqs = categoryFaqs(category, lang);
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(f => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const note = categoryNotes[category];
+// Other category hubs, for internal linking / crawlability.
+const otherCategories = categories.filter(
+  c => c !== category && tools.some(t2 => t2.category === c && !t2.desktopOnly),
+);
+// Keyword-rich meta: category + every tool name in it.
+const keywords = [
+  `${category.toLowerCase()} tools`,
+  `free ${category.toLowerCase()} tools`,
+  `online ${category.toLowerCase()} tools`,
+  ...categoryTools.map(t2 => t2.name.toLowerCase()),
+  'browser', 'privacy', 'no upload', 'free',
+];
 ---
 
 <Base
   title={t(lang, 'category.freePrivate', { category })}
   description={description}
-  keywords={[`${category.toLowerCase()} tools`, 'free', 'online', 'browser', 'privacy', 'no upload']}
-  jsonLd={[breadcrumbJsonLd, itemListJsonLd]}
+  keywords={keywords}
+  jsonLd={[breadcrumbJsonLd, itemListJsonLd, faqJsonLd]}
   lang={lang}
   localized
 >
@@ -71,6 +96,7 @@ const itemListJsonLd = {
         <span class="text-sm font-bold text-muted-foreground">({categoryTools.length})</span>
       </div>
       <p class="max-w-3xl text-muted-foreground">{description}</p>
+      {note && <p class="mt-2 max-w-3xl text-sm text-muted-foreground">{note}</p>}
     </header>
 
     <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
@@ -89,5 +115,37 @@ const itemListJsonLd = {
         );
       })}
     </div>
+
+    <section class="mt-12 max-w-3xl">
+      <h2 class="mb-4 text-2xl font-bold uppercase tracking-tight">{t(lang, 'tool.faq')}</h2>
+      <div class="flex flex-col gap-2">
+        {faqs.map(f => (
+          <details class="group border-2 border-border bg-muted">
+            <summary class="cursor-pointer list-none px-4 py-3 font-bold [&::-webkit-details-marker]:hidden">
+              <span class="flex items-center justify-between gap-2">
+                <span>{f.q}</span>
+                <ChevronRight className="h-4 w-4 shrink-0 transition-transform group-open:rotate-90" />
+              </span>
+            </summary>
+            <p class="border-t-2 border-border px-4 py-3 text-muted-foreground">{f.a}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+
+    <nav aria-label={t(lang, 'category.other')} class="mt-12">
+      <h2 class="mb-3 text-sm font-bold uppercase tracking-wide text-muted-foreground">{t(lang, 'category.other')}</h2>
+      <ul class="flex flex-wrap gap-2">
+        {otherCategories.map(c => (
+          <li>
+            <a href={localizePath(`/category/${categorySlug(c)}`, lang)}
+              class="inline-flex items-center gap-1.5 border-2 border-border bg-muted px-3 py-1.5 text-sm font-bold shadow-brutal-sm press-brutal">
+              <span class={`inline-block h-3 w-3 border border-border ${categoryColors[c]}`} />
+              {t(lang, 'category.heading', { category: c })}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
   </main>
 </Base>

--- a/src/registry/categories.ts
+++ b/src/registry/categories.ts
@@ -65,6 +65,40 @@ export const categoryDescriptionsId: Record<Category, string> = {
   Playground: 'Playground interaktif dan eksperimen untuk menjelajah dan belajar — semuanya berjalan di sisi klien di browser Anda.',
 };
 
+/** Per-category nouns/actions used to build unique FAQ copy for each hub page. */
+const categoryFacts: Record<Category, { en: { noun: string; actions: string }; id: { noun: string; actions: string } }> = {
+  Dev: { en: { noun: 'inputs', actions: 'formatting JSON, encoding Base64, hashing text and generating UUIDs' }, id: { noun: 'input', actions: 'memformat JSON, meng-encode Base64, hashing teks, dan membuat UUID' } },
+  PDF: { en: { noun: 'PDFs', actions: 'merging, splitting, compressing, signing and editing' }, id: { noun: 'PDF', actions: 'menggabung, memisah, memperkecil, menandatangani, dan mengedit' } },
+  Image: { en: { noun: 'images', actions: 'resizing, cropping, converting, removing backgrounds and extracting text' }, id: { noun: 'gambar', actions: 'mengubah ukuran, memotong, mengonversi, menghapus latar, dan mengekstrak teks' } },
+  Files: { en: { noun: 'files', actions: 'archiving, extracting, encrypting and inspecting' }, id: { noun: 'berkas', actions: 'mengarsip, mengekstrak, mengenkripsi, dan memeriksa' } },
+  Documents: { en: { noun: 'documents', actions: 'opening Word, OpenDocument, spreadsheet and e-book files' }, id: { noun: 'dokumen', actions: 'membuka berkas Word, OpenDocument, spreadsheet, dan e-book' } },
+  Draw: { en: { noun: 'drawings', actions: 'sketching, annotating and diagramming' }, id: { noun: 'gambar', actions: 'membuat sketsa, anotasi, dan diagram' } },
+  Media: { en: { noun: 'recordings', actions: 'converting, trimming, recording and transcribing' }, id: { noun: 'rekaman', actions: 'mengonversi, memangkas, merekam, dan mentranskripsi' } },
+  Network: { en: { noun: 'files', actions: 'transferring files and communicating device to device' }, id: { noun: 'berkas', actions: 'mentransfer berkas dan berkomunikasi antar perangkat' } },
+  Maps: { en: { noun: 'map data', actions: 'converting coordinates and viewing GeoJSON, GPX and KML' }, id: { noun: 'data peta', actions: 'mengonversi koordinat dan melihat GeoJSON, GPX, dan KML' } },
+  Legacy: { en: { noun: 'messages', actions: 'encrypting messages and passwords for your family' }, id: { noun: 'pesan', actions: 'mengenkripsi pesan dan kata sandi untuk keluarga' } },
+  Playground: { en: { noun: 'inputs', actions: 'experimenting and learning interactively' }, id: { noun: 'input', actions: 'bereksperimen dan belajar secara interaktif' } },
+};
+
+/** Unique, keyword-aware FAQ for each category hub page (for FAQPage rich results). */
+export function categoryFaqs(category: Category, lang: Lang): { q: string; a: string }[] {
+  const f = categoryFacts[category][lang === 'id' ? 'id' : 'en'];
+  if (lang === 'id') {
+    return [
+      { q: `Apakah ${f.noun} saya diunggah ke server?`, a: `Tidak. Setiap tool kategori ${category} berjalan di browser Anda — ${f.actions} semuanya terjadi di perangkat Anda, jadi ${f.noun} Anda tidak pernah diunggah.` },
+      { q: 'Apakah perlu memasang aplikasi atau membuat akun?', a: 'Tidak. Buka halaman dan langsung pakai tool mana pun — tanpa instalasi, tanpa pendaftaran, tanpa batas, dan tanpa tanda air.' },
+      { q: `Apakah tool ${category} ini bekerja offline?`, a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool tetap berjalan tanpa koneksi internet.' },
+      { q: `Apakah tool ${category} ini gratis?`, a: `Ya, setiap tool di kategori ${category} gratis sepenuhnya — tanpa batas dan tanpa tanda air.` },
+    ];
+  }
+  return [
+    { q: `Are my ${f.noun} uploaded to a server?`, a: `No. Every ${category} tool on GoodWebTools runs in your browser — ${f.actions} all happen on your device, so your ${f.noun} never leave it.` },
+    { q: 'Do I need to install anything or create an account?', a: 'No install and no sign-up. Open the page and use any tool instantly — no limits and no watermarks.' },
+    { q: `Do these ${category} tools work offline?`, a: 'Yes. GoodWebTools is a PWA, so once loaded the tools keep working with no internet connection.' },
+    { q: `Are these ${category} tools free?`, a: `Yes — every tool in the ${category} category is completely free, with no limits or watermarks.` },
+  ];
+}
+
 /** SEO lead copy for each category hub page (unique, keyword-aware). */
 export const categoryDescriptions: Record<Category, string> = {
   Dev: 'Free developer utilities that run entirely in your browser — format and validate JSON, encode Base64 and URLs, hash and diff text, generate UUIDs, and more. Nothing is uploaded.',

--- a/src/registry/tools.test.ts
+++ b/src/registry/tools.test.ts
@@ -45,4 +45,25 @@ describe('Tool Registry', () => {
   it('returns nothing for a nonsense query', () => {
     expect(searchTools('zzzznotarealtool')).toHaveLength(0);
   });
+
+  it('matches inflected / stemmed queries', () => {
+    // The original bug: "signed" did not surface the Sign PDF tool.
+    expect(searchTools('signed').some(t => t.id === 'pdf-sign')).toBe(true);
+    expect(searchTools('sign').some(t => t.id === 'pdf-sign')).toBe(true);
+    // plural / gerund forms should still match
+    expect(searchTools('images').some(t => t.category === 'Image')).toBe(true);
+    expect(searchTools('converting').some(t => t.id === 'image-convert')).toBe(true);
+  });
+
+  it('handles multi-word queries and abbreviations', () => {
+    const signPdf = searchTools('sign pdf');
+    expect(signPdf.some(t => t.id === 'pdf-sign')).toBe(true);
+    // abbreviation keyword match
+    expect(searchTools('css').some(t => t.id === 'minifier')).toBe(true);
+  });
+
+  it('ranks the most relevant tool first', () => {
+    expect(searchTools('sign pdf')[0].id).toBe('pdf-sign');
+    expect(searchTools('word counter')[0].id).toBe('word-counter');
+  });
 });

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1219,27 +1219,68 @@ export function searchTools(query: string): ToolDef[] {
     .map(({ tool }) => tool);
 }
 
+/** Split text into lowercase word tokens (letters/digits). */
+function tokenize(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/**
+ * Crude English stemmer — strips common inflection suffixes so "signed" →
+ * "sign", "images" → "image", "converting" → "convert". Only strips when the
+ * stem stays at least 3 chars, to avoid mangling short words.
+ */
+function stem(word: string): string {
+  if (word.length <= 3) return word;
+  if (word.endsWith('ies') && word.length > 4) return word.slice(0, -3) + 'y';
+  for (const suffix of ['ing', 'ed', 'es', 's']) {
+    if (word.endsWith(suffix) && word.length - suffix.length >= 3) return word.slice(0, -suffix.length);
+  }
+  return word;
+}
+
+/** Score how well one query token matches a set of field tokens (0 = no match). */
+function tokenScore(q: string, qStem: string, fieldTokens: string[], weight: number): number {
+  let best = 0;
+  for (const t of fieldTokens) {
+    if (t === q) return weight; // exact — can't do better
+    // Prefix either way ("sig"→"sign", "signed"→"sign") when the shorter side is meaningful.
+    if ((t.startsWith(q) || q.startsWith(t)) && Math.min(t.length, q.length) >= 3) {
+      best = Math.max(best, weight * 0.85);
+      continue;
+    }
+    if (stem(t) === qStem) best = Math.max(best, weight * 0.7);
+  }
+  return best;
+}
+
 function calculateScore(tool: ToolDef, query: string): number {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return 0;
+
+  const nameTokens = tokenize(tool.name);
+  const keywordTokens = tool.keywords.flatMap(tokenize);
+  const summaryTokens = tokenize(tool.summary);
+  const categoryTokens = tokenize(tool.category);
+
+  // Every query token must match somewhere (AND) so multi-word queries narrow.
   let score = 0;
+  for (const q of queryTokens) {
+    const qStem = stem(q);
+    const best = Math.max(
+      tokenScore(q, qStem, nameTokens, 100),
+      tokenScore(q, qStem, keywordTokens, 80),
+      tokenScore(q, qStem, summaryTokens, 30),
+      tokenScore(q, qStem, categoryTokens, 20),
+    );
+    if (best === 0) return 0;
+    score += best;
+  }
 
-  const lowerName = tool.name.toLowerCase();
-  const lowerSummary = tool.summary.toLowerCase();
-  const lowerCategory = tool.category.toLowerCase();
-
-  // Exact name match
-  if (lowerName === query) score += 200;
-  // Name contains query
-  if (lowerName.includes(query)) score += 100;
-
-  // Keywords match
-  if (tool.keywords.some(k => k.toLowerCase() === query)) score += 150;
-  if (tool.keywords.some(k => k.toLowerCase().includes(query))) score += 50;
-
-  // Summary/description match (including subtitle)
-  if (lowerSummary.includes(query)) score += 30;
-
-  // Category match
-  if (lowerCategory.includes(query)) score += 20;
+  // Bonuses that reward tighter matches.
+  const q = query.toLowerCase().trim();
+  if (tool.name.toLowerCase() === q) score += 200;
+  else if (tool.name.toLowerCase().includes(q)) score += 60;
+  if (`${tool.name} ${tool.keywords.join(' ')} ${tool.summary}`.toLowerCase().includes(q)) score += 40;
 
   return score;
 }


### PR DESCRIPTION
**Search fix** — the bug where typing 'signed' didn't surface Sign PDF. Rewrote `searchTools` scoring to tokenize + stem + prefix-match (signed→sign, images→image, converting→convert), require every query token to match (AND), and rank exact/substring higher. Also set `shouldFilter={false}` on the command palette so cmdk stops re-filtering on `tool.name` and hiding valid keyword matches. 10 unit tests incl. 'signed'→pdf-sign, 'sign pdf' ranked first.

**Category hub SEO** (e.g. /category/pdf) — added unique per-category **FAQs** (EN + ID) with **FAQPage** structured data (rich-result eligible), sibling-category internal links (crawlability), a category note, and keyword-rich `<meta keywords>` that includes every tool name. Kept existing BreadcrumbList + ItemList schema. Verified FAQPage + FAQ + links in the built HTML for both locales.

Full suite 1105 green, lint 0 errors, build green.