### PR TITLE
feat(calculators): Unit Converter

### DIFF
--- a/src/islands/calculators/UnitConverter.tsx
+++ b/src/islands/calculators/UnitConverter.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { UNIT_CATEGORIES, getCategory, convert, formatNumber } from '@/tools/calculators/units.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, { intro: string; category: string; from: string; to: string; swap: string; value: string; result: string }> = {
+  en: {
+    intro: 'Convert between units of length, mass, temperature, area, volume, speed, time and digital storage. Type a value and read the result instantly — everything is computed in your browser.',
+    category: 'Category', from: 'From', to: 'To', swap: 'Swap', value: 'Value', result: 'Result',
+  },
+  id: {
+    intro: 'Konversi antar satuan panjang, massa, suhu, luas, volume, kecepatan, waktu, dan penyimpanan digital. Ketik nilai dan lihat hasilnya seketika — semua dihitung di browser Anda.',
+    category: 'Kategori', from: 'Dari', to: 'Ke', swap: 'Tukar', value: 'Nilai', result: 'Hasil',
+  },
+};
+
+export default function UnitConverter({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const l: Lang = lang === 'id' ? 'id' : 'en';
+  const [catId, setCatId] = useState(UNIT_CATEGORIES[0].id);
+  const [fromId, setFromId] = useState(UNIT_CATEGORIES[0].units[0].id);
+  const [toId, setToId] = useState(UNIT_CATEGORIES[0].units[1].id);
+  const [value, setValue] = useState('1');
+
+  const cat = getCategory(catId)!;
+
+  const output = useMemo(() => {
+    const v = Number(value);
+    if (value.trim() === '' || !Number.isFinite(v)) return '';
+    try {
+      return formatNumber(convert(catId, v, fromId, toId));
+    } catch {
+      return '';
+    }
+  }, [catId, value, fromId, toId]);
+
+  const pickCategory = (id: string) => {
+    const c = getCategory(id)!;
+    setCatId(id);
+    setFromId(c.units[0].id);
+    setToId(c.units[1]?.id ?? c.units[0].id);
+  };
+
+  const swap = () => {
+    setFromId(toId);
+    setToId(fromId);
+    if (output !== '') setValue(output);
+  };
+
+  const unitOptions = cat.units.map(u => (
+    <option key={u.id} value={u.id}>{u.label[l]} ({u.symbol})</option>
+  ));
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="space-y-1.5">
+        <span className="block text-sm font-semibold">{t.category}</span>
+        <div className="flex flex-wrap gap-2">
+          {UNIT_CATEGORIES.map(c => (
+            <button key={c.id} onClick={() => pickCategory(c.id)} aria-pressed={catId === c.id}
+              className={`border-2 px-3 py-1 text-sm font-medium transition-all ${catId === c.id ? 'border-border bg-accent text-accent-foreground shadow-brutal' : 'border-border hover:shadow-brutal'}`}>
+              {c.label[l]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid items-end gap-3 sm:grid-cols-[1fr_auto_1fr]">
+        <div className="space-y-1 text-sm">
+          <span className="block font-semibold">{t.from}</span>
+          <input type="number" inputMode="decimal" value={value} onChange={e => setValue(e.target.value)}
+            aria-label={t.value}
+            className="w-full border-2 border-border bg-muted p-2 text-sm tabular-nums" />
+          <select value={fromId} onChange={e => setFromId(e.target.value)}
+            className="w-full border-2 border-border bg-background p-2 text-sm">{unitOptions}</select>
+        </div>
+
+        <div className="flex justify-center pb-2 sm:pb-8">
+          <Button variant="secondary" onClick={swap} className="text-xs" aria-label={t.swap}>⇄ {t.swap}</Button>
+        </div>
+
+        <div className="space-y-1 text-sm">
+          <span className="block font-semibold">{t.to}</span>
+          <output aria-label={t.result}
+            className="block w-full break-words border-2 border-border bg-accent p-2 text-sm font-bold tabular-nums text-accent-foreground min-h-[2.5rem]">
+            {output || '—'}
+          </output>
+          <select value={toId} onChange={e => setToId(e.target.value)}
+            className="w-full border-2 border-border bg-background p-2 text-sm">{unitOptions}</select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -349,6 +349,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the calculator works with no internet connection.' },
     ],
   },
+  'unit-converter': {
+    title: 'Free Unit Converter — Length, Weight, Temperature & More',
+    description: 'Convert between units of length, mass, temperature, area, volume, speed, time and digital storage — km to miles, kg to lb, °C to °F and more. Instant, in your browser.',
+    intro: 'A fast, accurate unit converter for everyday measurements — length, mass, temperature, area, volume, speed, time and digital storage. Pick a category, type a value, and read the converted result instantly. All conversions run in your browser with no rounding surprises; nothing is uploaded.',
+    howTo: [
+      'Choose a category (length, mass, temperature, …).',
+      'Type the value you want to convert.',
+      'Pick the “from” and “to” units.',
+      'Read the result instantly, or hit Swap to reverse the direction.',
+    ],
+    faqs: [
+      { q: 'Is anything uploaded?', a: 'No. The converter runs entirely in your browser — your values never leave your device.' },
+      { q: 'How do I convert km to miles or kg to lb?', a: 'Pick the Length or Mass category, type your value, then set the units (e.g. km → mi, or kg → lb). The result updates as you type.' },
+      { q: 'How is temperature handled?', a: 'Temperature uses proper affine conversions, so 100 °C correctly gives 212 °F and 0 °C gives 273.15 K — not a naive multiply.' },
+      { q: 'Does it cover both metric (1000) and binary (1024) data sizes?', a: 'Yes. Digital storage includes both decimal units (KB, MB, GB = 1000) and binary units (KiB, MiB, GiB = 1024).' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the converter works with no internet connection.' },
+    ],
+  },
   'pdf-organize': {
     title: 'Free Organize PDF — Reorder, Delete Pages & Add Page Numbers',
     description: 'Organize a PDF in your browser: drag to reorder pages, delete pages, and add page numbers, then download. Nothing is uploaded.',
@@ -2233,6 +2251,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apa itu weton dan neptu?', a: 'Weton adalah perpaduan Jawa antara siklus 7 hari dengan siklus pasaran 5 hari (Legi, Pahing, Pon, Wage, Kliwon) — misalnya “Jumat Legi”. Neptu adalah nilai angka tiap bagian; jumlahnya dipakai dalam tradisi Jawa.' },
       { q: 'Bisakah menghitung usia pada tanggal lampau atau mendatang?', a: 'Bisa. Ubah kolom “Usia pada tanggal” ke tanggal mana pun untuk melihat usia, total, dan weton relatif terhadap hari itu.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat kalkulator bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'unit-converter': {
+    title: 'Konverter Satuan Gratis — Panjang, Berat, Suhu & Lainnya',
+    description: 'Konversi antar satuan panjang, massa, suhu, luas, volume, kecepatan, waktu, dan penyimpanan digital — km ke mil, kg ke lb, °C ke °F, dan lainnya. Seketika, di browser.',
+    intro: 'Konverter satuan yang cepat dan akurat untuk pengukuran sehari-hari — panjang, massa, suhu, luas, volume, kecepatan, waktu, dan penyimpanan digital. Pilih kategori, ketik nilai, dan lihat hasil konversi seketika. Semua konversi berjalan di browser Anda tanpa kejutan pembulatan; tidak ada yang diunggah.',
+    howTo: [
+      'Pilih kategori (panjang, massa, suhu, …).',
+      'Ketik nilai yang ingin dikonversi.',
+      'Pilih satuan “dari” dan “ke”.',
+      'Lihat hasilnya seketika, atau tekan Tukar untuk membalik arah.',
+    ],
+    faqs: [
+      { q: 'Apakah ada yang diunggah?', a: 'Tidak. Konverter berjalan sepenuhnya di browser Anda — nilai Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Bagaimana konversi km ke mil atau kg ke lb?', a: 'Pilih kategori Panjang atau Massa, ketik nilai, lalu set satuannya (mis. km → mi, atau kg → lb). Hasil diperbarui saat Anda mengetik.' },
+      { q: 'Bagaimana suhu ditangani?', a: 'Suhu memakai konversi afin yang benar, sehingga 100 °C tepat menjadi 212 °F dan 0 °C menjadi 273,15 K — bukan sekadar perkalian.' },
+      { q: 'Apakah mencakup ukuran data desimal (1000) dan biner (1024)?', a: 'Ya. Penyimpanan digital mencakup satuan desimal (KB, MB, GB = 1000) dan biner (KiB, MiB, GiB = 1024).' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat konverter bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-organize': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -386,6 +386,17 @@ export const tools: ToolDef[] = [
     icon: Cake,
     summary: 'Work out an exact age plus your Javanese weton and neptu',
     load: () => import('@/islands/calculators/AgeWeton'),
+    status: 'beta'
+  },
+  {
+    id: 'unit-converter',
+    name: 'Unit Converter',
+    category: 'Calculators',
+    route: '/tools/unit-converter',
+    keywords: ['unit converter', 'convert units', 'length', 'weight', 'temperature', 'celsius fahrenheit', 'km to miles', 'kg to lb', 'konversi satuan', 'metric imperial'],
+    icon: Ruler,
+    summary: 'Convert length, mass, temperature, volume, speed and more',
+    load: () => import('@/islands/calculators/UnitConverter'),
     status: 'beta'
   },
   {

--- a/src/tools/calculators/units.lib.test.ts
+++ b/src/tools/calculators/units.lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { UNIT_CATEGORIES, convert, formatNumber, getCategory } from './units.lib';
+
+describe('convert — linear', () => {
+  it('length: 1 mile = 1609.344 m', () => {
+    expect(convert('length', 1, 'mi', 'm')).toBeCloseTo(1609.344, 6);
+  });
+  it('length: 100 cm = 1 m', () => {
+    expect(convert('length', 100, 'cm', 'm')).toBeCloseTo(1, 12);
+  });
+  it('mass: 1 kg ≈ 2.2046226 lb', () => {
+    expect(convert('mass', 1, 'kg', 'lb')).toBeCloseTo(2.2046226, 6);
+  });
+  it('digital: 1 GiB = 1073741824 byte', () => {
+    expect(convert('digital', 1, 'GiB', 'B')).toBe(1073741824);
+  });
+  it('same unit is identity', () => {
+    expect(convert('volume', 3.5, 'l', 'l')).toBe(3.5);
+  });
+  it('round-trips within tolerance', () => {
+    const there = convert('speed', 65, 'mph', 'kmh');
+    expect(convert('speed', there, 'kmh', 'mph')).toBeCloseTo(65, 9);
+  });
+});
+
+describe('convert — temperature (affine)', () => {
+  it('100 °C = 212 °F', () => {
+    expect(convert('temperature', 100, 'C', 'F')).toBeCloseTo(212, 9);
+  });
+  it('0 °C = 273.15 K', () => {
+    expect(convert('temperature', 0, 'C', 'K')).toBeCloseTo(273.15, 9);
+  });
+  it('32 °F = 0 °C', () => {
+    expect(convert('temperature', 32, 'F', 'C')).toBeCloseTo(0, 9);
+  });
+});
+
+describe('convert — guards', () => {
+  it('unknown category throws', () => {
+    expect(() => convert('nope', 1, 'a', 'b')).toThrow();
+  });
+  it('unknown unit throws', () => {
+    expect(() => convert('length', 1, 'm', 'parsec')).toThrow();
+  });
+});
+
+describe('getCategory / registry', () => {
+  it('exposes several categories each with ≥2 units', () => {
+    expect(UNIT_CATEGORIES.length).toBeGreaterThanOrEqual(6);
+    for (const c of UNIT_CATEGORIES) expect(c.units.length).toBeGreaterThanOrEqual(2);
+  });
+  it('looks a category up by id', () => {
+    expect(getCategory('length')?.units.some(u => u.id === 'km')).toBe(true);
+  });
+});
+
+describe('formatNumber', () => {
+  it('trims trailing zeros', () => {
+    expect(formatNumber(1)).toBe('1');
+    expect(formatNumber(1.5)).toBe('1.5');
+  });
+  it('keeps precision for small values', () => {
+    expect(Number(formatNumber(0.0254))).toBeCloseTo(0.0254, 12);
+  });
+  it('handles large values without scientific noise for readable ranges', () => {
+    expect(formatNumber(1609.344)).toBe('1609.344');
+  });
+});

--- a/src/tools/calculators/units.lib.ts
+++ b/src/tools/calculators/units.lib.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure unit-conversion engine. Each unit converts to/from a category base unit,
+ * which handles both linear scales (length, mass, …) and affine ones
+ * (temperature) uniformly. No I/O, no browser APIs.
+ */
+import type { Lang } from '@/i18n/config';
+
+export interface Unit {
+  id: string;
+  symbol: string;
+  label: Record<Lang, string>;
+  toBase: (v: number) => number;
+  fromBase: (v: number) => number;
+}
+
+export interface UnitCategory {
+  id: string;
+  label: Record<Lang, string>;
+  units: Unit[];
+}
+
+/** Build a linear unit whose value is `factor` base units. */
+function lin(id: string, symbol: string, en: string, id_: string, factor: number): Unit {
+  return {
+    id,
+    symbol,
+    label: { en, id: id_ },
+    toBase: (v) => v * factor,
+    fromBase: (v) => v / factor,
+  };
+}
+
+export const UNIT_CATEGORIES: UnitCategory[] = [
+  {
+    id: 'length',
+    label: { en: 'Length', id: 'Panjang' },
+    units: [
+      lin('mm', 'mm', 'Millimetre', 'Milimeter', 0.001),
+      lin('cm', 'cm', 'Centimetre', 'Sentimeter', 0.01),
+      lin('m', 'm', 'Metre', 'Meter', 1),
+      lin('km', 'km', 'Kilometre', 'Kilometer', 1000),
+      lin('in', 'in', 'Inch', 'Inci', 0.0254),
+      lin('ft', 'ft', 'Foot', 'Kaki', 0.3048),
+      lin('yd', 'yd', 'Yard', 'Yard', 0.9144),
+      lin('mi', 'mi', 'Mile', 'Mil', 1609.344),
+      lin('nmi', 'nmi', 'Nautical mile', 'Mil laut', 1852),
+    ],
+  },
+  {
+    id: 'mass',
+    label: { en: 'Mass', id: 'Massa' },
+    units: [
+      lin('mg', 'mg', 'Milligram', 'Miligram', 1e-6),
+      lin('g', 'g', 'Gram', 'Gram', 0.001),
+      lin('kg', 'kg', 'Kilogram', 'Kilogram', 1),
+      lin('t', 't', 'Tonne', 'Ton', 1000),
+      lin('oz', 'oz', 'Ounce', 'Ons (oz)', 0.028349523125),
+      lin('lb', 'lb', 'Pound', 'Pon', 0.45359237),
+      lin('st', 'st', 'Stone', 'Stone', 6.35029318),
+    ],
+  },
+  {
+    id: 'temperature',
+    label: { en: 'Temperature', id: 'Suhu' },
+    units: [
+      { id: 'C', symbol: '°C', label: { en: 'Celsius', id: 'Celsius' }, toBase: (v) => v, fromBase: (v) => v },
+      { id: 'F', symbol: '°F', label: { en: 'Fahrenheit', id: 'Fahrenheit' }, toBase: (v) => (v - 32) * 5 / 9, fromBase: (v) => v * 9 / 5 + 32 },
+      { id: 'K', symbol: 'K', label: { en: 'Kelvin', id: 'Kelvin' }, toBase: (v) => v - 273.15, fromBase: (v) => v + 273.15 },
+    ],
+  },
+  {
+    id: 'area',
+    label: { en: 'Area', id: 'Luas' },
+    units: [
+      lin('mm2', 'mm²', 'Square millimetre', 'Milimeter persegi', 1e-6),
+      lin('cm2', 'cm²', 'Square centimetre', 'Sentimeter persegi', 1e-4),
+      lin('m2', 'm²', 'Square metre', 'Meter persegi', 1),
+      lin('ha', 'ha', 'Hectare', 'Hektare', 10000),
+      lin('km2', 'km²', 'Square kilometre', 'Kilometer persegi', 1e6),
+      lin('in2', 'in²', 'Square inch', 'Inci persegi', 0.00064516),
+      lin('ft2', 'ft²', 'Square foot', 'Kaki persegi', 0.09290304),
+      lin('acre', 'acre', 'Acre', 'Acre', 4046.8564224),
+      lin('mi2', 'mi²', 'Square mile', 'Mil persegi', 2589988.110336),
+    ],
+  },
+  {
+    id: 'volume',
+    label: { en: 'Volume', id: 'Volume' },
+    units: [
+      lin('ml', 'ml', 'Millilitre', 'Mililiter', 0.001),
+      lin('l', 'l', 'Litre', 'Liter', 1),
+      lin('m3', 'm³', 'Cubic metre', 'Meter kubik', 1000),
+      lin('tsp', 'tsp', 'Teaspoon (US)', 'Sendok teh (US)', 0.00492892159375),
+      lin('tbsp', 'tbsp', 'Tablespoon (US)', 'Sendok makan (US)', 0.01478676478125),
+      lin('floz', 'fl oz', 'Fluid ounce (US)', 'Fluid ounce (US)', 0.0295735295625),
+      lin('cup', 'cup', 'Cup (US)', 'Cangkir (US)', 0.2365882365),
+      lin('pt', 'pt', 'Pint (US)', 'Pint (US)', 0.473176473),
+      lin('qt', 'qt', 'Quart (US)', 'Quart (US)', 0.946352946),
+      lin('gal', 'gal', 'Gallon (US)', 'Galon (US)', 3.785411784),
+    ],
+  },
+  {
+    id: 'speed',
+    label: { en: 'Speed', id: 'Kecepatan' },
+    units: [
+      lin('ms', 'm/s', 'Metre / second', 'Meter / detik', 1),
+      lin('kmh', 'km/h', 'Kilometre / hour', 'Kilometer / jam', 0.2777777777777778),
+      lin('mph', 'mph', 'Mile / hour', 'Mil / jam', 0.44704),
+      lin('knot', 'kn', 'Knot', 'Knot', 0.5144444444444445),
+      lin('fts', 'ft/s', 'Foot / second', 'Kaki / detik', 0.3048),
+    ],
+  },
+  {
+    id: 'time',
+    label: { en: 'Time', id: 'Waktu' },
+    units: [
+      lin('ms', 'ms', 'Millisecond', 'Milidetik', 0.001),
+      lin('s', 's', 'Second', 'Detik', 1),
+      lin('min', 'min', 'Minute', 'Menit', 60),
+      lin('h', 'h', 'Hour', 'Jam', 3600),
+      lin('d', 'd', 'Day', 'Hari', 86400),
+      lin('wk', 'wk', 'Week', 'Minggu', 604800),
+    ],
+  },
+  {
+    id: 'digital',
+    label: { en: 'Digital storage', id: 'Penyimpanan digital' },
+    units: [
+      lin('bit', 'bit', 'Bit', 'Bit', 0.125),
+      lin('B', 'B', 'Byte', 'Byte', 1),
+      lin('KB', 'KB', 'Kilobyte (1000)', 'Kilobyte (1000)', 1e3),
+      lin('MB', 'MB', 'Megabyte (1000)', 'Megabyte (1000)', 1e6),
+      lin('GB', 'GB', 'Gigabyte (1000)', 'Gigabyte (1000)', 1e9),
+      lin('TB', 'TB', 'Terabyte (1000)', 'Terabyte (1000)', 1e12),
+      lin('KiB', 'KiB', 'Kibibyte (1024)', 'Kibibyte (1024)', 1024),
+      lin('MiB', 'MiB', 'Mebibyte (1024)', 'Mebibyte (1024)', 1048576),
+      lin('GiB', 'GiB', 'Gibibyte (1024)', 'Gibibyte (1024)', 1073741824),
+      lin('TiB', 'TiB', 'Tebibyte (1024)', 'Tebibyte (1024)', 1099511627776),
+    ],
+  },
+];
+
+export function getCategory(id: string): UnitCategory | undefined {
+  return UNIT_CATEGORIES.find((c) => c.id === id);
+}
+
+export function convert(categoryId: string, value: number, fromId: string, toId: string): number {
+  const cat = getCategory(categoryId);
+  if (!cat) throw new Error(`Unknown category: ${categoryId}`);
+  const from = cat.units.find((u) => u.id === fromId);
+  const to = cat.units.find((u) => u.id === toId);
+  if (!from) throw new Error(`Unknown unit: ${fromId}`);
+  if (!to) throw new Error(`Unknown unit: ${toId}`);
+  return to.fromBase(from.toBase(value));
+}
+
+/** Format a converted number for display: up to 12 significant digits, trailing zeros trimmed. */
+export function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (n === 0) return '0';
+  const abs = Math.abs(n);
+  // Use fixed notation for a readable range; fall back to precision for extremes.
+  let s: string;
+  if (abs >= 1e-6 && abs < 1e15) {
+    s = n.toFixed(12);
+    if (s.includes('.')) s = s.replace(/0+$/, '').replace(/\.$/, '');
+  } else {
+    s = n.toPrecision(12);
+    if (s.includes('e')) return s;
+    if (s.includes('.')) s = s.replace(/0+$/, '').replace(/\.$/, '');
+  }
+  return s;
+}


### PR DESCRIPTION
Adds a **Unit Converter** to the Calculators category (`/tools/unit-converter`).

- 8 categories: length, mass, temperature, area, volume, speed, time, digital storage.
- Base-unit engine converts to/from a category base, handling **linear** scales and **affine** temperature (100 °C → 212 °F, 0 °C → 273.15 K) uniformly.
- Digital storage covers both **decimal (1000)** and **binary (1024)** units.
- Type-to-convert, Swap button, per-locale unit labels.
- Pure `units.lib.ts` unit-tested (16 tests), fully client-side. EN + ID SEO.

Verify: 1148 tests green, lint 0 errors, build OK; both `/tools/unit-converter/` locales built and listed on the Calculators hub.