### PR TITLE
feat: Pomodoro Timer + True PDF Redaction

### DIFF
--- a/src/islands/calculators/TimerPomodoro.tsx
+++ b/src/islands/calculators/TimerPomodoro.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { formatClock, phaseDuration, nextPhase, type Phase, type PomodoroConfig } from '@/tools/calculators/pomodoro.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; work: string; short: string; long: string; round: string;
+  start: string; pause: string; reset: string; skip: string;
+  workMin: string; shortMin: string; longMin: string; rounds: string; settings: string; done: string;
+}> = {
+  en: {
+    intro: 'A Pomodoro focus timer: work in focused sessions with short breaks and a longer break every few rounds. Adjust the lengths to suit you. It beeps at the end of each phase and runs entirely in your browser.',
+    work: 'Focus', short: 'Short break', long: 'Long break', round: 'Round',
+    start: 'Start', pause: 'Pause', reset: 'Reset', skip: 'Skip',
+    workMin: 'Focus (min)', shortMin: 'Short break (min)', longMin: 'Long break (min)', rounds: 'Rounds → long break',
+    settings: 'Settings', done: 'sessions done',
+  },
+  id: {
+    intro: 'Timer fokus Pomodoro: bekerja dalam sesi fokus dengan istirahat singkat dan istirahat panjang setiap beberapa ronde. Sesuaikan durasinya. Tool berbunyi di akhir setiap fase dan berjalan sepenuhnya di browser Anda.',
+    work: 'Fokus', short: 'Istirahat singkat', long: 'Istirahat panjang', round: 'Ronde',
+    start: 'Mulai', pause: 'Jeda', reset: 'Atur ulang', skip: 'Lewati',
+    workMin: 'Fokus (menit)', shortMin: 'Istirahat singkat (menit)', longMin: 'Istirahat panjang (menit)', rounds: 'Ronde → istirahat panjang',
+    settings: 'Pengaturan', done: 'sesi selesai',
+  },
+};
+
+const DEFAULT_CFG: PomodoroConfig = { workMin: 25, shortMin: 5, longMin: 15, rounds: 4 };
+
+const PHASE_BG: Record<Phase, string> = {
+  work: 'bg-red-500 text-white',
+  short: 'bg-lime-500 text-black',
+  long: 'bg-cyan-500 text-black',
+};
+
+/** Short two-tone beep via Web Audio. Best-effort — silent if unavailable. */
+function beep() {
+  try {
+    const Ctx = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const now = ctx.currentTime;
+    const play = (freq: number, start: number, dur: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.frequency.value = freq;
+      osc.type = 'sine';
+      gain.gain.setValueAtTime(0.0001, now + start);
+      gain.gain.exponentialRampToValueAtTime(0.3, now + start + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + start + dur);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now + start);
+      osc.stop(now + start + dur);
+    };
+    play(880, 0, 0.2);
+    play(1320, 0.22, 0.25);
+    setTimeout(() => ctx.close().catch(() => {}), 700);
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function TimerPomodoro({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [cfg, setCfg] = useState<PomodoroConfig>(DEFAULT_CFG);
+  const [phase, setPhase] = useState<Phase>('work');
+  const [completedWork, setCompletedWork] = useState(0);
+  const [remaining, setRemaining] = useState(DEFAULT_CFG.workMin * 60);
+  const [running, setRunning] = useState(false);
+  const endRef = useRef<number>(0);
+
+  const phaseLabel = phase === 'work' ? t.work : phase === 'short' ? t.short : t.long;
+
+  // Reset the current phase's clock when config changes while idle.
+  useEffect(() => {
+    if (!running) setRemaining(phaseDuration(phase, cfg));
+  }, [cfg, phase, running]);
+
+  const advance = useCallback(() => {
+    beep();
+    const { phase: np, completedWork: cw } = nextPhase(phase, completedWork, cfg);
+    setPhase(np);
+    setCompletedWork(cw);
+    const dur = phaseDuration(np, cfg);
+    setRemaining(dur);
+    endRef.current = Date.now() + dur * 1000; // auto-continue into the next phase
+  }, [phase, completedWork, cfg]);
+
+  useEffect(() => {
+    if (!running) return;
+    const tick = () => {
+      const secs = Math.max(0, Math.round((endRef.current - Date.now()) / 1000));
+      setRemaining(secs);
+      if (secs <= 0) advance();
+    };
+    const id = window.setInterval(tick, 250);
+    return () => window.clearInterval(id);
+  }, [running, advance]);
+
+  const startPause = () => {
+    if (running) {
+      setRunning(false);
+    } else {
+      endRef.current = Date.now() + remaining * 1000;
+      setRunning(true);
+    }
+  };
+
+  const reset = () => {
+    setRunning(false);
+    setPhase('work');
+    setCompletedWork(0);
+    setRemaining(phaseDuration('work', cfg));
+  };
+
+  const skip = () => {
+    if (running) endRef.current = Date.now(); // let the tick advance cleanly
+    else advance();
+  };
+
+  const setNum = (key: keyof PomodoroConfig) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Math.max(1, Math.min(180, Math.round(Number(e.target.value) || 0)));
+    setCfg(c => ({ ...c, [key]: v }));
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className={`border-2 border-border p-6 text-center shadow-brutal ${PHASE_BG[phase]}`}>
+        <div className="text-xs font-black uppercase tracking-widest">{phaseLabel}</div>
+        <div className="mt-1 font-mono text-6xl font-black tabular-nums sm:text-7xl">{formatClock(remaining)}</div>
+        <div className="mt-1 text-xs font-semibold opacity-90">{completedWork} {t.done}</div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={startPause}>{running ? t.pause : t.start}</Button>
+        <Button variant="secondary" onClick={skip}>{t.skip}</Button>
+        <Button variant="secondary" onClick={reset}>{t.reset}</Button>
+      </div>
+
+      <div>
+        <span className="block text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.settings}</span>
+        <div className="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {([
+            { k: 'workMin' as const, l: t.workMin },
+            { k: 'shortMin' as const, l: t.shortMin },
+            { k: 'longMin' as const, l: t.longMin },
+            { k: 'rounds' as const, l: t.rounds },
+          ]).map(f => (
+            <label key={f.k} className="space-y-1 text-xs">
+              <span className="block font-semibold">{f.l}</span>
+              <input type="number" min={1} max={180} value={cfg[f.k]} onChange={setNum(f.k)} disabled={running}
+                className="w-full border-2 border-border bg-muted p-2 text-sm tabular-nums disabled:opacity-50" />
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/islands/pdf/PdfRedact.tsx
+++ b/src/islands/pdf/PdfRedact.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ResultActions } from '@/components/ui/ResultActions';
+import { openPdfRenderer, type PdfRenderer } from '@/tools/pdf/render.lib';
+import { redactPdf, type RedactBox } from '@/tools/pdf/mupdf.client';
+import { normalizeDragRect } from '@/tools/pdf/redact.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; drop: string; dropSub: string; failed: string;
+  drawHint: string; page: string; prev: string; next: string; boxes: (n: number) => string;
+  clear: string; apply: string; working: string; warn: string; note: string; remove: string;
+}> = {
+  en: {
+    intro: 'Permanently remove sensitive text and images from a PDF. Draw a box over anything you want to hide — the content underneath is deleted, not just covered — then download the redacted file. Everything runs in your browser; nothing is uploaded.',
+    drop: 'Drop a PDF or click to browse', dropSub: 'Redacted on your device',
+    failed: 'Something went wrong.',
+    drawHint: 'Drag on the page to draw a redaction box over sensitive content.',
+    page: 'Page', prev: 'Prev', next: 'Next',
+    boxes: n => `${n} box${n === 1 ? '' : 'es'} to redact`,
+    clear: 'Clear all', apply: 'Redact & download', working: 'Redacting…',
+    warn: 'Redaction is permanent: the covered text, images and vector art are removed from the file, so the result cannot be un-redacted. Download and check the output before sharing.',
+    note: 'True redaction — content is deleted from the PDF, not hidden behind a box.',
+    remove: 'Remove',
+  },
+  id: {
+    intro: 'Hapus permanen teks dan gambar sensitif dari PDF. Gambar kotak di atas apa pun yang ingin disembunyikan — konten di baliknya dihapus, bukan sekadar ditutup — lalu unduh berkas yang sudah disensor. Semuanya berjalan di browser Anda; tidak ada yang diunggah.',
+    drop: 'Letakkan PDF atau klik untuk memilih', dropSub: 'Disensor di perangkat Anda',
+    failed: 'Terjadi kesalahan.',
+    drawHint: 'Seret pada halaman untuk menggambar kotak sensor di atas konten sensitif.',
+    page: 'Halaman', prev: 'Sebelumnya', next: 'Berikutnya',
+    boxes: n => `${n} kotak untuk disensor`,
+    clear: 'Hapus semua', apply: 'Sensor & unduh', working: 'Menyensor…',
+    warn: 'Sensor bersifat permanen: teks, gambar, dan grafik vektor yang tertutup dihapus dari berkas, sehingga hasilnya tidak bisa dikembalikan. Unduh dan periksa hasilnya sebelum dibagikan.',
+    note: 'Sensor sejati — konten dihapus dari PDF, bukan disembunyikan di balik kotak.',
+    remove: 'Hapus',
+  },
+};
+
+interface Box extends RedactBox { id: number }
+
+export default function PdfRedact({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [file, setFile] = useState<File | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+  const [pageNum, setPageNum] = useState(1);
+  const [pageUrl, setPageUrl] = useState('');
+  const [boxes, setBoxes] = useState<Box[]>([]);
+  const [draft, setDraft] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<Blob | null>(null);
+
+  const rendererRef = useRef<PdfRenderer | null>(null);
+  const pageBoxRef = useRef<HTMLDivElement | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const nextId = useRef(1);
+
+  useEffect(() => () => {
+    rendererRef.current?.destroy();
+    if (pageUrl) URL.revokeObjectURL(pageUrl);
+  }, [pageUrl]);
+
+  const renderPage = async (renderer: PdfRenderer, n: number) => {
+    const page = await renderer.renderPage(n, 1.4);
+    setPageUrl(prev => { if (prev) URL.revokeObjectURL(prev); return URL.createObjectURL(page.blob); });
+  };
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find(x => x.type === 'application/pdf' || x.name.toLowerCase().endsWith('.pdf'));
+    if (!f) return;
+    setFile(f); setResult(null); setError(''); setBoxes([]); setDraft(null);
+    try {
+      const renderer = await openPdfRenderer(await f.arrayBuffer());
+      rendererRef.current = renderer;
+      setPageCount(renderer.pageCount);
+      setPageNum(1);
+      await renderPage(renderer, 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    }
+  };
+
+  const goPage = async (n: number) => {
+    if (!rendererRef.current || n < 1 || n > pageCount) return;
+    setPageNum(n);
+    setDraft(null);
+    await renderPage(rendererRef.current, n);
+  };
+
+  const localXY = (e: React.PointerEvent) => {
+    const rect = pageBoxRef.current!.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top, rect };
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!pageBoxRef.current) return;
+    const { x, y } = localXY(e);
+    startRef.current = { x, y };
+    setDraft({ x, y, w: 0, h: 0 });
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!startRef.current) return;
+    const { x, y } = localXY(e);
+    const s = startRef.current;
+    setDraft({ x: Math.min(s.x, x), y: Math.min(s.y, y), w: Math.abs(x - s.x), h: Math.abs(y - s.y) });
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (!startRef.current || !pageBoxRef.current) { startRef.current = null; return; }
+    const s = startRef.current;
+    startRef.current = null;
+    setDraft(null);
+    const { x, y, rect } = localXY(e);
+    const r = normalizeDragRect(s.x, s.y, x, y, rect.width, rect.height);
+    if (r.w < 0.01 || r.h < 0.01) return; // ignore stray clicks
+    setBoxes(b => [...b, { id: nextId.current++, pageIndex: pageNum - 1, ...r }]);
+  };
+
+  const removeBox = (id: number) => setBoxes(b => b.filter(x => x.id !== id));
+
+  const apply = async () => {
+    if (!file || boxes.length === 0) return;
+    setBusy(true); setError('');
+    try {
+      setResult(await redactPdf(file, boxes.map(({ pageIndex, x, y, w, h }) => ({ pageIndex, x, y, w, h }))));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const pageBoxes = boxes.filter(b => b.pageIndex === pageNum - 1);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!file && (
+        <Dropzone onDrop={onDrop} accept="application/pdf" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {file && (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">{t.drawHint}</p>
+
+          {pageUrl && (
+            <div
+              ref={pageBoxRef}
+              className="relative inline-block touch-none select-none border-2 border-border"
+              style={{ cursor: 'crosshair' }}
+              onPointerDown={onPointerDown}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+            >
+              <img src={pageUrl} alt={`page ${pageNum}`} className="block max-h-[72vh] w-auto" draggable={false} />
+              {pageBoxes.map(b => (
+                <div key={b.id}
+                  className="group absolute bg-black"
+                  style={{ left: `${b.x * 100}%`, top: `${b.y * 100}%`, width: `${b.w * 100}%`, height: `${b.h * 100}%` }}>
+                  <button
+                    onPointerDown={e => { e.stopPropagation(); }}
+                    onClick={e => { e.stopPropagation(); removeBox(b.id); }}
+                    aria-label={t.remove}
+                    className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center border-2 border-border bg-white text-xs font-black text-black opacity-0 group-hover:opacity-100">
+                    ×
+                  </button>
+                </div>
+              ))}
+              {draft && (
+                <div className="absolute border-2 border-dashed border-red-500 bg-red-500/30"
+                  style={{ left: draft.x, top: draft.y, width: draft.w, height: draft.h }} />
+              )}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <Button variant="secondary" onClick={() => goPage(pageNum - 1)} disabled={pageNum <= 1}>{t.prev}</Button>
+            <span>{t.page} {pageNum} / {pageCount}</span>
+            <Button variant="secondary" onClick={() => goPage(pageNum + 1)} disabled={pageNum >= pageCount}>{t.next}</Button>
+          </div>
+
+          <div className="border-2 border-border bg-yellow-300 p-3 text-sm font-medium text-black shadow-brutal-sm">
+            {t.warn}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-semibold">{t.boxes(boxes.length)}</span>
+            <Button variant="ghost" onClick={() => setBoxes([])} disabled={boxes.length === 0}>{t.clear}</Button>
+            <Button onClick={apply} disabled={busy || boxes.length === 0}>{busy ? t.working : t.apply}</Button>
+          </div>
+          <p className="text-xs text-muted-foreground">{t.note}</p>
+        </div>
+      )}
+
+      {result && <ResultActions blob={result} filename="redacted.pdf" disabled={busy} />}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -367,6 +367,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the converter works with no internet connection.' },
     ],
   },
+  'pomodoro-timer': {
+    title: 'Free Online Pomodoro Timer — Focus Timer with Breaks',
+    description: 'A free Pomodoro focus timer: work in focused sessions with short and long breaks, fully adjustable. Beeps at each phase and runs in your browser — nothing to install.',
+    intro: 'Stay focused with the Pomodoro technique: work in focused sessions separated by short breaks, with a longer break every few rounds. Adjust the focus and break lengths to suit you, and the timer beeps and rolls into the next phase automatically. It runs entirely in your browser — no sign-up, no install.',
+    howTo: [
+      'Set your focus, short-break and long-break lengths (defaults 25 / 5 / 15).',
+      'Press Start to begin a focus session.',
+      'When it beeps, take the break — the timer advances automatically.',
+      'Use Skip to jump ahead or Reset to start over.',
+    ],
+    faqs: [
+      { q: 'Is this Pomodoro timer free?', a: 'Yes — completely free, with no account, no install and no limits.' },
+      { q: 'What are the default Pomodoro lengths?', a: '25 minutes of focus, a 5-minute short break, and a 15-minute long break every 4 focus sessions. You can change all of these.' },
+      { q: 'Will it alert me when a session ends?', a: 'Yes. It plays a short beep at the end of each phase and shows the next phase with its own colour.' },
+      { q: 'Does the timer keep time if I switch tabs?', a: 'Yes. It tracks the real end time, so the countdown stays accurate even if the browser throttles background tabs.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the timer works with no internet connection.' },
+    ],
+  },
   'pdf-organize': {
     title: 'Free Organize PDF — Reorder, Delete Pages & Add Page Numbers',
     description: 'Organize a PDF in your browser: drag to reorder pages, delete pages, and add page numbers, then download. Nothing is uploaded.',
@@ -399,6 +417,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Can I sign more than one page?', a: 'Yes. Position the signature and add it to each page you need; all placements are applied when you download.' },
       { q: 'Can I upload an existing signature image?', a: 'Yes. Upload a PNG (ideally with a transparent background) instead of drawing, and place it the same way.' },
       { q: 'Is a drawn signature legally binding?', a: 'A drawn or image signature is a simple electronic signature. Whether it is legally sufficient depends on your jurisdiction and the document; check local requirements for important agreements.' },
+    ],
+  },
+  'pdf-redact': {
+    title: 'Free Redact PDF — Permanently Black Out Text & Images',
+    description: 'Redact a PDF in your browser: draw boxes over sensitive text and images and the content underneath is permanently removed — not just covered. Private, nothing uploaded.',
+    intro: 'This free Redact PDF tool permanently removes sensitive information from a PDF. Draw a box over any text, image or graphic you want to hide and the content underneath is deleted from the file — unlike a black rectangle drawn on top, it cannot be copied out or uncovered later. Everything runs in your browser using an on-device PDF engine, so your confidential document is never uploaded.',
+    howTo: [
+      'Drop your PDF to open it.',
+      'Drag on the page to draw a box over anything you want to redact.',
+      'Add boxes across pages; remove any box with its × button.',
+      'Click Redact & download, then verify the output before sharing.',
+    ],
+    faqs: [
+      { q: 'Is this true redaction or just a black box on top?', a: 'True redaction. The tool adds redaction annotations and applies them, so the underlying text, images and vector art are physically removed from the PDF — you cannot copy the text out or delete the box to reveal it.' },
+      { q: 'Is my document uploaded to a server?', a: 'No. Redaction runs entirely in your browser with an on-device PDF engine, so your file never leaves your device — essential for confidential documents.' },
+      { q: 'Can the redaction be undone?', a: 'No. Because the content is deleted from the file, it cannot be recovered from the output. Keep your original and check the redacted copy before sharing.' },
+      { q: 'Does it redact images as well as text?', a: 'Yes. Anything under a box — text, images and line/vector art — is removed, and a black rectangle is burned in its place.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
   'compare-lists': {
@@ -2271,6 +2307,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat konverter bekerja tanpa koneksi internet.' },
     ],
   },
+  'pomodoro-timer': {
+    title: 'Timer Pomodoro Online Gratis — Timer Fokus dengan Istirahat',
+    description: 'Timer fokus Pomodoro gratis: bekerja dalam sesi fokus dengan istirahat singkat dan panjang, bisa disesuaikan. Berbunyi tiap fase dan berjalan di browser — tanpa instalasi.',
+    intro: 'Tetap fokus dengan teknik Pomodoro: bekerja dalam sesi fokus yang dipisah istirahat singkat, dengan istirahat panjang setiap beberapa ronde. Sesuaikan durasi fokus dan istirahat, dan timer akan berbunyi lalu lanjut ke fase berikutnya otomatis. Berjalan sepenuhnya di browser Anda — tanpa pendaftaran, tanpa instalasi.',
+    howTo: [
+      'Atur durasi fokus, istirahat singkat, dan istirahat panjang (default 25 / 5 / 15).',
+      'Tekan Mulai untuk memulai sesi fokus.',
+      'Saat berbunyi, ambil istirahat — timer lanjut otomatis.',
+      'Gunakan Lewati untuk maju atau Atur ulang untuk mengulang.',
+    ],
+    faqs: [
+      { q: 'Apakah timer Pomodoro ini gratis?', a: 'Ya — sepenuhnya gratis, tanpa akun, tanpa instalasi, tanpa batas.' },
+      { q: 'Berapa durasi Pomodoro default?', a: 'Fokus 25 menit, istirahat singkat 5 menit, dan istirahat panjang 15 menit setiap 4 sesi fokus. Semua bisa diubah.' },
+      { q: 'Apakah ada peringatan saat sesi berakhir?', a: 'Ya. Timer berbunyi singkat di akhir tiap fase dan menampilkan fase berikutnya dengan warna tersendiri.' },
+      { q: 'Apakah timer tetap akurat jika saya pindah tab?', a: 'Ya. Timer melacak waktu akhir sebenarnya, jadi hitungan mundur tetap akurat meski browser membatasi tab latar belakang.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat timer bekerja tanpa koneksi internet.' },
+    ],
+  },
   'pdf-organize': {
     title: 'Organize PDF Gratis — Susun Ulang, Hapus Halaman & Nomor Halaman',
     description: 'Susun PDF di browser Anda: seret untuk menyusun ulang halaman, hapus halaman, dan tambahkan nomor halaman, lalu unduh. Tidak ada yang diunggah.',
@@ -2303,6 +2357,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah menandatangani lebih dari satu halaman?', a: 'Ya. Posisikan tanda tangan dan tambahkan ke tiap halaman yang diperlukan; semua penempatan diterapkan saat Anda mengunduh.' },
       { q: 'Bisakah mengunggah gambar tanda tangan yang sudah ada?', a: 'Ya. Unggah PNG (idealnya berlatar transparan) alih-alih menggambar, dan tempatkan dengan cara yang sama.' },
       { q: 'Apakah tanda tangan gambar sah secara hukum?', a: 'Tanda tangan gambar adalah tanda tangan elektronik sederhana. Keabsahannya bergantung pada yurisdiksi dan dokumen Anda; periksa ketentuan setempat untuk perjanjian penting.' },
+    ],
+  },
+  'pdf-redact': {
+    title: 'Redact PDF Gratis — Hapus Permanen Teks & Gambar Sensitif',
+    description: 'Sensor PDF di browser Anda: gambar kotak di atas teks dan gambar sensitif dan konten di baliknya dihapus permanen — bukan sekadar ditutup. Privat, tidak ada yang diunggah.',
+    intro: 'Tool Redact PDF gratis ini menghapus permanen informasi sensitif dari PDF. Gambar kotak di atas teks, gambar, atau grafik yang ingin disembunyikan dan konten di baliknya dihapus dari berkas — tidak seperti kotak hitam yang digambar di atas, konten ini tidak bisa disalin atau dibuka kembali. Semuanya berjalan di browser Anda memakai mesin PDF di perangkat, jadi dokumen rahasia Anda tidak pernah diunggah.',
+    howTo: [
+      'Letakkan PDF Anda untuk membukanya.',
+      'Seret pada halaman untuk menggambar kotak di atas apa pun yang ingin disensor.',
+      'Tambahkan kotak di berbagai halaman; hapus kotak mana pun dengan tombol ×.',
+      'Klik Sensor & unduh, lalu periksa hasilnya sebelum dibagikan.',
+    ],
+    faqs: [
+      { q: 'Apakah ini sensor sejati atau sekadar kotak hitam di atas?', a: 'Sensor sejati. Tool menambahkan anotasi redaksi dan menerapkannya, sehingga teks, gambar, dan grafik vektor di baliknya benar-benar dihapus dari PDF — Anda tidak bisa menyalin teksnya atau menghapus kotak untuk membukanya.' },
+      { q: 'Apakah dokumen saya diunggah ke server?', a: 'Tidak. Sensor berjalan sepenuhnya di browser Anda dengan mesin PDF di perangkat, jadi berkas tidak pernah meninggalkan perangkat — penting untuk dokumen rahasia.' },
+      { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
+      { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
     ],
   },
   'compare-lists': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -400,6 +400,17 @@ export const tools: ToolDef[] = [
     status: 'beta'
   },
   {
+    id: 'pomodoro-timer',
+    name: 'Pomodoro Timer',
+    category: 'Calculators',
+    route: '/tools/pomodoro-timer',
+    keywords: ['pomodoro', 'timer', 'focus timer', 'productivity', 'countdown', 'study timer', 'work break', 'timer pomodoro', 'fokus'],
+    icon: Timer,
+    summary: 'A configurable Pomodoro focus timer with breaks',
+    load: () => import('@/islands/calculators/TimerPomodoro'),
+    status: 'beta'
+  },
+  {
     id: 'pdf-organize',
     name: 'Organize PDF',
     category: 'PDF',
@@ -419,6 +430,17 @@ export const tools: ToolDef[] = [
     icon: FileSignature,
     summary: 'Draw or upload a signature and place it on a PDF',
     load: () => import('@/islands/pdf/PdfSign'),
+    status: 'beta'
+  },
+  {
+    id: 'pdf-redact',
+    name: 'Redact PDF',
+    category: 'PDF',
+    route: '/tools/pdf-redact',
+    keywords: ['redact pdf', 'redaction', 'black out', 'remove text', 'hide sensitive', 'censor pdf', 'sensor pdf', 'blackout', 'privacy'],
+    icon: Highlighter,
+    summary: 'Permanently remove sensitive text and images from a PDF',
+    load: () => import('@/islands/pdf/PdfRedact'),
     status: 'beta'
   },
   {

--- a/src/tools/calculators/pomodoro.lib.test.ts
+++ b/src/tools/calculators/pomodoro.lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { formatClock, phaseDuration, nextPhase, type PomodoroConfig } from './pomodoro.lib';
+
+const CFG: PomodoroConfig = { workMin: 25, shortMin: 5, longMin: 15, rounds: 4 };
+
+describe('formatClock', () => {
+  it('formats MM:SS', () => {
+    expect(formatClock(0)).toBe('00:00');
+    expect(formatClock(65)).toBe('01:05');
+    expect(formatClock(1500)).toBe('25:00');
+  });
+  it('adds hours when needed', () => {
+    expect(formatClock(3600)).toBe('1:00:00');
+    expect(formatClock(3661)).toBe('1:01:01');
+  });
+  it('clamps negatives to zero', () => {
+    expect(formatClock(-10)).toBe('00:00');
+  });
+});
+
+describe('phaseDuration', () => {
+  it('returns seconds for each phase', () => {
+    expect(phaseDuration('work', CFG)).toBe(1500);
+    expect(phaseDuration('short', CFG)).toBe(300);
+    expect(phaseDuration('long', CFG)).toBe(900);
+  });
+});
+
+describe('nextPhase', () => {
+  it('work → short break, incrementing completed work', () => {
+    expect(nextPhase('work', 0, CFG)).toEqual({ phase: 'short', completedWork: 1 });
+  });
+  it('every Nth work → long break', () => {
+    expect(nextPhase('work', 3, CFG)).toEqual({ phase: 'long', completedWork: 4 });
+  });
+  it('short break → work, completed unchanged', () => {
+    expect(nextPhase('short', 2, CFG)).toEqual({ phase: 'work', completedWork: 2 });
+  });
+  it('long break → work, completed unchanged', () => {
+    expect(nextPhase('long', 4, CFG)).toEqual({ phase: 'work', completedWork: 4 });
+  });
+});

--- a/src/tools/calculators/pomodoro.lib.ts
+++ b/src/tools/calculators/pomodoro.lib.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure Pomodoro sequencing and clock formatting. The ticking itself lives in the
+ * island (it needs real time); everything decidable without a clock is here and
+ * unit-tested.
+ */
+
+export type Phase = 'work' | 'short' | 'long';
+
+export interface PomodoroConfig {
+  workMin: number;
+  shortMin: number;
+  longMin: number;
+  /** Work sessions between long breaks. */
+  rounds: number;
+}
+
+/** Duration of a phase in seconds for the given config. */
+export function phaseDuration(phase: Phase, cfg: PomodoroConfig): number {
+  const min = phase === 'work' ? cfg.workMin : phase === 'short' ? cfg.shortMin : cfg.longMin;
+  return Math.max(0, Math.round(min * 60));
+}
+
+/**
+ * Given the phase that just finished and how many work sessions were completed
+ * before it, return the next phase and the updated completed-work count.
+ */
+export function nextPhase(phase: Phase, completedWork: number, cfg: PomodoroConfig): { phase: Phase; completedWork: number } {
+  if (phase === 'work') {
+    const done = completedWork + 1;
+    const takeLong = cfg.rounds > 0 && done % cfg.rounds === 0;
+    return { phase: takeLong ? 'long' : 'short', completedWork: done };
+  }
+  return { phase: 'work', completedWork };
+}
+
+/** Seconds → `MM:SS`, or `H:MM:SS` once there is at least an hour. Negatives clamp to 0. */
+export function formatClock(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return hours > 0 ? `${hours}:${pad(minutes)}:${pad(secs)}` : `${pad(minutes)}:${pad(secs)}`;
+}

--- a/src/tools/pdf/mupdf.client.ts
+++ b/src/tools/pdf/mupdf.client.ts
@@ -79,3 +79,20 @@ export async function protectPdf(file: File, password: string): Promise<Blob> {
 export async function unlockPdf(file: File, password: string): Promise<Blob> {
   return toBlob(await engine().unlock(await bytesOf(file), password));
 }
+
+/** A redaction rectangle as page-relative ratios with a top-left origin. */
+export interface RedactBox {
+  pageIndex: number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * True redaction — mupdf physically removes the text/images/line-art under each
+ * box and burns a black rectangle in its place (not a removable overlay).
+ */
+export async function redactPdf(file: File, boxes: RedactBox[]): Promise<Blob> {
+  return toBlob(await engine().redact(await bytesOf(file), boxes));
+}

--- a/src/tools/pdf/mupdf.worker.ts
+++ b/src/tools/pdf/mupdf.worker.ts
@@ -217,6 +217,52 @@ const api = {
       doc.destroy?.();
     }
   },
+
+  /**
+   * True redaction: for each box, add a Redact annotation at its rectangle, then
+   * applyRedactions so mupdf physically removes the covered text, images and line
+   * art (not just paints over it) and burns a black box in its place. Boxes are
+   * given as page-relative ratios with a top-left origin (as drawn on screen).
+   */
+  async redact(
+    bytes: Uint8Array,
+    boxes: { pageIndex: number; x: number; y: number; w: number; h: number }[],
+  ): Promise<Uint8Array> {
+    const mupdf = await loadMupdf();
+    const doc = open(mupdf, bytes);
+    try {
+      const total = doc.countPages();
+      const byPage = new Map<number, typeof boxes>();
+      for (const b of boxes) {
+        if (b.pageIndex < 0 || b.pageIndex >= total || b.w <= 0 || b.h <= 0) continue;
+        const list = byPage.get(b.pageIndex) ?? [];
+        list.push(b);
+        byPage.set(b.pageIndex, list);
+      }
+      for (const [pageIndex, list] of byPage) {
+        const page: any = doc.loadPage(pageIndex);
+        const [x0, y0, x1, y1] = page.getBounds();
+        const pw = x1 - x0;
+        const ph = y1 - y0;
+        for (const b of list) {
+          const rx0 = x0 + b.x * pw;
+          const rx1 = x0 + (b.x + b.w) * pw;
+          // Screen y is top-down; PDF y is bottom-up, so flip against the top edge (y1).
+          const ryTop = y1 - b.y * ph;
+          const ryBottom = y1 - (b.y + b.h) * ph;
+          const annot = page.createAnnotation('Redact');
+          annot.setRect([rx0, ryBottom, rx1, ryTop]);
+          annot.update?.();
+        }
+        // black_boxes=true, image=REMOVE(1), line_art=REMOVE_IF_TOUCHED(2), text=REMOVE(0)
+        page.applyRedactions(true, 1, 2, 0);
+      }
+      // Garbage-collect so the removed content can't linger in the file.
+      return transfer(save(doc, 'garbage=compact'));
+    } finally {
+      doc.destroy?.();
+    }
+  },
 };
 
 export type MupdfApi = typeof api;

--- a/src/tools/pdf/redact.lib.test.ts
+++ b/src/tools/pdf/redact.lib.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDragRect } from './redact.lib';
+
+describe('normalizeDragRect', () => {
+  it('converts a top-left → bottom-right drag to ratios', () => {
+    expect(normalizeDragRect(50, 100, 150, 200, 200, 400)).toEqual({ x: 0.25, y: 0.25, w: 0.5, h: 0.25 });
+  });
+
+  it('handles an inverted (bottom-right → top-left) drag', () => {
+    expect(normalizeDragRect(150, 200, 50, 100, 200, 400)).toEqual({ x: 0.25, y: 0.25, w: 0.5, h: 0.25 });
+  });
+
+  it('clamps a drag that runs past the edges', () => {
+    const r = normalizeDragRect(-20, -20, 260, 500, 200, 400);
+    expect(r).toEqual({ x: 0, y: 0, w: 1, h: 1 });
+  });
+
+  it('reports zero size for a click without movement', () => {
+    const r = normalizeDragRect(100, 100, 100, 100, 200, 400);
+    expect(r.w).toBe(0);
+    expect(r.h).toBe(0);
+  });
+});

--- a/src/tools/pdf/redact.lib.ts
+++ b/src/tools/pdf/redact.lib.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure geometry helper for the redaction UI: turn a pointer drag (two points in
+ * element pixel space) into a page-relative box of top-left-origin ratios,
+ * clamped to the page. The PDF-space coordinate flip happens in the mupdf worker.
+ */
+
+export interface RatioRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+export function normalizeDragRect(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  width: number,
+  height: number,
+): RatioRect {
+  if (width <= 0 || height <= 0) return { x: 0, y: 0, w: 0, h: 0 };
+  const left = Math.min(x1, x2);
+  const top = Math.min(y1, y2);
+  const right = Math.max(x1, x2);
+  const bottom = Math.max(y1, y2);
+  const x = clamp01(left / width);
+  const y = clamp01(top / height);
+  return {
+    x,
+    y,
+    w: clamp01(right / width) - x,
+    h: clamp01(bottom / height) - y,
+  };
+}


### PR DESCRIPTION
Two new tools, both fully client-side.

**Pomodoro Timer** (`/tools/pomodoro-timer`, Calculators)
- Configurable focus / short-break / long-break lengths and rounds-before-long-break.
- Drift-free countdown (tracks a real end time, stays accurate in throttled background tabs), beeps and auto-advances between phases, round counter.
- Pure `pomodoro.lib.ts` (phase sequencing + clock formatting) unit-tested (8 tests).

**Redact PDF** (`/tools/pdf-redact`, PDF) — *true* redaction
- Draw boxes over sensitive content; the mupdf worker adds Redact annotations and calls `applyRedactions`, so the underlying **text, images and vector art are physically removed** and a black box is burned in place — not a removable overlay, can't be copied out or uncovered.
- New worker `redact` op (garbage-collected save) + `redactPdf` client; reuses the existing mupdf worker + pdfjs renderer (no new precache chunk).
- Pure `redact.lib.ts` (drag→page-ratio geometry) unit-tested (4 tests).

EN + ID SEO for both. Verify: 1162 tests green, lint 0 errors, build OK; `/tools/pomodoro-timer/`, `/tools/pdf-redact/` (+ `/id/`) all built and listed on their category hubs.