### PR TITLE
feat(pdf): PDF Metadata Scrubber

### DIFF
--- a/src/islands/pdf/PdfScrubMetadata.tsx
+++ b/src/islands/pdf/PdfScrubMetadata.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ResultActions } from '@/components/ui/ResultActions';
+import { readPdfMetadata, scrubPdfMetadata } from '@/tools/pdf/mupdf.client';
+import { presentFields, metadataLabel } from '@/tools/pdf/scrub-metadata.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; drop: string; dropSub: string; reading: string; failed: string;
+  found: string; none: string; scrub: string; working: string; removedHeading: string;
+  cleanNote: string; nonePresent: string;
+}> = {
+  en: {
+    intro: 'Remove hidden metadata from a PDF — author name, the original file name, the software used, timestamps and the XMP block. Drop a PDF to see what it carries, then scrub it. Everything runs in your browser.',
+    drop: 'Drop a PDF or click to browse', dropSub: 'Cleaned on your device',
+    reading: 'Reading metadata…', failed: 'Something went wrong.',
+    found: 'Metadata found in this PDF', none: 'No standard metadata was found — the PDF may still contain an XMP block, which scrubbing also removes.',
+    scrub: 'Scrub metadata & download', working: 'Scrubbing…', removedHeading: 'Removed',
+    cleanNote: 'The Info fields and the XMP metadata stream were removed. Content and pages are unchanged.',
+    nonePresent: 'No fields had values to remove, but the XMP block (if any) was stripped.',
+  },
+  id: {
+    intro: 'Hapus metadata tersembunyi dari PDF — nama penulis, nama berkas asli, software yang dipakai, timestamp, dan blok XMP. Letakkan PDF untuk melihat isinya, lalu bersihkan. Semuanya berjalan di browser Anda.',
+    drop: 'Letakkan PDF atau klik untuk memilih', dropSub: 'Dibersihkan di perangkat Anda',
+    reading: 'Membaca metadata…', failed: 'Terjadi kesalahan.',
+    found: 'Metadata ditemukan di PDF ini', none: 'Tidak ada metadata standar ditemukan — PDF mungkin masih memuat blok XMP, yang juga dihapus saat pembersihan.',
+    scrub: 'Bersihkan metadata & unduh', working: 'Membersihkan…', removedHeading: 'Dihapus',
+    cleanNote: 'Kolom Info dan aliran metadata XMP telah dihapus. Konten dan halaman tidak berubah.',
+    nonePresent: 'Tidak ada kolom bernilai untuk dihapus, tetapi blok XMP (jika ada) telah dibuang.',
+  },
+};
+
+export default function PdfScrubMetadata({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const l: Lang = lang === 'id' ? 'id' : 'en';
+  const [file, setFile] = useState<File | null>(null);
+  const [meta, setMeta] = useState<Record<string, string> | null>(null);
+  const [removed, setRemoved] = useState<Record<string, string> | null>(null);
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find(x => x.type === 'application/pdf' || x.name.toLowerCase().endsWith('.pdf'));
+    if (!f) return;
+    setFile(f); setMeta(null); setRemoved(null); setBlob(null); setError(''); setBusy(true);
+    try {
+      setMeta(await readPdfMetadata(f));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const scrub = async () => {
+    if (!file) return;
+    setBusy(true); setError('');
+    try {
+      const r = await scrubPdfMetadata(file);
+      setRemoved(r.removed);
+      setBlob(r.blob);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const fields = meta ? presentFields(meta) : [];
+  const removedFields = removed ? presentFields(removed) : [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!file && (
+        <Dropzone onDrop={onDrop} accept="application/pdf" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+      {busy && !meta && <p className="text-sm text-muted-foreground">{t.reading}</p>}
+
+      {file && meta && !blob && (
+        <div className="space-y-3">
+          {fields.length > 0 ? (
+            <div className="space-y-2">
+              <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">{t.found}</span>
+              <div className="divide-y-2 divide-border border-2 border-border">
+                {fields.map(f => (
+                  <div key={f.key} className="grid grid-cols-[9rem_1fr] gap-2 p-2 text-sm">
+                    <span className="font-semibold">{metadataLabel(f.key, l)}</span>
+                    <span className="break-words font-mono text-xs">{f.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <Alert variant="success">{t.none}</Alert>
+          )}
+          <Button onClick={scrub} disabled={busy}>{busy ? t.working : t.scrub}</Button>
+        </div>
+      )}
+
+      {blob && (
+        <div className="space-y-3">
+          {removedFields.length > 0 ? (
+            <div className="space-y-2">
+              <span className="block text-sm font-bold uppercase tracking-wide text-muted-foreground">{t.removedHeading}</span>
+              <div className="divide-y-2 divide-border border-2 border-border">
+                {removedFields.map(f => (
+                  <div key={f.key} className="grid grid-cols-[9rem_1fr] gap-2 p-2 text-sm line-through opacity-70">
+                    <span className="font-semibold">{metadataLabel(f.key, l)}</span>
+                    <span className="break-words font-mono text-xs">{f.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">{t.nonePresent}</p>
+          )}
+          <p className="text-xs text-muted-foreground">{t.cleanNote}</p>
+          <ResultActions blob={blob} filename={file ? file.name.replace(/\.pdf$/i, '') + '-clean.pdf' : 'clean.pdf'} disabled={busy} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -455,6 +455,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'pdf-scrub-metadata': {
+    title: 'Free PDF Metadata Scrubber — Remove Author, Dates & XMP',
+    description: 'Remove hidden metadata from a PDF — author, original file name, software, timestamps and the XMP block. See what it carries, then scrub it. Private, in your browser.',
+    intro: 'PDFs quietly carry hidden metadata: the author’s name, the original file name, the software that made it, creation and edit timestamps, and an XMP block that can hold even more. This free PDF metadata scrubber shows you exactly what a PDF contains and removes it — the document’s Info fields and its XMP stream — while leaving the pages and content untouched. Everything runs on your device; nothing is uploaded.',
+    howTo: [
+      'Drop your PDF to see the metadata it currently contains.',
+      'Review the author, dates, software and other fields found.',
+      'Click Scrub metadata & download.',
+      'Save the cleaned PDF — Info fields and the XMP block are gone.',
+    ],
+    faqs: [
+      { q: 'What metadata does it remove?', a: 'The standard document Info fields — title, author, subject, keywords, creator, producer and the creation/modification dates — plus the XMP metadata stream. Page content is not changed.' },
+      { q: 'Is my PDF uploaded?', a: 'No. Reading and scrubbing run entirely in your browser with an on-device PDF engine, so your file never leaves your device.' },
+      { q: 'Why does removing metadata matter?', a: 'Metadata can leak your real name, your computer’s user or file path, the software you use, and when a document was created or edited — details you may not want to share.' },
+      { q: 'Does it change how the PDF looks?', a: 'No. Only metadata is removed; the pages, text and images stay exactly the same.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the scrubber works with no internet connection.' },
+    ],
+  },
   'compare-lists': {
     title: 'Compare Two Lists — Merge, Dedupe & Diff Lines',
     description: 'Compare two lists of lines online: merge and remove duplicates, subtract one list from another, or find common lines. Free, private and instant — nothing is uploaded.',
@@ -2447,6 +2465,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'pdf-scrub-metadata': {
+    title: 'Pembersih Metadata PDF Gratis — Hapus Penulis, Tanggal & XMP',
+    description: 'Hapus metadata tersembunyi dari PDF — penulis, nama berkas asli, software, timestamp, dan blok XMP. Lihat isinya, lalu bersihkan. Privat, di browser Anda.',
+    intro: 'PDF diam-diam membawa metadata tersembunyi: nama penulis, nama berkas asli, software pembuatnya, timestamp pembuatan dan penyuntingan, serta blok XMP yang bisa memuat lebih banyak lagi. Pembersih metadata PDF gratis ini menunjukkan persis apa yang dimuat PDF dan menghapusnya — kolom Info dokumen dan aliran XMP-nya — sambil membiarkan halaman dan konten utuh. Semuanya berjalan di perangkat Anda; tidak ada yang diunggah.',
+    howTo: [
+      'Letakkan PDF Anda untuk melihat metadata yang saat ini dimuat.',
+      'Tinjau penulis, tanggal, software, dan kolom lain yang ditemukan.',
+      'Klik Bersihkan metadata & unduh.',
+      'Simpan PDF yang sudah bersih — kolom Info dan blok XMP hilang.',
+    ],
+    faqs: [
+      { q: 'Metadata apa saja yang dihapus?', a: 'Kolom Info dokumen standar — judul, penulis, subjek, kata kunci, aplikasi pembuat, produser, serta tanggal pembuatan/modifikasi — plus aliran metadata XMP. Konten halaman tidak diubah.' },
+      { q: 'Apakah PDF saya diunggah?', a: 'Tidak. Pembacaan dan pembersihan berjalan sepenuhnya di browser Anda dengan mesin PDF di perangkat, jadi berkas tidak pernah meninggalkan perangkat.' },
+      { q: 'Mengapa menghapus metadata itu penting?', a: 'Metadata bisa membocorkan nama asli Anda, pengguna atau path berkas komputer Anda, software yang Anda pakai, serta kapan dokumen dibuat atau diedit — detail yang mungkin tak ingin Anda bagikan.' },
+      { q: 'Apakah mengubah tampilan PDF?', a: 'Tidak. Hanya metadata yang dihapus; halaman, teks, dan gambar tetap sama persis.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pembersih bekerja tanpa koneksi internet.' },
     ],
   },
   'compare-lists': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -452,6 +452,17 @@ export const tools: ToolDef[] = [
     icon: Highlighter,
     summary: 'Permanently remove sensitive text and images from a PDF',
     load: () => import('@/islands/pdf/PdfRedact'),
+    status: 'beta'
+  },
+  {
+    id: 'pdf-scrub-metadata',
+    name: 'PDF Metadata Scrubber',
+    category: 'PDF',
+    route: '/tools/pdf-scrub-metadata',
+    keywords: ['pdf metadata', 'remove metadata', 'scrub metadata', 'author', 'strip metadata', 'xmp', 'privacy', 'clean pdf', 'metadata pdf'],
+    icon: Tags,
+    summary: 'Remove hidden author, dates and XMP metadata from a PDF',
+    load: () => import('@/islands/pdf/PdfScrubMetadata'),
     status: 'beta'
   },
   {

--- a/src/tools/pdf/mupdf.client.ts
+++ b/src/tools/pdf/mupdf.client.ts
@@ -96,3 +96,26 @@ export interface RedactBox {
 export async function redactPdf(file: File, boxes: RedactBox[]): Promise<Blob> {
   return toBlob(await engine().redact(await bytesOf(file), boxes));
 }
+
+/** Read the document Info metadata without modifying the file. */
+export async function readPdfMetadata(file: File): Promise<Record<string, string>> {
+  return engine().readMetadata(await bytesOf(file));
+}
+
+/**
+ * Strip all Info metadata via mupdf, then remove the XMP metadata stream with
+ * pdf-lib. Returns the cleaned blob and the map of fields that were removed.
+ */
+export async function scrubPdfMetadata(file: File): Promise<{ blob: Blob; removed: Record<string, string> }> {
+  const { bytes, removed } = await engine().scrubMetadata(await bytesOf(file));
+  let cleaned = bytes;
+  try {
+    const { PDFDocument, PDFName } = await import('pdf-lib');
+    const doc = await PDFDocument.load(bytes, { updateMetadata: false });
+    doc.catalog.delete(PDFName.of('Metadata')); // drop the XMP stream
+    cleaned = await doc.save({ updateMetadata: false });
+  } catch {
+    // If pdf-lib can't parse it, the mupdf-cleaned bytes are still returned.
+  }
+  return { blob: toBlob(cleaned), removed };
+}

--- a/src/tools/pdf/mupdf.worker.ts
+++ b/src/tools/pdf/mupdf.worker.ts
@@ -44,6 +44,8 @@ function save(doc: any, options = ''): Uint8Array {
 
 const transfer = (bytes: Uint8Array) => Comlink.transfer(bytes, [bytes.buffer]);
 
+const METADATA_KEYS = ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer', 'CreationDate', 'ModDate'];
+
 const api = {
   async normalize(bytes: Uint8Array): Promise<Uint8Array> {
     const mupdf = await loadMupdf();
@@ -259,6 +261,43 @@ const api = {
       }
       // Garbage-collect so the removed content can't linger in the file.
       return transfer(save(doc, 'garbage=compact'));
+    } finally {
+      doc.destroy?.();
+    }
+  },
+
+  /** Read the document Info metadata (author, title, dates, …) without changing it. */
+  async readMetadata(bytes: Uint8Array): Promise<Record<string, string>> {
+    const mupdf = await loadMupdf();
+    const doc = open(mupdf, bytes);
+    try {
+      const out: Record<string, string> = {};
+      for (const k of METADATA_KEYS) {
+        const v = doc.getMetaData(`info:${k}`);
+        if (v && String(v).trim()) out[k] = String(v);
+      }
+      return out;
+    } finally {
+      doc.destroy?.();
+    }
+  },
+
+  /**
+   * Strip all standard Info metadata (author, title, creator, producer, subject,
+   * keywords, creation/mod dates). Returns the cleaned bytes and what was removed.
+   * The XMP stream is dropped separately by the client via pdf-lib.
+   */
+  async scrubMetadata(bytes: Uint8Array): Promise<{ bytes: Uint8Array; removed: Record<string, string> }> {
+    const mupdf = await loadMupdf();
+    const doc = open(mupdf, bytes);
+    try {
+      const removed: Record<string, string> = {};
+      for (const k of METADATA_KEYS) {
+        const v = doc.getMetaData(`info:${k}`);
+        if (v && String(v).trim()) removed[k] = String(v);
+        doc.setMetaData(`info:${k}`, '');
+      }
+      return { bytes: save(doc, 'garbage=compact,sanitize=yes'), removed };
     } finally {
       doc.destroy?.();
     }

--- a/src/tools/pdf/scrub-metadata.lib.test.ts
+++ b/src/tools/pdf/scrub-metadata.lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { presentFields, metadataLabel } from './scrub-metadata.lib';
+
+describe('presentFields', () => {
+  it('lists only non-empty fields in a stable order', () => {
+    const fields = presentFields({ Author: 'Jane', Title: '', Producer: 'Acme PDF', Keywords: '   ' });
+    expect(fields).toEqual([
+      { key: 'Author', value: 'Jane' },
+      { key: 'Producer', value: 'Acme PDF' },
+    ]);
+  });
+
+  it('returns [] when nothing is present', () => {
+    expect(presentFields({})).toEqual([]);
+    expect(presentFields({ Title: '', Author: '' })).toEqual([]);
+  });
+});
+
+describe('metadataLabel', () => {
+  it('maps known keys to friendly labels', () => {
+    expect(metadataLabel('Author', 'en')).toBe('Author');
+    expect(metadataLabel('ModDate', 'en')).toBe('Modified');
+    expect(metadataLabel('CreationDate', 'id')).toBe('Dibuat');
+  });
+  it('falls back to the raw key for unknown fields', () => {
+    expect(metadataLabel('Custom', 'en')).toBe('Custom');
+  });
+});

--- a/src/tools/pdf/scrub-metadata.lib.ts
+++ b/src/tools/pdf/scrub-metadata.lib.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for the PDF metadata scrubber: filter the present fields and
+ * label them per locale. The actual read/scrub happens via the mupdf client.
+ */
+import type { Lang } from '@/i18n/config';
+
+export type PdfMetadata = Record<string, string>;
+
+const ORDER = ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer', 'CreationDate', 'ModDate'];
+
+const LABELS: Record<string, Record<Lang, string>> = {
+  Title: { en: 'Title', id: 'Judul' },
+  Author: { en: 'Author', id: 'Penulis' },
+  Subject: { en: 'Subject', id: 'Subjek' },
+  Keywords: { en: 'Keywords', id: 'Kata kunci' },
+  Creator: { en: 'Creator', id: 'Aplikasi pembuat' },
+  Producer: { en: 'Producer', id: 'Produser' },
+  CreationDate: { en: 'Created', id: 'Dibuat' },
+  ModDate: { en: 'Modified', id: 'Dimodifikasi' },
+};
+
+/** Non-empty metadata fields, in canonical order, as {key, value}. */
+export function presentFields(meta: PdfMetadata): { key: string; value: string }[] {
+  const keys = Object.keys(meta);
+  const ordered = [
+    ...ORDER.filter(k => keys.includes(k)),
+    ...keys.filter(k => !ORDER.includes(k)),
+  ];
+  return ordered
+    .filter(k => meta[k] && String(meta[k]).trim() !== '')
+    .map(k => ({ key: k, value: String(meta[k]) }));
+}
+
+/** Friendly label for a metadata key, falling back to the raw key. */
+export function metadataLabel(key: string, lang: Lang): string {
+  const entry = LABELS[key];
+  if (!entry) return key;
+  return entry[lang === 'id' ? 'id' : 'en'];
+}


### PR DESCRIPTION
Adds a **PDF Metadata Scrubber** to the PDF category (`/tools/pdf-scrub-metadata`).

- Drop a PDF to **see the hidden metadata** it carries (author, title, creator, producer, subject, keywords, creation/modification dates).
- Scrub removes all standard **Info fields via mupdf** and the **XMP metadata stream via pdf-lib**, then shows what was removed. Pages and content are untouched.
- New worker `readMetadata`/`scrubMetadata` ops + client wrappers; pure `scrub-metadata.lib.ts` (present-field filtering + labels) unit-tested (4 tests). Fully client-side. EN + ID SEO.

Verify: 1196 tests green, lint 0 errors, build OK; both `/tools/pdf-scrub-metadata/` locales built and listed on the PDF hub.