### PR TITLE
feat(calculators): Typing Speed Test

### DIFF
--- a/src/islands/calculators/TypingTest.tsx
+++ b/src/islands/calculators/TypingTest.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { typingStats } from '@/tools/calculators/typing.lib';
+import type { Lang } from '@/i18n/config';
+
+const PASSAGES: Record<Lang, string[]> = {
+  en: [
+    'The quick brown fox jumps over the lazy dog while the sun sets slowly behind the quiet hills.',
+    'Typing well is less about speed and more about rhythm, accuracy, and keeping your eyes on the screen.',
+    'A small river winds through the valley, past old stone bridges and fields that turn gold in autumn.',
+    'Good habits are built one day at a time, so practice a little every morning and progress will follow.',
+  ],
+  id: [
+    'Rubah cokelat yang gesit melompati anjing yang malas saat matahari perlahan tenggelam di balik bukit.',
+    'Mengetik dengan baik bukan soal kecepatan semata, tetapi tentang irama, ketepatan, dan fokus pada layar.',
+    'Sebuah sungai kecil berkelok melewati lembah, jembatan batu tua, dan sawah yang menguning saat kemarau.',
+    'Kebiasaan baik dibangun sedikit demi sedikit, jadi berlatihlah setiap pagi dan kemajuan akan mengikuti.',
+  ],
+};
+
+const TR: Record<Lang, {
+  intro: string; start: string; restart: string; newText: string;
+  wpm: string; accuracy: string; time: string; chars: string; finished: string; hint: string;
+}> = {
+  en: {
+    intro: 'Test your typing speed and accuracy. Start typing the text below — the timer begins on your first keystroke and your words-per-minute and accuracy update live. Nothing is uploaded.',
+    start: 'Start typing below', restart: 'Try again', newText: 'New text',
+    wpm: 'WPM', accuracy: 'Accuracy', time: 'Time', chars: 'Characters', finished: 'Done!',
+    hint: 'Pasting is disabled — type it out to get a real score.',
+  },
+  id: {
+    intro: 'Uji kecepatan dan ketepatan mengetik Anda. Mulai ketik teks di bawah — timer dimulai pada ketukan pertama dan kata per menit serta akurasi diperbarui langsung. Tidak ada yang diunggah.',
+    start: 'Mulai ketik di bawah', restart: 'Coba lagi', newText: 'Teks baru',
+    wpm: 'KPM', accuracy: 'Akurasi', time: 'Waktu', chars: 'Karakter', finished: 'Selesai!',
+    hint: 'Menempel dinonaktifkan — ketik langsung untuk skor yang benar.',
+  },
+};
+
+export default function TypingTest({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const l: Lang = lang === 'id' ? 'id' : 'en';
+  const pool = PASSAGES[l] ?? PASSAGES.en;
+
+  const [idx, setIdx] = useState(() => Math.floor(Math.random() * pool.length));
+  const passage = pool[idx];
+  const [typed, setTyped] = useState('');
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [endTime, setEndTime] = useState<number | null>(null);
+  const [now, setNow] = useState(0);
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const finished = endTime !== null;
+
+  // Tick for live stats while typing.
+  useEffect(() => {
+    if (startTime === null || finished) return;
+    const id = window.setInterval(() => setNow(Date.now()), 250);
+    return () => window.clearInterval(id);
+  }, [startTime, finished]);
+
+  const elapsedMs = startTime === null ? 0 : (endTime ?? (now || Date.now())) - startTime;
+  const stats = useMemo(() => typingStats(passage, typed, elapsedMs), [passage, typed, elapsedMs]);
+
+  const reset = (newIdx = idx) => {
+    setIdx(newIdx);
+    setTyped('');
+    setStartTime(null);
+    setEndTime(null);
+    setNow(0);
+    requestAnimationFrame(() => taRef.current?.focus());
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (finished) return;
+    const value = e.target.value.slice(0, passage.length);
+    if (startTime === null && value.length > 0) setStartTime(Date.now());
+    setTyped(value);
+    if (value.length >= passage.length) setEndTime(Date.now());
+  };
+
+  const seconds = (elapsedMs / 1000).toFixed(1);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {[
+          { l: t.wpm, v: String(stats.wpm) },
+          { l: t.accuracy, v: `${stats.accuracy}%` },
+          { l: t.time, v: `${seconds}s` },
+          { l: t.chars, v: `${typed.length}/${passage.length}` },
+        ].map(x => (
+          <div key={x.l} className="border-2 border-border p-2 text-center">
+            <div className="text-2xl font-black tabular-nums">{x.v}</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{x.l}</div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        onClick={() => taRef.current?.focus()}
+        className="cursor-text select-none whitespace-pre-wrap break-words border-2 border-border p-4 font-mono text-lg leading-relaxed">
+        {passage.split('').map((ch, i) => {
+          let cls = 'text-muted-foreground';
+          if (i < typed.length) cls = typed[i] === ch ? 'text-green-600 dark:text-green-400' : 'bg-red-500/40 text-red-700 dark:text-red-300';
+          const cursor = i === typed.length && !finished ? ' border-l-2 border-accent' : '';
+          return <span key={i} className={`${cls}${cursor}`}>{ch}</span>;
+        })}
+      </div>
+
+      <textarea
+        ref={taRef}
+        value={typed}
+        onChange={onChange}
+        onPaste={e => e.preventDefault()}
+        disabled={finished}
+        autoFocus
+        rows={3}
+        aria-label={t.start}
+        placeholder={t.start}
+        className="w-full resize-none border-2 border-border bg-muted p-3 font-mono text-sm disabled:opacity-60"
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        {finished && <span className="text-sm font-black text-green-600 dark:text-green-400">{t.finished}</span>}
+        <Button onClick={() => reset()}>{t.restart}</Button>
+        <Button variant="secondary" onClick={() => reset((idx + 1) % pool.length)}>{t.newText}</Button>
+        <span className="text-xs text-muted-foreground">{t.hint}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -385,6 +385,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the timer works with no internet connection.' },
     ],
   },
+  'typing-test': {
+    title: 'Free Typing Speed Test — Words Per Minute (WPM) & Accuracy',
+    description: 'Test your typing speed and accuracy online. The timer starts on your first keystroke and shows live words-per-minute and accuracy. Free, private — nothing is uploaded.',
+    intro: 'Find out how fast you type. Start typing the sample text and this free typing test measures your speed in words per minute (WPM) and your accuracy in real time. The timer begins on your first keystroke and stops when you finish the passage. Everything runs in your browser — no sign-up and nothing uploaded.',
+    howTo: [
+      'Start typing the sample text shown above the box.',
+      'The timer starts automatically on your first keystroke.',
+      'Watch your live WPM and accuracy as you go.',
+      'Finish the passage, then hit Try again or New text.',
+    ],
+    faqs: [
+      { q: 'How is WPM calculated?', a: 'A “word” is the standard five characters. WPM is your correctly typed characters divided by five, per minute — so accuracy directly affects your score.' },
+      { q: 'Is my typing sent anywhere?', a: 'No. The test runs entirely in your browser; what you type never leaves your device.' },
+      { q: 'Why is pasting disabled?', a: 'Pasting would skip the actual typing, so it is blocked to keep your score honest — type the text out.' },
+      { q: 'Can I get a different passage?', a: 'Yes. Click New text for another sample, or Try again to retype the same one.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the typing test works with no internet connection.' },
+    ],
+  },
   'pdf-organize': {
     title: 'Free Organize PDF — Reorder, Delete Pages & Add Page Numbers',
     description: 'Organize a PDF in your browser: drag to reorder pages, delete pages, and add page numbers, then download. Nothing is uploaded.',
@@ -2323,6 +2341,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah ada peringatan saat sesi berakhir?', a: 'Ya. Timer berbunyi singkat di akhir tiap fase dan menampilkan fase berikutnya dengan warna tersendiri.' },
       { q: 'Apakah timer tetap akurat jika saya pindah tab?', a: 'Ya. Timer melacak waktu akhir sebenarnya, jadi hitungan mundur tetap akurat meski browser membatasi tab latar belakang.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat timer bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'typing-test': {
+    title: 'Tes Kecepatan Mengetik Gratis — Kata Per Menit (KPM) & Akurasi',
+    description: 'Uji kecepatan dan akurasi mengetik Anda online. Timer dimulai pada ketukan pertama dan menampilkan kata per menit serta akurasi langsung. Gratis, privat — tidak ada yang diunggah.',
+    intro: 'Cari tahu seberapa cepat Anda mengetik. Mulai ketik teks contoh dan tes mengetik gratis ini mengukur kecepatan Anda dalam kata per menit (KPM) dan akurasi secara langsung. Timer dimulai pada ketukan pertama dan berhenti saat Anda menyelesaikan teks. Semuanya berjalan di browser Anda — tanpa pendaftaran dan tidak ada yang diunggah.',
+    howTo: [
+      'Mulai ketik teks contoh yang ditampilkan di atas kotak.',
+      'Timer mulai otomatis pada ketukan pertama Anda.',
+      'Perhatikan KPM dan akurasi langsung saat mengetik.',
+      'Selesaikan teksnya, lalu tekan Coba lagi atau Teks baru.',
+    ],
+    faqs: [
+      { q: 'Bagaimana KPM dihitung?', a: 'Satu “kata” adalah lima karakter standar. KPM adalah karakter yang diketik dengan benar dibagi lima, per menit — jadi akurasi langsung memengaruhi skor Anda.' },
+      { q: 'Apakah ketikan saya dikirim ke mana pun?', a: 'Tidak. Tes berjalan sepenuhnya di browser Anda; apa yang Anda ketik tidak pernah meninggalkan perangkat.' },
+      { q: 'Mengapa menempel dinonaktifkan?', a: 'Menempel akan melewati proses mengetik sebenarnya, jadi diblokir agar skor Anda jujur — ketik teksnya.' },
+      { q: 'Bisakah mendapat teks berbeda?', a: 'Bisa. Klik Teks baru untuk contoh lain, atau Coba lagi untuk mengetik ulang yang sama.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tes mengetik bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-organize': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -408,6 +408,17 @@ export const tools: ToolDef[] = [
     icon: Timer,
     summary: 'A configurable Pomodoro focus timer with breaks',
     load: () => import('@/islands/calculators/TimerPomodoro'),
+    status: 'beta'
+  },
+  {
+    id: 'typing-test',
+    name: 'Typing Speed Test',
+    category: 'Calculators',
+    route: '/tools/typing-test',
+    keywords: ['typing test', 'typing speed', 'wpm', 'words per minute', 'typing accuracy', 'tes mengetik', 'kecepatan mengetik', 'keyboard'],
+    icon: Gauge,
+    summary: 'Measure your typing speed (WPM) and accuracy',
+    load: () => import('@/islands/calculators/TypingTest'),
     status: 'beta'
   },
   {

--- a/src/tools/calculators/typing.lib.test.ts
+++ b/src/tools/calculators/typing.lib.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { compareChars, netWpm, grossWpm, accuracy, typingStats } from './typing.lib';
+
+describe('compareChars', () => {
+  it('counts correct and incorrect against the target', () => {
+    expect(compareChars('hello', 'hallo')).toEqual({ correct: 4, incorrect: 1 });
+  });
+  it('counts characters typed past the target end as incorrect', () => {
+    expect(compareChars('hi', 'hix')).toEqual({ correct: 2, incorrect: 1 });
+  });
+  it('empty input is all zero', () => {
+    expect(compareChars('hello', '')).toEqual({ correct: 0, incorrect: 0 });
+  });
+});
+
+describe('wpm', () => {
+  it('net WPM uses correct chars / 5 per minute', () => {
+    expect(netWpm(25, 60000)).toBe(5);
+    expect(netWpm(250, 60000)).toBe(50);
+  });
+  it('gross WPM uses all typed chars', () => {
+    expect(grossWpm(300, 60000)).toBe(60);
+  });
+  it('is zero when no time has elapsed', () => {
+    expect(netWpm(25, 0)).toBe(0);
+  });
+});
+
+describe('accuracy', () => {
+  it('is a rounded percentage of correct over total', () => {
+    expect(accuracy(45, 50)).toBe(90);
+  });
+  it('is 100 when nothing has been typed', () => {
+    expect(accuracy(0, 0)).toBe(100);
+  });
+});
+
+describe('typingStats', () => {
+  it('integrates comparison, wpm and accuracy', () => {
+    const s = typingStats('hello world', 'hello world', 60000);
+    expect(s.correctChars).toBe(11);
+    expect(s.incorrectChars).toBe(0);
+    expect(s.accuracy).toBe(100);
+    expect(s.wpm).toBe(Math.round((11 / 5)));
+  });
+});

--- a/src/tools/calculators/typing.lib.ts
+++ b/src/tools/calculators/typing.lib.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure typing-test math: compare typed text against a target and derive
+ * words-per-minute and accuracy. A "word" is the standard 5 characters.
+ */
+
+export interface TypingStats {
+  wpm: number;
+  accuracy: number;
+  correctChars: number;
+  incorrectChars: number;
+  totalTyped: number;
+}
+
+/** Character-by-character comparison; anything typed past the target counts as incorrect. */
+export function compareChars(target: string, typed: string): { correct: number; incorrect: number } {
+  let correct = 0;
+  let incorrect = 0;
+  for (let i = 0; i < typed.length; i++) {
+    if (i < target.length && typed[i] === target[i]) correct++;
+    else incorrect++;
+  }
+  return { correct, incorrect };
+}
+
+function wpm(chars: number, elapsedMs: number): number {
+  if (elapsedMs <= 0) return 0;
+  return Math.round((chars / 5) / (elapsedMs / 60000));
+}
+
+/** WPM counting only correctly typed characters. */
+export function netWpm(correctChars: number, elapsedMs: number): number {
+  return wpm(correctChars, elapsedMs);
+}
+
+/** WPM counting every typed character, right or wrong. */
+export function grossWpm(totalTyped: number, elapsedMs: number): number {
+  return wpm(totalTyped, elapsedMs);
+}
+
+/** Percentage of typed characters that were correct (100 when nothing typed). */
+export function accuracy(correct: number, total: number): number {
+  if (total <= 0) return 100;
+  return Math.round((correct / total) * 100);
+}
+
+export function typingStats(target: string, typed: string, elapsedMs: number): TypingStats {
+  const { correct, incorrect } = compareChars(target, typed);
+  return {
+    wpm: netWpm(correct, elapsedMs),
+    accuracy: accuracy(correct, typed.length),
+    correctChars: correct,
+    incorrectChars: incorrect,
+    totalTyped: typed.length,
+  };
+}


### PR DESCRIPTION
Adds a **Typing Speed Test** to the Calculators category (`/tools/typing-test`).

- Type a sample passage; live **WPM (net, correct-chars/5 per minute)** and **accuracy**, timer starts on first keystroke and stops at the end.
- Per-character highlighting (green correct / red wrong) with a caret at the current position; paste disabled to keep scores honest; New text / Try again.
- Pure `typing.lib.ts` (char compare, net/gross WPM, accuracy) unit-tested (9 tests). EN + ID passages and SEO.

Verify: 1172 tests green, lint 0 errors, build OK; both `/tools/typing-test/` locales built and listed on the Calculators hub.