### PR TITLE
feat(dev): WCAG Contrast Checker

### DIFF
--- a/src/islands/dev/ContrastChecker.tsx
+++ b/src/islands/dev/ContrastChecker.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { parseColor, contrastRatio, wcagLevels } from '@/tools/dev/contrast.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; fg: string; bg: string; swap: string; ratio: string;
+  preview: string; sampleNormal: string; sampleLarge: string;
+  normalText: string; largeText: string; pass: string; fail: string; hint: string;
+}> = {
+  en: {
+    intro: 'Check the colour contrast between text and its background against WCAG 2.1. Pick two colours and see the contrast ratio and whether it passes AA and AAA for normal and large text. Runs in your browser.',
+    fg: 'Text colour', bg: 'Background', swap: 'Swap', ratio: 'Contrast ratio',
+    preview: 'Preview', sampleNormal: 'Normal text — the quick brown fox jumps over the lazy dog.',
+    sampleLarge: 'Large text sample',
+    normalText: 'Normal text', largeText: 'Large text', pass: 'Pass', fail: 'Fail',
+    hint: 'Large text is 18pt+ (or 14pt+ bold). AAA is the strictest level.',
+  },
+  id: {
+    intro: 'Periksa kontras warna antara teks dan latarnya terhadap WCAG 2.1. Pilih dua warna dan lihat rasio kontras serta apakah lolos AA dan AAA untuk teks normal dan besar. Berjalan di browser Anda.',
+    fg: 'Warna teks', bg: 'Latar', swap: 'Tukar', ratio: 'Rasio kontras',
+    preview: 'Pratinjau', sampleNormal: 'Teks normal — rubah cokelat gesit melompati anjing malas.',
+    sampleLarge: 'Contoh teks besar',
+    normalText: 'Teks normal', largeText: 'Teks besar', pass: 'Lolos', fail: 'Gagal',
+    hint: 'Teks besar adalah 18pt+ (atau 14pt+ tebal). AAA adalah level paling ketat.',
+  },
+};
+
+function Badge({ ok, label, pass, fail }: { ok: boolean; label: string; pass: string; fail: string }) {
+  return (
+    <div className={`flex items-center justify-between border-2 border-border px-3 py-2 text-sm ${ok ? 'bg-green-500 text-black' : 'bg-red-500 text-white'}`}>
+      <span className="font-semibold">{label}</span>
+      <span className="font-black">{ok ? `✓ ${pass}` : `✕ ${fail}`}</span>
+    </div>
+  );
+}
+
+export default function ContrastChecker({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [fg, setFg] = useState('#1a1a1a');
+  const [bg, setBg] = useState('#ffffff');
+
+  const { ratio, levels, fgOk, bgOk } = useMemo(() => {
+    const f = parseColor(fg);
+    const b = parseColor(bg);
+    if (!f || !b) return { ratio: 0, levels: wcagLevels(0), fgOk: !!f, bgOk: !!b };
+    const r = contrastRatio(f, b);
+    return { ratio: r, levels: wcagLevels(r), fgOk: true, bgOk: true };
+  }, [fg, bg]);
+
+  const swap = () => { setFg(bg); setBg(fg); };
+
+  const colorField = (label: string, value: string, set: (v: string) => void, ok: boolean) => (
+    <div className="space-y-1 text-sm">
+      <span className="block font-semibold">{label}</span>
+      <div className="flex items-center gap-2">
+        <input type="color" value={parseColor(value) ? value : '#000000'} onChange={e => set(e.target.value)}
+          aria-label={label} className="h-10 w-12 cursor-pointer border-2 border-border bg-transparent p-0.5" />
+        <input type="text" value={value} onChange={e => set(e.target.value)}
+          className={`w-32 border-2 bg-muted p-2 font-mono text-sm ${ok ? 'border-border' : 'border-red-500'}`} />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="flex flex-wrap items-end gap-4">
+        {colorField(t.fg, fg, setFg, fgOk)}
+        <Button variant="secondary" onClick={swap} className="text-xs">⇄ {t.swap}</Button>
+        {colorField(t.bg, bg, setBg, bgOk)}
+      </div>
+
+      <div className="border-2 border-border p-4 text-center shadow-brutal">
+        <div className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.ratio}</div>
+        <div className="text-5xl font-black tabular-nums">{ratio.toFixed(2)}<span className="text-2xl">:1</span></div>
+      </div>
+
+      {fgOk && bgOk && (
+        <div className="space-y-3">
+          <div className="border-2 border-border p-4" style={{ background: bg, color: fg }}>
+            <div className="text-xs font-bold uppercase tracking-wide opacity-70">{t.preview}</div>
+            <p className="mt-1 text-base">{t.sampleNormal}</p>
+            <p className="mt-1 text-2xl font-bold">{t.sampleLarge}</p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <span className="text-sm font-bold">{t.normalText}</span>
+              <Badge ok={levels.normalAA} label="AA (4.5:1)" pass={t.pass} fail={t.fail} />
+              <Badge ok={levels.normalAAA} label="AAA (7:1)" pass={t.pass} fail={t.fail} />
+            </div>
+            <div className="space-y-2">
+              <span className="text-sm font-bold">{t.largeText}</span>
+              <Badge ok={levels.largeAA} label="AA (3:1)" pass={t.pass} fail={t.fail} />
+              <Badge ok={levels.largeAAA} label="AAA (4.5:1)" pass={t.pass} fail={t.fail} />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">{t.hint}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -916,6 +916,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Why is my color showing as invalid?', a: 'The input has to be a valid hex code like #rrggbb or an rgb(r, g, b) value. Check for a missing # or a typo, and the tool will convert it once the format is right.' },
     ],
   },
+  'contrast-checker': {
+    title: 'WCAG Contrast Checker — Color Contrast Ratio (AA & AAA)',
+    description: 'Check colour contrast between text and background against WCAG 2.1. See the contrast ratio and AA/AAA pass or fail for normal and large text. Free, in your browser.',
+    intro: 'This free WCAG contrast checker measures the colour contrast between text and its background so your designs stay readable and accessible. Pick a text colour and a background colour to see the exact contrast ratio, a live preview, and whether it meets WCAG 2.1 AA and AAA for both normal and large text. Everything runs in your browser.',
+    howTo: [
+      'Choose your text colour and background colour (swatch or hex).',
+      'Read the contrast ratio and the live preview.',
+      'Check the AA / AAA pass or fail badges for normal and large text.',
+      'Use Swap to try the reverse, and adjust until it passes.',
+    ],
+    faqs: [
+      { q: 'What contrast ratio do I need?', a: 'WCAG 2.1 AA needs 4.5:1 for normal text and 3:1 for large text; AAA needs 7:1 and 4.5:1 respectively. Large text is roughly 18pt+ (or 14pt+ bold).' },
+      { q: 'How is the ratio calculated?', a: 'It uses the WCAG relative-luminance formula on both colours, then (lighter + 0.05) / (darker + 0.05), giving a value from 1:1 to 21:1.' },
+      { q: 'Is anything uploaded?', a: 'No. The check runs entirely in your browser; your colours never leave your device.' },
+      { q: 'What is the difference between AA and AAA?', a: 'AA is the common legal and practical baseline; AAA is the strictest level for enhanced accessibility. Aim for AA at minimum, AAA where you can.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the checker works with no internet connection.' },
+    ],
+  },
   'pdf-merge': {
     title: 'Free Merge PDF Tool — Combine PDFs Online',
     description: 'A free online tool to merge multiple PDFs into a single file, in any order — 100% private. Your PDFs are combined in your browser and never uploaded.',
@@ -2890,6 +2908,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah ada yang dikirim ke server?', a: 'Tidak. Konversi berjalan sepenuhnya di browser Anda dengan JavaScript, jadi tidak ada nilai warna atau data yang meninggalkan perangkat Anda.' },
       { q: 'Bisakah saya memilih warna alih-alih mengetiknya?', a: 'Ya. Klik kotak warna untuk membuka pemilih warna sistem Anda, dan nilai HEX, RGB, serta HSL akan diperbarui sesuai pilihan Anda.' },
       { q: 'Mengapa warna saya ditampilkan sebagai tidak valid?', a: 'Masukan harus berupa kode hex yang valid seperti #rrggbb atau nilai rgb(r, g, b). Periksa apakah ada # yang hilang atau salah ketik, dan konversi akan dilakukan begitu formatnya benar.' },
+    ],
+  },
+  'contrast-checker': {
+    title: 'Pemeriksa Kontras WCAG — Rasio Kontras Warna (AA & AAA)',
+    description: 'Periksa kontras warna antara teks dan latar terhadap WCAG 2.1. Lihat rasio kontras dan lolos/gagal AA/AAA untuk teks normal dan besar. Gratis, di browser Anda.',
+    intro: 'Pemeriksa kontras WCAG gratis ini mengukur kontras warna antara teks dan latarnya agar desain Anda tetap mudah dibaca dan aksesibel. Pilih warna teks dan warna latar untuk melihat rasio kontras yang tepat, pratinjau langsung, serta apakah memenuhi WCAG 2.1 AA dan AAA untuk teks normal maupun besar. Semuanya berjalan di browser Anda.',
+    howTo: [
+      'Pilih warna teks dan warna latar Anda (swatch atau hex).',
+      'Baca rasio kontras dan pratinjau langsung.',
+      'Cek badge lolos/gagal AA / AAA untuk teks normal dan besar.',
+      'Gunakan Tukar untuk mencoba kebalikannya, dan sesuaikan hingga lolos.',
+    ],
+    faqs: [
+      { q: 'Rasio kontras berapa yang saya butuhkan?', a: 'WCAG 2.1 AA butuh 4,5:1 untuk teks normal dan 3:1 untuk teks besar; AAA butuh 7:1 dan 4,5:1. Teks besar kira-kira 18pt+ (atau 14pt+ tebal).' },
+      { q: 'Bagaimana rasio dihitung?', a: 'Menggunakan rumus luminansi relatif WCAG pada kedua warna, lalu (lebih terang + 0,05) / (lebih gelap + 0,05), menghasilkan nilai dari 1:1 hingga 21:1.' },
+      { q: 'Apakah ada yang diunggah?', a: 'Tidak. Pemeriksaan berjalan sepenuhnya di browser Anda; warna Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Apa beda AA dan AAA?', a: 'AA adalah baseline umum secara hukum dan praktik; AAA adalah level paling ketat untuk aksesibilitas lebih tinggi. Targetkan minimal AA, dan AAA bila memungkinkan.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pemeriksa bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-merge': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -607,6 +607,17 @@ export const tools: ToolDef[] = [
     summary: 'Pick or Convert colors between HEX, RGB, and HSL',
     load: () => import('@/islands/dev/ColorConvert'),
     status: 'stable'
+  },
+  {
+    id: 'contrast-checker',
+    name: 'WCAG Contrast Checker',
+    category: 'Dev',
+    route: '/tools/contrast-checker',
+    keywords: ['contrast', 'wcag', 'accessibility', 'a11y', 'color contrast', 'aa', 'aaa', 'contrast ratio', 'kontras', 'aksesibilitas'],
+    icon: Accessibility,
+    summary: 'Check text/background colour contrast against WCAG AA & AAA',
+    load: () => import('@/islands/dev/ContrastChecker'),
+    status: 'beta'
   },
   {
     id: 'pdf-merge',

--- a/src/tools/dev/contrast.lib.test.ts
+++ b/src/tools/dev/contrast.lib.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseColor, relativeLuminance, contrastRatio, wcagLevels } from './contrast.lib';
+
+describe('parseColor', () => {
+  it('parses #rrggbb', () => {
+    expect(parseColor('#ffffff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseColor('#000000')).toEqual({ r: 0, g: 0, b: 0 });
+  });
+  it('parses shorthand #rgb', () => {
+    expect(parseColor('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseColor('#f00')).toEqual({ r: 255, g: 0, b: 0 });
+  });
+  it('parses rgb()', () => {
+    expect(parseColor('rgb(255, 0, 0)')).toEqual({ r: 255, g: 0, b: 0 });
+  });
+  it('returns null for junk', () => {
+    expect(parseColor('nope')).toBeNull();
+    expect(parseColor('#12')).toBeNull();
+  });
+});
+
+describe('relativeLuminance', () => {
+  it('is 1 for white and 0 for black', () => {
+    expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1, 5);
+    expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBeCloseTo(0, 5);
+  });
+});
+
+describe('contrastRatio', () => {
+  it('black on white is 21:1', () => {
+    expect(contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })).toBeCloseTo(21, 2);
+  });
+  it('identical colors are 1:1', () => {
+    expect(contrastRatio({ r: 120, g: 120, b: 120 }, { r: 120, g: 120, b: 120 })).toBeCloseTo(1, 5);
+  });
+  it('is symmetric', () => {
+    const a = { r: 30, g: 60, b: 90 };
+    const b = { r: 200, g: 200, b: 200 };
+    expect(contrastRatio(a, b)).toBeCloseTo(contrastRatio(b, a), 6);
+  });
+});
+
+describe('wcagLevels', () => {
+  it('21:1 passes everything', () => {
+    expect(wcagLevels(21)).toEqual({ normalAA: true, normalAAA: true, largeAA: true, largeAAA: true });
+  });
+  it('4.5:1 passes normal AA and large AA/AAA but not normal AAA', () => {
+    expect(wcagLevels(4.5)).toEqual({ normalAA: true, normalAAA: false, largeAA: true, largeAAA: true });
+  });
+  it('3:1 passes only large AA', () => {
+    expect(wcagLevels(3)).toEqual({ normalAA: false, normalAAA: false, largeAA: true, largeAAA: false });
+  });
+  it('1:1 fails everything', () => {
+    expect(wcagLevels(1)).toEqual({ normalAA: false, normalAAA: false, largeAA: false, largeAAA: false });
+  });
+});

--- a/src/tools/dev/contrast.lib.ts
+++ b/src/tools/dev/contrast.lib.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure WCAG contrast math: parse a colour, compute relative luminance and the
+ * contrast ratio between two colours, and map a ratio to WCAG 2.1 pass/fail.
+ */
+
+export interface RGB { r: number; g: number; b: number; }
+
+export interface WcagLevels {
+  normalAA: boolean;
+  normalAAA: boolean;
+  largeAA: boolean;
+  largeAAA: boolean;
+}
+
+/** Parse `#rgb`, `#rrggbb` or `rgb(r,g,b)` into 0–255 channels, or null. */
+export function parseColor(input: string): RGB | null {
+  const s = input.trim().toLowerCase();
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/.exec(s);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    return { r: parseInt(h.slice(0, 2), 16), g: parseInt(h.slice(2, 4), 16), b: parseInt(h.slice(4, 6), 16) };
+  }
+  const rgb = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/.exec(s);
+  if (rgb) {
+    const r = Number(rgb[1]);
+    const g = Number(rgb[2]);
+    const b = Number(rgb[3]);
+    if (r > 255 || g > 255 || b > 255) return null;
+    return { r, g, b };
+  }
+  return null;
+}
+
+/** WCAG relative luminance (0 = black, 1 = white). */
+export function relativeLuminance({ r, g, b }: RGB): number {
+  const lin = (c: number) => {
+    const cs = c / 255;
+    return cs <= 0.03928 ? cs / 12.92 : Math.pow((cs + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** Contrast ratio between two colours (1–21), order-independent. */
+export function contrastRatio(a: RGB, b: RGB): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** WCAG 2.1 thresholds: normal text AA 4.5 / AAA 7; large text AA 3 / AAA 4.5. */
+export function wcagLevels(ratio: number): WcagLevels {
+  return {
+    normalAA: ratio >= 4.5,
+    normalAAA: ratio >= 7,
+    largeAA: ratio >= 3,
+    largeAAA: ratio >= 4.5,
+  };
+}


### PR DESCRIPTION
Adds a **WCAG Contrast Checker** to the Dev category (`/tools/contrast-checker`).

- Pick a text colour and background colour → exact **contrast ratio** (1–21), a live preview, and **AA/AAA pass-fail** badges for normal and large text per WCAG 2.1.
- Swatch + hex entry for each colour, Swap button, invalid-colour highlighting.
- Pure `contrast.lib.ts` (colour parse, WCAG relative luminance, ratio, level thresholds) unit-tested (12 tests). EN + ID SEO.

Verify: 1191 tests green, lint 0 errors, build OK; both `/tools/contrast-checker/` locales built and listed on the Dev hub.