### PR TITLE
feat(dev): URL Tracking Stripper

### DIFF
--- a/src/islands/dev/UrlStripper.tsx
+++ b/src/islands/dev/UrlStripper.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from 'react';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { cleanUrls } from '@/tools/dev/url-clean.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, {
+  intro: string; placeholder: string; upload: string; clean: string;
+  removed: string; nothing: string; invalid: string; copyAll: string; summary: (u: number, p: number) => string;
+}> = {
+  en: {
+    intro: 'Strip tracking parameters from links — utm_*, fbclid, gclid, si and more. Paste one or many URLs (one per line) or upload a .csv/.txt, and copy the clean versions. Runs entirely in your browser.',
+    placeholder: 'Paste one URL per line…',
+    upload: 'Upload .csv / .txt', clean: 'Clean URL',
+    removed: 'Removed', nothing: 'already clean', invalid: 'not a valid URL',
+    copyAll: 'Copy all clean URLs',
+    summary: (u, p) => `${u} URL${u === 1 ? '' : 's'} · ${p} tracking parameter${p === 1 ? '' : 's'} removed`,
+  },
+  id: {
+    intro: 'Hapus parameter pelacak dari tautan — utm_*, fbclid, gclid, si, dan lainnya. Tempel satu atau banyak URL (satu per baris) atau unggah .csv/.txt, lalu salin versi bersihnya. Berjalan sepenuhnya di browser Anda.',
+    placeholder: 'Tempel satu URL per baris…',
+    upload: 'Unggah .csv / .txt', clean: 'URL bersih',
+    removed: 'Dihapus', nothing: 'sudah bersih', invalid: 'bukan URL valid',
+    copyAll: 'Salin semua URL bersih',
+    summary: (u, p) => `${u} URL · ${p} parameter pelacak dihapus`,
+  },
+};
+
+export default function UrlStripper({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [input, setInput] = useState('');
+
+  const results = useMemo(() => cleanUrls(input), [input]);
+  const totalRemoved = results.reduce((n, r) => n + r.removed.length, 0);
+  const allClean = results.filter(r => r.valid).map(r => r.clean).join('\n');
+
+  const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    const text = await f.text();
+    // Split CSV/TSV cells too, keeping anything that looks like a URL on its own line.
+    const urls = text.split(/[\r\n,;\t]+/).map(s => s.trim().replace(/^"|"$/g, '')).filter(s => /^https?:\/\//i.test(s));
+    setInput(prev => (prev ? prev + '\n' : '') + urls.join('\n'));
+    e.target.value = '';
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <textarea
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        rows={5}
+        placeholder={t.placeholder}
+        className="w-full resize-y border-2 border-border bg-muted p-3 font-mono text-sm"
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="cursor-pointer border-2 border-border px-3 py-2 text-sm font-medium hover:shadow-brutal">
+          {t.upload}
+          <input type="file" accept=".csv,.txt,text/csv,text/plain" onChange={onUpload} className="hidden" />
+        </label>
+        {results.length > 0 && <CopyButton value={allClean} label={t.copyAll} />}
+      </div>
+
+      {results.length > 0 && (
+        <>
+          <p className="text-sm font-semibold">{t.summary(results.length, totalRemoved)}</p>
+          <div className="space-y-2">
+            {results.map((r, i) => (
+              <div key={i} className="space-y-1 border-2 border-border p-2">
+                <div className="flex items-start justify-between gap-2">
+                  <span className={`break-all font-mono text-sm ${r.valid ? '' : 'text-red-600 dark:text-red-400'}`}>
+                    {r.valid ? r.clean : `${r.original} — ${t.invalid}`}
+                  </span>
+                  {r.valid && <CopyButton value={r.clean} />}
+                </div>
+                {r.removed.length > 0 ? (
+                  <div className="flex flex-wrap items-center gap-1 text-xs">
+                    <span className="text-muted-foreground">{t.removed}:</span>
+                    {r.removed.map(p => (
+                      <span key={p} className="border border-border bg-red-500/20 px-1.5 py-0.5 font-mono line-through">{p}</span>
+                    ))}
+                  </div>
+                ) : r.valid ? (
+                  <span className="text-xs text-green-600 dark:text-green-400">✓ {t.nothing}</span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -952,6 +952,23 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the checker works with no internet connection.' },
     ],
   },
+  'url-cleaner': {
+    title: 'URL Tracking Stripper — Remove utm_, fbclid & gclid from Links',
+    description: 'Clean tracking parameters from any link — utm_*, fbclid, gclid, si and more. Paste one or many URLs, or upload a CSV, and copy the clean versions. Private, in your browser.',
+    intro: 'Shared links are often stuffed with tracking parameters — utm_source, fbclid, gclid, si and dozens more — that reveal where you found the link and let it be tracked. This tool strips them out while keeping the parts that actually matter (the path, real query parameters and the page anchor). Paste a single link or many (one per line), or upload a CSV/TXT for bulk cleaning, then copy the results. Everything runs in your browser.',
+    howTo: [
+      'Paste one or more URLs, one per line — or upload a .csv/.txt.',
+      'See each cleaned URL and exactly which parameters were removed.',
+      'Copy a single result, or use Copy all clean URLs for the batch.',
+    ],
+    faqs: [
+      { q: 'Which parameters get removed?', a: 'Common tracking families and click IDs: utm_* and mtm_/pk_ campaign tags, plus fbclid, gclid, dclid, msclkid, igshid, mc_eid, si, ref and many more — while normal parameters like id or q are kept.' },
+      { q: 'Is my list of links uploaded?', a: 'No. Cleaning runs entirely in your browser; your URLs and any uploaded file never leave your device.' },
+      { q: 'Can I clean a whole spreadsheet of links?', a: 'Yes. Export your sheet to CSV (or TXT) and upload it — every cell that looks like a URL is pulled out and cleaned in bulk.' },
+      { q: 'Will it break my links?', a: 'No. Only known tracking parameters are removed; the path, remaining query parameters and the #fragment are preserved, so the link still works.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the stripper works with no internet connection.' },
+    ],
+  },
   'pdf-merge': {
     title: 'Free Merge PDF Tool — Combine PDFs Online',
     description: 'A free online tool to merge multiple PDFs into a single file, in any order — 100% private. Your PDFs are combined in your browser and never uploaded.',
@@ -2962,6 +2979,23 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah ada yang diunggah?', a: 'Tidak. Pemeriksaan berjalan sepenuhnya di browser Anda; warna Anda tidak pernah meninggalkan perangkat.' },
       { q: 'Apa beda AA dan AAA?', a: 'AA adalah baseline umum secara hukum dan praktik; AAA adalah level paling ketat untuk aksesibilitas lebih tinggi. Targetkan minimal AA, dan AAA bila memungkinkan.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pemeriksa bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'url-cleaner': {
+    title: 'Penghapus Pelacak URL — Hapus utm_, fbclid & gclid dari Tautan',
+    description: 'Bersihkan parameter pelacak dari tautan apa pun — utm_*, fbclid, gclid, si, dan lainnya. Tempel satu atau banyak URL, atau unggah CSV, lalu salin versi bersihnya. Privat, di browser.',
+    intro: 'Tautan yang dibagikan sering dipenuhi parameter pelacak — utm_source, fbclid, gclid, si, dan puluhan lainnya — yang mengungkap dari mana Anda menemukan tautan dan memungkinkan pelacakan. Tool ini menghapusnya sambil mempertahankan bagian yang benar-benar penting (path, parameter query asli, dan anchor halaman). Tempel satu tautan atau banyak (satu per baris), atau unggah CSV/TXT untuk pembersihan massal, lalu salin hasilnya. Semuanya berjalan di browser Anda.',
+    howTo: [
+      'Tempel satu atau beberapa URL, satu per baris — atau unggah .csv/.txt.',
+      'Lihat setiap URL bersih dan parameter mana yang dihapus.',
+      'Salin satu hasil, atau gunakan Salin semua URL bersih untuk seluruhnya.',
+    ],
+    faqs: [
+      { q: 'Parameter apa saja yang dihapus?', a: 'Keluarga pelacak umum dan click ID: utm_* serta tag kampanye mtm_/pk_, plus fbclid, gclid, dclid, msclkid, igshid, mc_eid, si, ref, dan banyak lagi — sementara parameter normal seperti id atau q tetap dipertahankan.' },
+      { q: 'Apakah daftar tautan saya diunggah?', a: 'Tidak. Pembersihan berjalan sepenuhnya di browser Anda; URL dan berkas yang diunggah tidak pernah meninggalkan perangkat.' },
+      { q: 'Bisakah membersihkan satu spreadsheet penuh tautan?', a: 'Bisa. Ekspor sheet Anda ke CSV (atau TXT) dan unggah — setiap sel yang tampak seperti URL diambil dan dibersihkan sekaligus.' },
+      { q: 'Apakah akan merusak tautan saya?', a: 'Tidak. Hanya parameter pelacak yang diketahui yang dihapus; path, parameter query lainnya, dan #fragment dipertahankan, jadi tautan tetap berfungsi.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat penghapus bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-merge': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -628,6 +628,17 @@ export const tools: ToolDef[] = [
     icon: Accessibility,
     summary: 'Check text/background colour contrast against WCAG AA & AAA',
     load: () => import('@/islands/dev/ContrastChecker'),
+    status: 'beta'
+  },
+  {
+    id: 'url-cleaner',
+    name: 'URL Tracking Stripper',
+    category: 'Dev',
+    route: '/tools/url-cleaner',
+    keywords: ['url', 'tracking', 'utm', 'fbclid', 'gclid', 'clean url', 'remove tracking', 'strip parameters', 'privacy', 'share link'],
+    icon: Link2Off,
+    summary: 'Remove utm_, fbclid, gclid and other tracking parameters from links',
+    load: () => import('@/islands/dev/UrlStripper'),
     status: 'beta'
   },
   {

--- a/src/tools/dev/url-clean.lib.test.ts
+++ b/src/tools/dev/url-clean.lib.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { cleanUrl, cleanUrls, isTrackingParam } from './url-clean.lib';
+
+describe('isTrackingParam', () => {
+  it('matches utm_* and known trackers', () => {
+    expect(isTrackingParam('utm_source')).toBe(true);
+    expect(isTrackingParam('UTM_Campaign')).toBe(true);
+    expect(isTrackingParam('fbclid')).toBe(true);
+    expect(isTrackingParam('gclid')).toBe(true);
+    expect(isTrackingParam('si')).toBe(true);
+  });
+  it('leaves ordinary params alone', () => {
+    expect(isTrackingParam('id')).toBe(false);
+    expect(isTrackingParam('q')).toBe(false);
+    expect(isTrackingParam('page')).toBe(false);
+  });
+});
+
+describe('cleanUrl', () => {
+  it('removes tracking params and keeps the rest in order', () => {
+    const r = cleanUrl('https://shop.example.com/p?utm_source=fb&id=5&fbclid=abc&color=red');
+    expect(r.clean).toBe('https://shop.example.com/p?id=5&color=red');
+    expect(r.removed.sort()).toEqual(['fbclid', 'utm_source']);
+    expect(r.valid).toBe(true);
+  });
+
+  it('drops the query string entirely when only trackers remain', () => {
+    const r = cleanUrl('https://example.com/article?utm_medium=email&utm_campaign=x');
+    expect(r.clean).toBe('https://example.com/article');
+    expect(r.removed).toHaveLength(2);
+  });
+
+  it('preserves the hash fragment', () => {
+    const r = cleanUrl('https://example.com/p?gclid=1#section-2');
+    expect(r.clean).toBe('https://example.com/p#section-2');
+  });
+
+  it('leaves a clean URL untouched', () => {
+    const r = cleanUrl('https://example.com/p?id=5');
+    expect(r.clean).toBe('https://example.com/p?id=5');
+    expect(r.removed).toEqual([]);
+  });
+
+  it('flags an unparseable string as invalid', () => {
+    const r = cleanUrl('not a url');
+    expect(r.valid).toBe(false);
+    expect(r.removed).toEqual([]);
+  });
+});
+
+describe('cleanUrls (bulk)', () => {
+  it('cleans each non-empty line', () => {
+    const out = cleanUrls('https://a.com/?utm_source=x\n\nhttps://b.com/?id=1&gclid=z');
+    expect(out).toHaveLength(2);
+    expect(out[0].clean).toBe('https://a.com/');
+    expect(out[1].clean).toBe('https://b.com/?id=1');
+  });
+});

--- a/src/tools/dev/url-clean.lib.ts
+++ b/src/tools/dev/url-clean.lib.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure URL tracking-parameter stripper. Removes common analytics/ad click IDs
+ * and campaign parameters while preserving everything functional (path, real
+ * query params, and the hash fragment). No I/O.
+ */
+
+export interface CleanResult {
+  clean: string;
+  removed: string[];
+  valid: boolean;
+}
+
+/** Exact parameter names known to be tracking-only. */
+const TRACKING_EXACT = new Set([
+  'fbclid', 'gclid', 'dclid', 'gbraid', 'wbraid', 'msclkid', 'yclid', 'twclid',
+  'igshid', 'igsh', 'mc_eid', 'mc_cid', 'mkt_tok', 'vero_id', 'vero_conv',
+  'oly_enc_id', 'oly_anon_id', '_openstat', 'wickedid', 'soc_src', 'soc_trk',
+  'si', 'spm', 'scm', 'ref', 'ref_src', 'ref_url', 'referrer', 'source',
+  'cmpid', 'campaign_id', 'ad_id', 'adset_id', 'gad_source', 'gclsrc',
+]);
+
+/** Parameter name prefixes that mark a tracking family. */
+const TRACKING_PREFIX = ['utm_', 'pk_', 'mtm_', 'matomo_', 'hsa_', 'ga_', '__hs', '_hs', 'piwik_'];
+
+export function isTrackingParam(name: string): boolean {
+  const k = name.toLowerCase();
+  if (TRACKING_EXACT.has(k)) return true;
+  return TRACKING_PREFIX.some(p => k.startsWith(p));
+}
+
+export function cleanUrl(input: string): CleanResult {
+  const trimmed = input.trim();
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return { clean: trimmed, removed: [], valid: false };
+  }
+  const removed: string[] = [];
+  const keep = new URLSearchParams();
+  for (const [k, v] of url.searchParams) {
+    if (isTrackingParam(k)) removed.push(k);
+    else keep.append(k, v);
+  }
+  url.search = keep.toString();
+  return { clean: url.toString(), removed, valid: true };
+}
+
+/** Clean every non-empty line of text; keeps the original alongside each result. */
+export function cleanUrls(text: string): (CleanResult & { original: string })[] {
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => ({ original: line, ...cleanUrl(line) }));
+}


### PR DESCRIPTION
Adds a **URL Tracking Stripper** to the Dev category (`/tools/url-cleaner`).

- Removes tracking parameters — utm_*, mtm_/pk_ campaign tags, fbclid, gclid, dclid, msclkid, igshid, mc_eid, si, ref and more — while keeping the path, real query params and #fragment.
- Paste one URL or many (one per line); **bulk .csv/.txt upload** pulls every URL-looking cell; per-row copy + **Copy all**; shows exactly which params were stripped.
- Pure `url-clean.lib.ts` unit-tested (8 tests). Fully client-side. EN + ID SEO.

Verify: 1205 tests green, lint 0 errors, build OK; both `/tools/url-cleaner/` locales built and listed on the Dev hub.