### PR TITLE
fix(pdf-redact): correct redaction position (Y-flip) and page navigation

### DIFF
--- a/src/islands/pdf/PdfRedact.tsx
+++ b/src/islands/pdf/PdfRedact.tsx
@@ -58,10 +58,9 @@ export default function PdfRedact({ lang = 'en' }: { lang?: Lang }) {
   const startRef = useRef<{ x: number; y: number } | null>(null);
   const nextId = useRef(1);
 
-  useEffect(() => () => {
-    rendererRef.current?.destroy();
-    if (pageUrl) URL.revokeObjectURL(pageUrl);
-  }, [pageUrl]);
+  // Tear down the renderer only on unmount. (Depending on pageUrl here would run
+  // this cleanup on every page change and destroy the renderer mid-session.)
+  useEffect(() => () => rendererRef.current?.destroy(), []);
 
   const renderPage = async (renderer: PdfRenderer, n: number) => {
     const page = await renderer.renderPage(n, 1.4);

--- a/src/tools/pdf/mupdf.worker.ts
+++ b/src/tools/pdf/mupdf.worker.ts
@@ -1,5 +1,6 @@
 import './mupdf-setup'; // must run before mupdf loads its wasm
 import * as Comlink from 'comlink';
+import { boxToRect } from './redact.lib';
 
 // mupdf's high-level object typings don't fully cover the low-level PDFObject
 // get/put/asNumber usage below, so a few casts to `any` keep it pragmatic.
@@ -243,17 +244,12 @@ const api = {
       }
       for (const [pageIndex, list] of byPage) {
         const page: any = doc.loadPage(pageIndex);
-        const [x0, y0, x1, y1] = page.getBounds();
-        const pw = x1 - x0;
-        const ph = y1 - y0;
+        const bounds = page.getBounds() as [number, number, number, number];
         for (const b of list) {
-          const rx0 = x0 + b.x * pw;
-          const rx1 = x0 + (b.x + b.w) * pw;
-          // Screen y is top-down; PDF y is bottom-up, so flip against the top edge (y1).
-          const ryTop = y1 - b.y * ph;
-          const ryBottom = y1 - (b.y + b.h) * ph;
+          // mupdf page space is top-left origin (y-down), matching the preview,
+          // so map the box directly with no vertical flip.
           const annot = page.createAnnotation('Redact');
-          annot.setRect([rx0, ryBottom, rx1, ryTop]);
+          annot.setRect(boxToRect(b, bounds));
           annot.update?.();
         }
         // black_boxes=true, image=REMOVE(1), line_art=REMOVE_IF_TOUCHED(2), text=REMOVE(0)

--- a/src/tools/pdf/redact.lib.test.ts
+++ b/src/tools/pdf/redact.lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeDragRect } from './redact.lib';
+import { normalizeDragRect, boxToRect } from './redact.lib';
 
 describe('normalizeDragRect', () => {
   it('converts a top-left → bottom-right drag to ratios', () => {
@@ -19,5 +19,21 @@ describe('normalizeDragRect', () => {
     const r = normalizeDragRect(100, 100, 100, 100, 200, 400);
     expect(r.w).toBe(0);
     expect(r.h).toBe(0);
+  });
+});
+
+describe('boxToRect', () => {
+  it('maps a box to a mupdf rect with no vertical flip (top-left origin)', () => {
+    // Box near the bottom of the page stays near the bottom (large y).
+    const r = boxToRect({ x: 0.1, y: 0.8, w: 0.2, h: 0.1 }, [0, 0, 100, 200]);
+    [10, 160, 30, 180].forEach((v, i) => expect(r[i]).toBeCloseTo(v, 6));
+  });
+
+  it('maps a top box to small y', () => {
+    expect(boxToRect({ x: 0, y: 0, w: 1, h: 0.25 }, [0, 0, 100, 200])).toEqual([0, 0, 100, 50]);
+  });
+
+  it('honours a non-zero page origin (CropBox offset)', () => {
+    expect(boxToRect({ x: 0.5, y: 0.5, w: 0.5, h: 0.5 }, [10, 20, 110, 220])).toEqual([60, 120, 110, 220]);
   });
 });

--- a/src/tools/pdf/redact.lib.ts
+++ b/src/tools/pdf/redact.lib.ts
@@ -13,6 +13,27 @@ export interface RatioRect {
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
 
+/**
+ * Convert a page-relative box (top-left-origin ratios) to a mupdf page rectangle
+ * `[x0, y0, x1, y1]`. MuPDF's page/annotation space is top-left origin with y
+ * increasing downward — the same orientation as the rendered preview image — so
+ * the mapping is a direct scale with NO vertical flip.
+ */
+export function boxToRect(
+  box: { x: number; y: number; w: number; h: number },
+  bounds: [number, number, number, number],
+): [number, number, number, number] {
+  const [x0, y0, x1, y1] = bounds;
+  const pw = x1 - x0;
+  const ph = y1 - y0;
+  return [
+    x0 + box.x * pw,
+    y0 + box.y * ph,
+    x0 + (box.x + box.w) * pw,
+    y0 + (box.y + box.h) * ph,
+  ];
+}
+
 export function normalizeDragRect(
   x1: number,
   y1: number,


### PR DESCRIPTION
Fixes two bugs reported on the live Redact PDF tool:

1. **Redaction position was vertically flipped** vs the preview — boxes drawn at the bottom landed at the top of the downloaded PDF. MuPDF's page/annotation coordinate space is **top-left origin (y-down)**, the same as the rendered preview image, so the box maps directly with **no Y flip**. Extracted the transform into a unit-tested `boxToRect()` and removed the incorrect flip in the worker.
2. **Next/Prev page did nothing** — the cleanup effect depended on `[pageUrl]`, so it ran on every page render and destroyed the pdf.js renderer right after page 1. Now the renderer is torn down on unmount only.

Verify: 1215 tests green (incl. new boxToRect cases), lint 0 errors, build OK.