### PR TITLE
feat(dev): Invoice Generator

### DIFF
--- a/src/islands/dev/InvoiceGenerator.tsx
+++ b/src/islands/dev/InvoiceGenerator.tsx
@@ -1,0 +1,197 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { computeInvoice, formatMoney, CURRENCIES, type InvoiceItem } from '@/tools/dev/invoice.lib';
+import { terbilangRupiah } from '@/tools/dev/terbilang.lib';
+import type { Lang } from '@/i18n/config';
+
+interface Field { description: string; qty: string; unitPrice: string; }
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Create a clean invoice and save it as PDF — add your details, line items, tax (PPN) and a discount, then print or save. Everything is generated in your browser; nothing is uploaded.',
+    currency: 'Currency', number: 'Invoice #', date: 'Date', due: 'Due date',
+    from: 'From', to: 'Bill to', namePlaceholder: 'Name / company', detailPlaceholder: 'Address, email, phone…',
+    items: 'Items', desc: 'Description', qty: 'Qty', price: 'Unit price', amount: 'Amount', addItem: 'Add item',
+    discount: 'Discount %', tax: 'Tax / PPN %', notes: 'Notes',
+    subtotal: 'Subtotal', discountL: 'Discount', taxL: 'Tax', total: 'Total', inWords: 'In words',
+    print: 'Print / Save as PDF', invoice: 'INVOICE', notesPlaceholder: 'Payment terms, bank account…',
+  },
+  id: {
+    intro: 'Buat invoice rapi dan simpan sebagai PDF — tambahkan detail Anda, item, pajak (PPN), dan diskon, lalu cetak atau simpan. Semuanya dibuat di browser Anda; tidak ada yang diunggah.',
+    currency: 'Mata uang', number: 'No. Invoice', date: 'Tanggal', due: 'Jatuh tempo',
+    from: 'Dari', to: 'Ditagihkan ke', namePlaceholder: 'Nama / perusahaan', detailPlaceholder: 'Alamat, email, telepon…',
+    items: 'Item', desc: 'Deskripsi', qty: 'Qty', price: 'Harga satuan', amount: 'Jumlah', addItem: 'Tambah item',
+    discount: 'Diskon %', tax: 'Pajak / PPN %', notes: 'Catatan',
+    subtotal: 'Subtotal', discountL: 'Diskon', taxL: 'Pajak', total: 'Total', inWords: 'Terbilang',
+    print: 'Cetak / Simpan PDF', invoice: 'INVOICE', notesPlaceholder: 'Syarat pembayaran, rekening…',
+  },
+};
+
+const esc = (s: string) => s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+
+export default function InvoiceGenerator({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [currency, setCurrency] = useState('IDR');
+  const [number, setNumber] = useState('INV-001');
+  const [date, setDate] = useState('');
+  const [due, setDue] = useState('');
+  const [fromName, setFromName] = useState('');
+  const [fromDetail, setFromDetail] = useState('');
+  const [toName, setToName] = useState('');
+  const [toDetail, setToDetail] = useState('');
+  const [items, setItems] = useState<Field[]>([{ description: '', qty: '1', unitPrice: '' }]);
+  const [discountPercent, setDiscountPercent] = useState('0');
+  const [taxPercent, setTaxPercent] = useState('11');
+  const [notes, setNotes] = useState('');
+
+  const parsed: InvoiceItem[] = useMemo(
+    () => items.map(it => ({ description: it.description, qty: Number(it.qty) || 0, unitPrice: Number(it.unitPrice) || 0 })),
+    [items],
+  );
+  const totals = useMemo(
+    () => computeInvoice(parsed, { discountPercent: Number(discountPercent) || 0, taxPercent: Number(taxPercent) || 0 }),
+    [parsed, discountPercent, taxPercent],
+  );
+  const money = (v: number) => formatMoney(v, currency);
+
+  const setItem = (i: number, key: keyof Field, value: string) =>
+    setItems(list => list.map((it, idx) => (idx === i ? { ...it, [key]: value } : it)));
+  const addItem = () => setItems(list => [...list, { description: '', qty: '1', unitPrice: '' }]);
+  const removeItem = (i: number) => setItems(list => (list.length > 1 ? list.filter((_, idx) => idx !== i) : list));
+
+  const rowsHtml = parsed
+    .filter(it => it.description || it.qty || it.unitPrice)
+    .map(it => `<tr><td>${esc(it.description)}</td><td class="r">${it.qty}</td><td class="r">${esc(money(it.unitPrice))}</td><td class="r">${esc(money(it.qty * it.unitPrice))}</td></tr>`)
+    .join('');
+
+  const buildHtml = () => `<!doctype html><html><head><meta charset="utf-8"><title>${esc(number || 'invoice')}</title>
+<style>
+  *{box-sizing:border-box} body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#111;margin:0;padding:32px;font-size:13px}
+  .head{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:24px}
+  h1{font-size:28px;letter-spacing:2px;margin:0} .muted{color:#666} .meta{text-align:right}
+  .parties{display:flex;gap:40px;margin-bottom:24px} .parties>div{flex:1}
+  .label{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#888;margin-bottom:4px}
+  .name{font-weight:700} .detail{white-space:pre-line;color:#444}
+  table{width:100%;border-collapse:collapse;margin-bottom:16px} th,td{padding:8px;border-bottom:1px solid #ddd;text-align:left}
+  th{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#888} .r{text-align:right}
+  .totals{margin-left:auto;width:280px} .totals td{border:none;padding:4px 8px} .grand{font-weight:700;font-size:16px;border-top:2px solid #111!important}
+  .words{font-style:italic;color:#444;margin-top:8px} .notes{margin-top:24px;white-space:pre-line;color:#444}
+</style></head><body>
+  <div class="head"><div><h1>${esc(t.invoice)}</h1><div class="muted">${esc(number)}</div></div>
+  <div class="meta"><div>${esc(t.date)}: ${esc(date)}</div><div>${esc(t.due)}: ${esc(due)}</div></div></div>
+  <div class="parties">
+    <div><div class="label">${esc(t.from)}</div><div class="name">${esc(fromName)}</div><div class="detail">${esc(fromDetail)}</div></div>
+    <div><div class="label">${esc(t.to)}</div><div class="name">${esc(toName)}</div><div class="detail">${esc(toDetail)}</div></div>
+  </div>
+  <table><thead><tr><th>${esc(t.desc)}</th><th class="r">${esc(t.qty)}</th><th class="r">${esc(t.price)}</th><th class="r">${esc(t.amount)}</th></tr></thead><tbody>${rowsHtml}</tbody></table>
+  <table class="totals">
+    <tr><td>${esc(t.subtotal)}</td><td class="r">${esc(money(totals.subtotal))}</td></tr>
+    ${totals.discountAmount ? `<tr><td>${esc(t.discountL)}</td><td class="r">- ${esc(money(totals.discountAmount))}</td></tr>` : ''}
+    ${totals.taxAmount ? `<tr><td>${esc(t.taxL)} (${esc(taxPercent)}%)</td><td class="r">${esc(money(totals.taxAmount))}</td></tr>` : ''}
+    <tr class="grand"><td>${esc(t.total)}</td><td class="r">${esc(money(totals.total))}</td></tr>
+  </table>
+  ${currency === 'IDR' ? `<div class="words">${esc(t.inWords)}: ${esc(terbilangRupiah(Math.round(totals.total)))}</div>` : ''}
+  ${notes ? `<div class="notes"><div class="label">${esc(t.notes)}</div>${esc(notes)}</div>` : ''}
+</body></html>`;
+
+  const print = () => {
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write(buildHtml());
+    w.document.close();
+    w.focus();
+    setTimeout(() => w.print(), 250);
+  };
+
+  const input = 'w-full border-2 border-border bg-muted p-2 text-sm';
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Form */}
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.currency}</span>
+              <select value={currency} onChange={e => setCurrency(e.target.value)} className={input}>
+                {Object.keys(CURRENCIES).map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.number}</span>
+              <input value={number} onChange={e => setNumber(e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.date}</span>
+              <input type="date" value={date} onChange={e => setDate(e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.due}</span>
+              <input type="date" value={due} onChange={e => setDue(e.target.value)} className={input} /></label>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1 text-xs"><span className="font-semibold">{t.from}</span>
+              <input value={fromName} onChange={e => setFromName(e.target.value)} placeholder={t.namePlaceholder} className={input} />
+              <textarea value={fromDetail} onChange={e => setFromDetail(e.target.value)} placeholder={t.detailPlaceholder} rows={3} className={input} /></div>
+            <div className="space-y-1 text-xs"><span className="font-semibold">{t.to}</span>
+              <input value={toName} onChange={e => setToName(e.target.value)} placeholder={t.namePlaceholder} className={input} />
+              <textarea value={toDetail} onChange={e => setToDetail(e.target.value)} placeholder={t.detailPlaceholder} rows={3} className={input} /></div>
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-xs font-semibold">{t.items}</span>
+            {items.map((it, i) => (
+              <div key={i} className="flex gap-1">
+                <input value={it.description} onChange={e => setItem(i, 'description', e.target.value)} placeholder={t.desc} className={`${input} flex-1`} />
+                <input value={it.qty} onChange={e => setItem(i, 'qty', e.target.value)} inputMode="decimal" placeholder={t.qty} className={`${input} w-14`} />
+                <input value={it.unitPrice} onChange={e => setItem(i, 'unitPrice', e.target.value)} inputMode="decimal" placeholder={t.price} className={`${input} w-24`} />
+                <button onClick={() => removeItem(i)} aria-label="remove" className="border-2 border-border px-2 text-sm">×</button>
+              </div>
+            ))}
+            <Button variant="secondary" onClick={addItem} className="text-xs">+ {t.addItem}</Button>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.discount}</span>
+              <input value={discountPercent} onChange={e => setDiscountPercent(e.target.value)} inputMode="decimal" className={input} /></label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.tax}</span>
+              <input value={taxPercent} onChange={e => setTaxPercent(e.target.value)} inputMode="decimal" className={input} /></label>
+          </div>
+          <label className="space-y-1 text-xs block"><span className="font-semibold">{t.notes}</span>
+            <textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder={t.notesPlaceholder} rows={2} className={input} /></label>
+        </div>
+
+        {/* Preview */}
+        <div className="space-y-3">
+          <div className="border-2 border-border bg-white p-4 text-sm text-black">
+            <div className="flex items-start justify-between">
+              <div><div className="text-2xl font-black tracking-widest">{t.invoice}</div><div className="text-gray-500">{number}</div></div>
+              <div className="text-right text-xs text-gray-600"><div>{t.date}: {date || '—'}</div><div>{t.due}: {due || '—'}</div></div>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-4 text-xs">
+              <div><div className="uppercase tracking-wide text-gray-400">{t.from}</div><div className="font-bold">{fromName || '—'}</div><div className="whitespace-pre-line text-gray-600">{fromDetail}</div></div>
+              <div><div className="uppercase tracking-wide text-gray-400">{t.to}</div><div className="font-bold">{toName || '—'}</div><div className="whitespace-pre-line text-gray-600">{toDetail}</div></div>
+            </div>
+            <table className="mt-4 w-full text-xs">
+              <thead><tr className="border-b border-gray-300 text-left text-gray-400">
+                <th className="py-1">{t.desc}</th><th className="py-1 text-right">{t.qty}</th><th className="py-1 text-right">{t.price}</th><th className="py-1 text-right">{t.amount}</th></tr></thead>
+              <tbody>
+                {parsed.filter(it => it.description || it.unitPrice).map((it, i) => (
+                  <tr key={i} className="border-b border-gray-100">
+                    <td className="py-1">{it.description}</td><td className="py-1 text-right">{it.qty}</td>
+                    <td className="py-1 text-right">{money(it.unitPrice)}</td><td className="py-1 text-right">{money(it.qty * it.unitPrice)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-3 ml-auto w-56 text-xs">
+              <div className="flex justify-between py-0.5"><span>{t.subtotal}</span><span>{money(totals.subtotal)}</span></div>
+              {totals.discountAmount > 0 && <div className="flex justify-between py-0.5"><span>{t.discountL}</span><span>- {money(totals.discountAmount)}</span></div>}
+              {totals.taxAmount > 0 && <div className="flex justify-between py-0.5"><span>{t.taxL} ({taxPercent}%)</span><span>{money(totals.taxAmount)}</span></div>}
+              <div className="mt-1 flex justify-between border-t-2 border-black py-1 text-sm font-black"><span>{t.total}</span><span>{money(totals.total)}</span></div>
+            </div>
+            {currency === 'IDR' && totals.total > 0 && <div className="mt-2 text-xs italic text-gray-600">{t.inWords}: {terbilangRupiah(Math.round(totals.total))}</div>}
+          </div>
+          <Button onClick={print}>{t.print}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -247,6 +247,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Is this official tax advice?', a: 'No. It is a calculation helper. Always confirm the correct rates and articles for your situation with a tax professional.' },
     ],
   },
+  'invoice-generator': {
+    title: 'Free Invoice Generator — Make an Invoice PDF Online',
+    description: 'Create a clean, professional invoice and save it as PDF. Add your details, line items, tax (PPN) and a discount, with an Indonesian amount-in-words. Free, in your browser.',
+    intro: 'This free invoice generator lets you make a professional invoice in minutes and save it as a PDF. Fill in your business and client details, add line items with quantities and prices, apply a discount and tax (PPN), and add notes — the totals update live and, for rupiah invoices, the amount in words (terbilang) is filled in automatically. Everything is generated in your browser; nothing is uploaded.',
+    howTo: [
+      'Pick a currency and fill in your details and the client’s.',
+      'Add line items with a description, quantity and unit price.',
+      'Set the discount and tax (PPN) percentages, and add any notes.',
+      'Click Print / Save as PDF and choose “Save as PDF”.',
+    ],
+    faqs: [
+      { q: 'Is my invoice data uploaded?', a: 'No. The invoice is built entirely in your browser and never leaves your device — safe for client and pricing details.' },
+      { q: 'How do I save it as a PDF?', a: 'Click Print / Save as PDF; in the print dialog choose “Save as PDF” as the destination (or print to paper).' },
+      { q: 'Does it handle Indonesian PPN and terbilang?', a: 'Yes. Set the PPN percentage (11% by default) and, for IDR invoices, the total is spelled out in Indonesian words automatically.' },
+      { q: 'Which currencies are supported?', a: 'IDR, USD, EUR, GBP, SGD and MYR, each formatted with the right symbol and grouping.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the generator works with no internet connection.' },
+    ],
+  },
   'word-counter': {
     title: 'Free Word Counter — Count Words, Characters & Reading Time',
     description: 'A free online word counter: count words, characters (with and without spaces), sentences, paragraphs, lines and reading time as you type. Runs in your browser — nothing is uploaded.',
@@ -2274,6 +2292,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bagaimana PPh dihitung?', a: 'PPh dipotong dari dasar (DPP) sesuai tarif jenis yang dipilih — mis. 2% untuk jasa PPh 23 atau 10% untuk sewa PPh 4(2). Vendor menerima total invoice dikurangi PPh.' },
       { q: 'Bisakah memisahkan harga yang sudah termasuk PPN?', a: 'Ya. Centang “nominal sudah termasuk PPN” dan tool memisahkan dasar dan PPN dari nilai bruto.' },
       { q: 'Apakah ini nasihat pajak resmi?', a: 'Bukan. Ini tool bantu hitung. Selalu konfirmasi tarif dan pasal yang benar untuk situasi Anda dengan profesional pajak.' },
+    ],
+  },
+  'invoice-generator': {
+    title: 'Pembuat Invoice Gratis — Buat Invoice PDF Online',
+    description: 'Buat invoice profesional yang rapi dan simpan sebagai PDF. Tambahkan detail Anda, item, pajak (PPN), dan diskon, lengkap dengan terbilang rupiah. Gratis, di browser.',
+    intro: 'Pembuat invoice gratis ini memungkinkan Anda membuat invoice profesional dalam hitungan menit dan menyimpannya sebagai PDF. Isi detail bisnis dan klien, tambahkan item beserta jumlah dan harga, terapkan diskon dan pajak (PPN), serta tambahkan catatan — total diperbarui langsung dan, untuk invoice rupiah, terbilang diisi otomatis. Semuanya dibuat di browser Anda; tidak ada yang diunggah.',
+    howTo: [
+      'Pilih mata uang dan isi detail Anda serta klien.',
+      'Tambahkan item dengan deskripsi, jumlah, dan harga satuan.',
+      'Atur persentase diskon dan pajak (PPN), lalu tambahkan catatan.',
+      'Klik Cetak / Simpan PDF dan pilih “Simpan sebagai PDF”.',
+    ],
+    faqs: [
+      { q: 'Apakah data invoice saya diunggah?', a: 'Tidak. Invoice dibuat sepenuhnya di browser Anda dan tidak pernah meninggalkan perangkat — aman untuk detail klien dan harga.' },
+      { q: 'Bagaimana menyimpannya sebagai PDF?', a: 'Klik Cetak / Simpan PDF; pada dialog cetak, pilih “Simpan sebagai PDF” sebagai tujuan (atau cetak ke kertas).' },
+      { q: 'Apakah mendukung PPN dan terbilang Indonesia?', a: 'Ya. Atur persentase PPN (default 11%) dan, untuk invoice IDR, total ditulis dalam terbilang secara otomatis.' },
+      { q: 'Mata uang apa saja yang didukung?', a: 'IDR, USD, EUR, GBP, SGD, dan MYR, masing-masing dengan simbol dan pemisah yang tepat.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pembuat invoice bekerja tanpa koneksi internet.' },
     ],
   },
   'word-counter': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -642,6 +642,17 @@ export const tools: ToolDef[] = [
     status: 'beta'
   },
   {
+    id: 'invoice-generator',
+    name: 'Invoice Generator',
+    category: 'Dev',
+    route: '/tools/invoice-generator',
+    keywords: ['invoice', 'invoice generator', 'faktur', 'kwitansi', 'billing', 'tax', 'ppn', 'receipt', 'buat invoice', 'pdf invoice'],
+    icon: FileText,
+    summary: 'Create a printable invoice with tax (PPN) and save as PDF',
+    load: () => import('@/islands/dev/InvoiceGenerator'),
+    status: 'beta'
+  },
+  {
     id: 'pdf-merge',
     name: 'Merge PDFs',
     category: 'PDF',

--- a/src/tools/dev/invoice.lib.test.ts
+++ b/src/tools/dev/invoice.lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { computeInvoice, formatMoney, type InvoiceItem } from './invoice.lib';
+
+const items: InvoiceItem[] = [
+  { description: 'Design', qty: 2, unitPrice: 100 },
+  { description: 'Hosting', qty: 1, unitPrice: 50 },
+];
+
+describe('computeInvoice', () => {
+  it('sums line items into a subtotal', () => {
+    const r = computeInvoice(items, {});
+    expect(r.subtotal).toBe(250);
+    expect(r.total).toBe(250);
+  });
+
+  it('applies tax on the subtotal', () => {
+    const r = computeInvoice(items, { taxPercent: 11 });
+    expect(r.taxAmount).toBeCloseTo(27.5, 6);
+    expect(r.total).toBeCloseTo(277.5, 6);
+  });
+
+  it('applies a discount before tax', () => {
+    const r = computeInvoice(items, { discountPercent: 10, taxPercent: 11 });
+    expect(r.discountAmount).toBeCloseTo(25, 6);
+    expect(r.taxableBase).toBeCloseTo(225, 6);
+    expect(r.taxAmount).toBeCloseTo(24.75, 6);
+    expect(r.total).toBeCloseTo(249.75, 6);
+  });
+
+  it('ignores blank/invalid rows', () => {
+    const r = computeInvoice([{ description: '', qty: 0, unitPrice: 0 }, { description: 'X', qty: 3, unitPrice: 10 }], {});
+    expect(r.subtotal).toBe(30);
+  });
+
+  it('is all zero for no items', () => {
+    const r = computeInvoice([], { taxPercent: 11 });
+    expect(r).toEqual({ subtotal: 0, discountAmount: 0, taxableBase: 0, taxAmount: 0, total: 0 });
+  });
+});
+
+describe('formatMoney', () => {
+  it('formats IDR without decimals', () => {
+    expect(formatMoney(1500000, 'IDR')).toBe('Rp 1.500.000');
+  });
+  it('formats USD with two decimals', () => {
+    expect(formatMoney(1234.5, 'USD')).toBe('$1,234.50');
+  });
+});

--- a/src/tools/dev/invoice.lib.ts
+++ b/src/tools/dev/invoice.lib.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure invoice math and money formatting. UI, layout and printing live in the
+ * island; the arithmetic and currency rendering are here and unit-tested.
+ */
+
+export interface InvoiceItem {
+  description: string;
+  qty: number;
+  unitPrice: number;
+}
+
+export interface InvoiceOptions {
+  discountPercent?: number;
+  taxPercent?: number;
+}
+
+export interface InvoiceTotals {
+  subtotal: number;
+  discountAmount: number;
+  taxableBase: number;
+  taxAmount: number;
+  total: number;
+}
+
+export function computeInvoice(items: InvoiceItem[], opts: InvoiceOptions): InvoiceTotals {
+  const subtotal = items.reduce((sum, it) => {
+    const qty = Number(it.qty) || 0;
+    const price = Number(it.unitPrice) || 0;
+    return sum + qty * price;
+  }, 0);
+  const discountAmount = subtotal * ((opts.discountPercent || 0) / 100);
+  const taxableBase = subtotal - discountAmount;
+  const taxAmount = taxableBase * ((opts.taxPercent || 0) / 100);
+  return {
+    subtotal,
+    discountAmount,
+    taxableBase,
+    taxAmount,
+    total: taxableBase + taxAmount,
+  };
+}
+
+interface CurrencyDef { symbol: string; locale: string; digits: number; after: boolean; }
+
+export const CURRENCIES: Record<string, CurrencyDef> = {
+  IDR: { symbol: 'Rp ', locale: 'id-ID', digits: 0, after: false },
+  USD: { symbol: '$', locale: 'en-US', digits: 2, after: false },
+  EUR: { symbol: '€', locale: 'en-IE', digits: 2, after: false },
+  GBP: { symbol: '£', locale: 'en-GB', digits: 2, after: false },
+  SGD: { symbol: 'S$', locale: 'en-SG', digits: 2, after: false },
+  MYR: { symbol: 'RM ', locale: 'ms-MY', digits: 2, after: false },
+};
+
+/** Format a value with the currency's symbol and locale grouping (deterministic). */
+export function formatMoney(value: number, currency: string): string {
+  const c = CURRENCIES[currency] ?? CURRENCIES.USD;
+  const num = new Intl.NumberFormat(c.locale, {
+    minimumFractionDigits: c.digits,
+    maximumFractionDigits: c.digits,
+  }).format(value);
+  return c.after ? `${num} ${c.symbol}` : `${c.symbol}${num}`;
+}


### PR DESCRIPTION
Adds an **Invoice Generator** to the Dev category (`/tools/invoice-generator`), pairing with the Terbilang and PPN/PPh tools.

- Form → live invoice preview: seller & client details, line items (qty × price), discount %, tax/PPN % (default 11), notes.
- **Multi-currency** (IDR, USD, EUR, GBP, SGD, MYR) with correct symbol/grouping; **IDR total spelled out in Indonesian words** (reuses `terbilang`).
- **Print / Save as PDF** via a clean standalone print document.
- Pure `invoice.lib.ts` (totals + money formatting) unit-tested (7 tests). Fully client-side. EN + ID SEO.

Verify: 1216 tests green, lint 0 errors, build OK; both `/tools/invoice-generator/` locales built and listed on the Dev hub.