### PR TITLE
feat(files): Compress to Size — image/PDF to a target file size

### DIFF
--- a/src/islands/files/CompressToSize.tsx
+++ b/src/islands/files/CompressToSize.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ImageResult } from '@/components/ui/ImageResult';
+import { ResultActions } from '@/components/ui/ResultActions';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { TARGET_PRESETS, targetToBytes, pctSmaller, formatSize, type SizeUnit } from '@/tools/files/compress-target.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; drop: string; dropSub: string; target: string; custom: string;
+  imageFormat: string; compress: string; working: string; failed: string;
+  original: string; result: string; smaller: string; missed: (b: string) => string;
+  rasterNote: string;
+}> = {
+  en: {
+    intro: 'Compress a JPG, PNG, WebP or PDF down to a target file size — perfect for upload limits (e.g. 100 KB, 500 KB). Everything runs in your browser; your file is never uploaded.',
+    drop: 'Drop an image or PDF, or click to browse',
+    dropSub: 'JPG, PNG, WebP or PDF · or paste an image (⌘V)',
+    target: 'Target size',
+    custom: 'Custom',
+    imageFormat: 'Image output',
+    compress: 'Compress',
+    working: 'Compressing…',
+    failed: 'Could not compress this file.',
+    original: 'Original',
+    result: 'Result',
+    smaller: 'smaller',
+    missed: b => `Couldn’t reach the target — this is the smallest achievable (${b}). Try a larger target.`,
+    rasterNote: 'To hit the target, pages were flattened to images, so the text is no longer selectable.',
+  },
+  id: {
+    intro: 'Kompres JPG, PNG, WebP, atau PDF hingga ukuran target — pas untuk batas unggah (mis. 100 KB, 500 KB). Semuanya berjalan di browser Anda; file tidak pernah diunggah.',
+    drop: 'Letakkan gambar atau PDF, atau klik untuk memilih',
+    dropSub: 'JPG, PNG, WebP, atau PDF · atau tempel gambar (⌘V)',
+    target: 'Ukuran target',
+    custom: 'Kustom',
+    imageFormat: 'Format gambar',
+    compress: 'Kompres',
+    working: 'Mengompres…',
+    failed: 'Tidak dapat mengompres file ini.',
+    original: 'Asli',
+    result: 'Hasil',
+    smaller: 'lebih kecil',
+    missed: b => `Tidak dapat mencapai target — ini yang terkecil bisa dicapai (${b}). Coba target lebih besar.`,
+    rasterNote: 'Untuk mencapai target, halaman diratakan menjadi gambar, sehingga teks tidak lagi bisa diseleksi.',
+  },
+};
+
+export default function CompressToSize({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [file, setFile] = useState<File | null>(null);
+  const [targetBytes, setTargetBytes] = useState(100 * 1024);
+  const [customValue, setCustomValue] = useState('100');
+  const [customUnit, setCustomUnit] = useState<SizeUnit>('KB');
+  const [format, setFormat] = useState<'jpeg' | 'webp'>('jpeg');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<{ blob: Blob; achieved: boolean; rasterized?: boolean; name: string } | null>(null);
+
+  const isPdf = file ? (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) : false;
+  const isImage = file ? file.type.startsWith('image/') : false;
+
+  const onDrop = (files: File[]) => {
+    const f = files.find(x => x.type.startsWith('image/') || x.type === 'application/pdf' || x.name.toLowerCase().endsWith('.pdf'));
+    if (!f) return;
+    setFile(f);
+    setResult(null);
+    setError('');
+  };
+  usePasteImage(f => onDrop([f]));
+
+  const applyCustom = () => {
+    const v = Number(customValue);
+    if (Number.isFinite(v) && v > 0) setTargetBytes(targetToBytes(v, customUnit));
+  };
+
+  const run = async () => {
+    if (!file) return;
+    setBusy(true);
+    setError('');
+    setResult(null);
+    try {
+      const base = file.name.replace(/\.[^.]+$/, '');
+      if (isPdf) {
+        const { compressPdfToTarget } = await import('@/tools/pdf/pdf-to-size.lib');
+        const r = await compressPdfToTarget(file, targetBytes);
+        setResult({ blob: r.blob, achieved: r.achieved, rasterized: r.rasterized, name: `${base}-compressed.pdf` });
+      } else if (isImage) {
+        const { compressImageToTarget } = await import('@/tools/image/image-to-size.lib');
+        const r = await compressImageToTarget(file, targetBytes, format);
+        setResult({ blob: r.blob, achieved: r.achieved, name: `${base}-compressed.${format === 'webp' ? 'webp' : 'jpg'}` });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <Dropzone onDrop={onDrop} accept="image/*,application/pdf" multiple={false}>
+        <div className="space-y-1">
+          <p className="text-lg font-bold">{t.drop}</p>
+          <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+        </div>
+      </Dropzone>
+
+      {file && (
+        <>
+          <p className="text-sm">
+            <span className="font-bold">{file.name}</span>{' '}
+            <span className="text-muted-foreground">· {t.original}: {formatSize(file.size)}</span>
+          </p>
+
+          <div className="space-y-1.5">
+            <span className="block text-sm font-semibold">{t.target}</span>
+            <div className="flex flex-wrap items-center gap-2">
+              {TARGET_PRESETS.map(p => (
+                <button key={p.bytes} onClick={() => setTargetBytes(p.bytes)}
+                  aria-pressed={targetBytes === p.bytes}
+                  className={`border-2 px-3 py-1 text-sm font-medium transition-all ${targetBytes === p.bytes ? 'border-border bg-accent text-accent-foreground shadow-brutal' : 'border-border hover:shadow-brutal'}`}>
+                  {p.label}
+                </button>
+              ))}
+              <span className="flex items-center gap-1">
+                <input type="number" min={1} value={customValue} onChange={e => setCustomValue(e.target.value)} onBlur={applyCustom}
+                  className="w-20 border-2 border-border bg-muted p-1.5 text-sm" />
+                <select value={customUnit} onChange={e => { setCustomUnit(e.target.value as SizeUnit); }}
+                  className="border-2 border-border bg-background px-2 py-1.5 text-sm">
+                  <option value="KB">KB</option>
+                  <option value="MB">MB</option>
+                </select>
+                <Button variant="secondary" onClick={applyCustom} className="text-xs">{t.custom}</Button>
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">→ {formatSize(targetBytes)}</p>
+          </div>
+
+          {isImage && (
+            <div className="space-y-1 text-sm">
+              <span className="block font-semibold">{t.imageFormat}</span>
+              <div className="flex gap-1">
+                {(['jpeg', 'webp'] as const).map(f => (
+                  <button key={f} onClick={() => setFormat(f)} aria-pressed={format === f}
+                    className={`border-2 px-3 py-1 font-medium transition-all ${format === f ? 'border-border bg-accent text-accent-foreground shadow-brutal' : 'border-border hover:shadow-brutal'}`}>
+                    {f.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <Button onClick={run} disabled={busy || targetBytes <= 0}>{busy ? t.working : t.compress}</Button>
+        </>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {result && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <span className="font-bold uppercase tracking-wide text-muted-foreground">{t.result}</span>
+            <span className="font-mono">{formatSize(result.blob.size)}</span>
+            {file && result.blob.size < file.size && (
+              <span className="font-bold text-green-600 dark:text-green-400">−{pctSmaller(file.size, result.blob.size)}% {t.smaller}</span>
+            )}
+          </div>
+          {!result.achieved && <Alert variant="error">{t.missed(formatSize(result.blob.size))}</Alert>}
+          {result.rasterized && <p className="text-xs text-muted-foreground">{t.rasterNote}</p>}
+          {result.blob.type.startsWith('image/')
+            ? <ImageResult blob={result.blob} filename={result.name} originalSize={file?.size} />
+            : <ResultActions blob={result.blob} filename={result.name} />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -313,6 +313,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. As a PWA it keeps generating favicons with no connection once loaded.' },
     ],
   },
+  'compress-to-size': {
+    title: 'Compress JPG, PNG & PDF to a Target Size (100 KB, 500 KB) — Free',
+    description: 'Compress an image or PDF to an exact target file size — 100 KB, 200 KB, 500 KB or any size you set. Perfect for upload limits. Runs in your browser; nothing is uploaded.',
+    intro: 'Need a photo under 100 KB or a PDF under 500 KB for a form upload? This free tool compresses a JPG, PNG, WebP or PDF down to the file size you choose. For images it searches the best quality (and downscales if needed) to just fit your target; for PDFs it compresses losslessly first, then flattens to images only if it must to reach the size. Everything runs on your device, so your file is never uploaded.',
+    howTo: [
+      'Drop or paste an image (JPG/PNG/WebP) or a PDF.',
+      'Pick a target size — 100 KB, 500 KB, 1 MB, or type your own.',
+      'For images, choose JPG or WebP output.',
+      'Click Compress, then download the file that fits your size limit.',
+    ],
+    faqs: [
+      { q: 'Is my file uploaded to a server?', a: 'No. All compression happens in your browser using the canvas and on-device PDF engine, so your image or PDF never leaves your device — safe for IDs, certificates and confidential documents.' },
+      { q: 'How do I compress a JPG to 100 KB?', a: 'Drop the JPG, choose the 100 KB preset (or type it), and click Compress. The tool searches the highest quality that fits 100 KB and downscales only if needed, then gives you the file to download.' },
+      { q: 'How do I compress a PDF to a target size?', a: 'Drop the PDF and pick a target. It first compresses losslessly (keeping selectable text); if that is still too big, it flattens pages to images at lower resolution until it fits — the usual way to hit a strict PDF size limit.' },
+      { q: 'What if it can’t reach my target?', a: 'If the target is smaller than what is achievable, the tool returns the smallest version it could make and tells you — just pick a slightly larger target.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded it keeps compressing with no internet connection.' },
+    ],
+  },
   'pdf-organize': {
     title: 'Free Organize PDF — Reorder, Delete Pages & Add Page Numbers',
     description: 'Organize a PDF in your browser: drag to reorder pages, delete pages, and add page numbers, then download. Nothing is uploaded.',
@@ -2161,6 +2179,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'File apa saja yang saya dapatkan?', a: 'favicon.ico (16/32/48), PNG favicon-16/32/48, apple-touch-icon (180px), PNG android-chrome 192 dan 512, site.webmanifest, dan snippet HTML.' },
       { q: 'Gambar seperti apa yang sebaiknya dipakai?', a: 'Gambar persegi minimal 512×512 paling bagus agar ikon terbesar tetap tajam. Desain sederhana berkontras tinggi paling terbaca pada 16px.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. Sebagai PWA tetap membuat favicon tanpa koneksi setelah dimuat.' },
+    ],
+  },
+  'compress-to-size': {
+    title: 'Kompres JPG, PNG & PDF ke Ukuran Target (100 KB, 500 KB) — Gratis',
+    description: 'Kompres gambar atau PDF ke ukuran file tepat — 100 KB, 200 KB, 500 KB, atau ukuran apa pun. Pas untuk batas unggah CPNS, SNBP, dan beasiswa. Berjalan di browser; tidak ada yang diunggah.',
+    intro: 'Butuh foto di bawah 100 KB atau PDF di bawah 500 KB untuk unggahan formulir? Tool gratis ini mengompres JPG, PNG, WebP, atau PDF hingga ukuran file yang Anda pilih. Untuk gambar, tool mencari kualitas terbaik (dan memperkecil bila perlu) agar pas dengan target; untuk PDF, dikompres lossless dulu, lalu diratakan menjadi gambar hanya bila perlu untuk mencapai ukuran. Semuanya berjalan di perangkat Anda, jadi file tidak pernah diunggah.',
+    howTo: [
+      'Letakkan atau tempel gambar (JPG/PNG/WebP) atau PDF.',
+      'Pilih ukuran target — 100 KB, 500 KB, 1 MB, atau ketik sendiri.',
+      'Untuk gambar, pilih keluaran JPG atau WebP.',
+      'Klik Kompres, lalu unduh file yang sesuai batas ukuran Anda.',
+    ],
+    faqs: [
+      { q: 'Apakah file saya diunggah ke server?', a: 'Tidak. Semua kompresi terjadi di browser Anda menggunakan canvas dan mesin PDF di perangkat, jadi gambar atau PDF Anda tidak pernah meninggalkan perangkat — aman untuk KTP, ijazah, dan dokumen rahasia.' },
+      { q: 'Bagaimana cara kompres JPG ke 100 KB?', a: 'Letakkan JPG, pilih preset 100 KB (atau ketik), lalu klik Kompres. Tool mencari kualitas tertinggi yang pas dengan 100 KB dan hanya memperkecil bila perlu, lalu memberi file untuk diunduh.' },
+      { q: 'Bagaimana cara kompres PDF ke ukuran target?', a: 'Letakkan PDF dan pilih target. Tool mengompres lossless dulu (mempertahankan teks yang bisa diseleksi); bila masih terlalu besar, halaman diratakan menjadi gambar pada resolusi lebih rendah hingga pas — cara umum untuk mencapai batas ukuran PDF yang ketat.' },
+      { q: 'Bagaimana jika target tidak tercapai?', a: 'Jika target lebih kecil dari yang bisa dicapai, tool mengembalikan versi terkecil yang bisa dibuat dan memberi tahu Anda — cukup pilih target sedikit lebih besar.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tetap bisa mengompres tanpa koneksi internet.' },
     ],
   },
   'pdf-organize': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -364,6 +364,17 @@ export const tools: ToolDef[] = [
     icon: AppWindow,
     summary: 'Turn an image into a favicon set (ICO, PNGs, manifest)',
     load: () => import('@/islands/image/FaviconGenerator'),
+    status: 'beta'
+  },
+  {
+    id: 'compress-to-size',
+    name: 'Compress to Size',
+    category: 'Files',
+    route: '/tools/compress-to-size',
+    keywords: ['compress', 'reduce file size', 'target size', 'compress jpg to 100kb', 'compress pdf', 'kompres pdf', 'kompres foto', 'compress image', 'kb', 'mb', 'shrink'],
+    icon: Shrink,
+    summary: 'Compress an image or PDF to a target file size (e.g. 100 KB)',
+    load: () => import('@/islands/files/CompressToSize'),
     status: 'beta'
   },
   {

--- a/src/tools/files/compress-target.lib.test.ts
+++ b/src/tools/files/compress-target.lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { targetToBytes, pctSmaller, formatSize, TARGET_PRESETS } from './compress-target.lib';
+
+describe('targetToBytes', () => {
+  it('converts KB and MB', () => {
+    expect(targetToBytes(100, 'KB')).toBe(102400);
+    expect(targetToBytes(1, 'MB')).toBe(1048576);
+    expect(targetToBytes(0.5, 'MB')).toBe(524288);
+  });
+  it('never returns negative', () => {
+    expect(targetToBytes(-5, 'KB')).toBe(0);
+  });
+});
+
+describe('pctSmaller', () => {
+  it('computes reduction', () => {
+    expect(pctSmaller(1000, 250)).toBe(75);
+    expect(pctSmaller(0, 100)).toBe(0);
+  });
+});
+
+describe('formatSize', () => {
+  it.each([
+    [500, '500 B'],
+    [1536, '1.5 KB'],
+    [102400, '100.0 KB'],
+    [1572864, '1.50 MB'],
+  ])('formats %i bytes as %s', (b, s) => {
+    expect(formatSize(b)).toBe(s);
+  });
+});
+
+describe('TARGET_PRESETS', () => {
+  it('includes the common Indonesian upload caps', () => {
+    expect(TARGET_PRESETS.map(p => p.bytes)).toContain(100 * 1024);
+    expect(TARGET_PRESETS.map(p => p.bytes)).toContain(500 * 1024);
+  });
+});

--- a/src/tools/files/compress-target.lib.ts
+++ b/src/tools/files/compress-target.lib.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared helpers for "compress to a target file size" — pure.
+ */
+
+export type SizeUnit = 'KB' | 'MB';
+
+export const TARGET_PRESETS: { label: string; bytes: number }[] = [
+  { label: '50 KB', bytes: 50 * 1024 },
+  { label: '100 KB', bytes: 100 * 1024 },
+  { label: '200 KB', bytes: 200 * 1024 },
+  { label: '500 KB', bytes: 500 * 1024 },
+  { label: '1 MB', bytes: 1024 * 1024 },
+  { label: '2 MB', bytes: 2 * 1024 * 1024 },
+];
+
+/** Convert a user-entered size + unit to bytes. */
+export function targetToBytes(value: number, unit: SizeUnit): number {
+  return Math.max(0, Math.round(value * (unit === 'MB' ? 1024 * 1024 : 1024)));
+}
+
+/** Percentage smaller `to` is than `from` (negative if it grew). */
+export function pctSmaller(from: number, to: number): number {
+  return from > 0 ? Math.round((1 - to / from) * 100) : 0;
+}
+
+/** Human-readable byte size. */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/src/tools/image/image-to-size.lib.ts
+++ b/src/tools/image/image-to-size.lib.ts
@@ -1,0 +1,65 @@
+/**
+ * Compress an image to hit a target file size by searching quality and, if
+ * needed, downscaling. Browser-only (canvas). JPEG/WebP have a real quality
+ * dial, so PNG inputs are re-encoded to one of those to reach a size target.
+ */
+import { encodeCanvas } from './canvas.lib';
+
+export interface ImageCompressResult {
+  blob: Blob;
+  quality: number;
+  /** Output dimensions as a percentage of the original (100 = full size). */
+  scalePct: number;
+  /** True if the target was met; false = smallest achievable is returned. */
+  achieved: boolean;
+}
+
+const SCALES = [1, 0.85, 0.7, 0.55, 0.42, 0.32, 0.24, 0.18];
+
+export async function compressImageToTarget(
+  file: File,
+  targetBytes: number,
+  format: 'jpeg' | 'webp',
+): Promise<ImageCompressResult> {
+  const bitmap = await createImageBitmap(file);
+  const mime = format === 'webp' ? 'image/webp' : 'image/jpeg';
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  let smallest: ImageCompressResult | null = null;
+  try {
+    if (!ctx) throw new Error('Canvas not supported');
+    for (const scale of SCALES) {
+      const w = Math.max(1, Math.round(bitmap.width * scale));
+      const h = Math.max(1, Math.round(bitmap.height * scale));
+      canvas.width = w;
+      canvas.height = h;
+      if (mime === 'image/jpeg') { ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, w, h); }
+      ctx.drawImage(bitmap, 0, 0, w, h);
+
+      // Binary-search the highest quality that still fits the target.
+      let lo = 0.05;
+      let hi = 0.98;
+      let fit: ImageCompressResult | null = null;
+      for (let i = 0; i < 8; i++) {
+        const q = (lo + hi) / 2;
+        const blob = await encodeCanvas(canvas, mime, q);
+        if (blob.size <= targetBytes) {
+          fit = { blob, quality: q, scalePct: Math.round(scale * 100), achieved: true };
+          lo = q;
+        } else {
+          hi = q;
+        }
+      }
+      if (fit) return fit; // largest scale that fits = best quality → done
+
+      // Track the smallest we can make, as a fallback if the target is unreachable.
+      const minBlob = await encodeCanvas(canvas, mime, 0.05);
+      if (!smallest || minBlob.size < smallest.blob.size) {
+        smallest = { blob: minBlob, quality: 0.05, scalePct: Math.round(scale * 100), achieved: false };
+      }
+    }
+    return smallest as ImageCompressResult;
+  } finally {
+    bitmap.close?.();
+  }
+}

--- a/src/tools/pdf/pdf-to-size.lib.ts
+++ b/src/tools/pdf/pdf-to-size.lib.ts
@@ -1,0 +1,53 @@
+/**
+ * Compress a PDF toward a target file size. First tries mupdf's lossless
+ * compression (keeps selectable text); if that isn't small enough, rasterizes
+ * pages at progressively lower resolution/quality until the target is met.
+ * Browser-only.
+ */
+import { compressPdf } from './pdf.lib';
+import { openPdfRenderer } from './render.lib';
+
+export interface PdfCompressResult {
+  blob: Blob;
+  achieved: boolean;
+  /** True when pages were flattened to images (text is no longer selectable). */
+  rasterized: boolean;
+}
+
+const RASTER_STEPS: [scale: number, quality: number][] = [
+  [1.5, 0.7], [1.25, 0.6], [1.0, 0.55], [0.85, 0.5], [0.7, 0.45], [0.55, 0.4], [0.45, 0.35],
+];
+
+export async function compressPdfToTarget(
+  file: File,
+  targetBytes: number,
+  onStage?: (stage: 'lossless' | 'rasterizing') => void,
+): Promise<PdfCompressResult> {
+  onStage?.('lossless');
+  const lossless = await compressPdf(file);
+  if (lossless.size <= targetBytes) return { blob: lossless, achieved: true, rasterized: false };
+
+  const { PDFDocument } = await import('pdf-lib');
+  const data = await file.arrayBuffer();
+  let smallest = lossless;
+  for (const [scale, quality] of RASTER_STEPS) {
+    onStage?.('rasterizing');
+    const renderer = await openPdfRenderer(data);
+    try {
+      const out = await PDFDocument.create();
+      for (let p = 1; p <= renderer.pageCount; p++) {
+        const page = await renderer.renderPage(p, scale, 'image/jpeg', quality);
+        const bytes = new Uint8Array(await page.blob.arrayBuffer());
+        const img = await out.embedJpg(bytes);
+        const pg = out.addPage([img.width, img.height]);
+        pg.drawImage(img, { x: 0, y: 0, width: img.width, height: img.height });
+      }
+      const blob = new Blob([await out.save()], { type: 'application/pdf' });
+      if (blob.size <= targetBytes) return { blob, achieved: true, rasterized: true };
+      if (blob.size < smallest.size) smallest = blob;
+    } finally {
+      renderer.destroy();
+    }
+  }
+  return { blob: smallest, achieved: false, rasterized: smallest !== lossless };
+}


### PR DESCRIPTION
Adds a new **Compress to Size** tool (Files category).

- Upload a **JPG/PNG/WebP or PDF** and compress it to hit a **target file size** (100 KB, 500 KB, or custom KB/MB) — for form/upload limits.
- **Images**: binary-search JPEG/WebP quality per scale, downscaling only if needed to fit the target (best quality that fits wins).
- **PDF**: lossless compression first (keeps selectable text); if still too big, rasterize pages at progressively lower res/quality until it fits (with a note that text is no longer selectable).
- 100% client-side; nothing is uploaded.
- Pure lib `compress-target.lib.ts` unit-tested (8 tests); browser libs `image-to-size.lib.ts` + `pdf-to-size.lib.ts`.
- EN + ID SEO entries (title/description/intro/howTo/faqs) targeting *compress jpg to 100kb*, *kompres pdf 500kb*, etc.

Verify: full suite green (1114), lint 0 errors, build OK, both `/tools/compress-to-size/` and `/id/tools/compress-to-size/` built.