### PR TITLE
feat(dev): Barcode Generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
         "idb": "^8.0.0",
+        "jsbarcode": "^3.12.3",
         "jsqr": "^1.4.0",
         "libarchive.js": "^2.0.2",
         "lucide-react": "^0.294.0",
@@ -14103,6 +14104,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsbarcode": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.12.3.tgz",
+      "integrity": "sha512-CuHU9hC6dPsHF5oVFMo8NW76uQVjH4L22CsP4hW+dNnGywJHC/B0ThA1CTDVLnxKLrrpYdicBLnd2xsgTfRnvg==",
       "license": "MIT"
     },
     "node_modules/jsdom": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
     "idb": "^8.0.0",
+    "jsbarcode": "^3.12.3",
     "jsqr": "^1.4.0",
     "libarchive.js": "^2.0.2",
     "lucide-react": "^0.294.0",

--- a/src/islands/image/BarcodeGenerator.tsx
+++ b/src/islands/image/BarcodeGenerator.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { BARCODE_FORMATS, validateValue } from '@/tools/image/barcode.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Generate a barcode — Code 128, EAN-13, UPC, Code 39 and more — and download it as PNG or SVG. Everything is rendered in your browser; nothing is uploaded.',
+    format: 'Format', value: 'Value', showText: 'Show text', png: 'Download PNG', svg: 'Download SVG',
+  },
+  id: {
+    intro: 'Buat barcode — Code 128, EAN-13, UPC, Code 39, dan lainnya — lalu unduh sebagai PNG atau SVG. Semuanya dirender di browser Anda; tidak ada yang diunggah.',
+    format: 'Format', value: 'Nilai', showText: 'Tampilkan teks', png: 'Unduh PNG', svg: 'Unduh SVG',
+  },
+};
+
+export default function BarcodeGenerator({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [format, setFormat] = useState('CODE128');
+  const [value, setValue] = useState('GOODWEBTOOLS');
+  const [showText, setShowText] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const hint = BARCODE_FORMATS.find(f => f.id === format)?.hint ?? '';
+
+  useEffect(() => {
+    let cancelled = false;
+    const err = validateValue(format, value);
+    if (err) {
+      setError(err);
+      const c = canvasRef.current;
+      if (c) c.getContext('2d')?.clearRect(0, 0, c.width, c.height);
+      return;
+    }
+    setError(null);
+    (async () => {
+      const JsBarcode = (await import('jsbarcode')).default;
+      if (cancelled || !canvasRef.current) return;
+      try {
+        JsBarcode(canvasRef.current, value, {
+          format,
+          displayValue: showText,
+          width: 2,
+          height: 90,
+          margin: 12,
+          background: '#ffffff',
+          lineColor: '#000000',
+          font: 'monospace',
+          fontSize: 16,
+        });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not render this barcode.');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [format, value, showText]);
+
+  const downloadPng = () => {
+    canvasRef.current?.toBlob(blob => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `barcode-${format}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  };
+
+  const downloadSvg = async () => {
+    const JsBarcode = (await import('jsbarcode')).default;
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    try {
+      JsBarcode(svg, value, { format, displayValue: showText, width: 2, height: 90, margin: 12, font: 'monospace', fontSize: 16 });
+    } catch {
+      return;
+    }
+    const xml = new XMLSerializer().serializeToString(svg);
+    const blob = new Blob([xml], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `barcode-${format}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const input = 'w-full border-2 border-border bg-muted p-2 text-sm';
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="space-y-1 text-sm"><span className="block font-semibold">{t.format}</span>
+          <select value={format} onChange={e => setFormat(e.target.value)} className={input}>
+            {BARCODE_FORMATS.map(f => <option key={f.id} value={f.id}>{f.name}</option>)}
+          </select>
+        </label>
+        <label className="space-y-1 text-sm"><span className="block font-semibold">{t.value}</span>
+          <input value={value} onChange={e => setValue(e.target.value)} className={input} />
+          <span className="text-xs text-muted-foreground">{hint}</span>
+        </label>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={showText} onChange={e => setShowText(e.target.checked)} />
+        <span>{t.showText}</span>
+      </label>
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      <div className="flex justify-center border-2 border-border bg-white p-4">
+        <canvas ref={canvasRef} className={error ? 'hidden' : 'max-w-full'} />
+      </div>
+
+      {!error && (
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={downloadPng}>{t.png}</Button>
+          <Button variant="secondary" onClick={downloadSvg}>{t.svg}</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1005,6 +1005,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Why is my color showing as invalid?', a: 'The input has to be a valid hex code like #rrggbb or an rgb(r, g, b) value. Check for a missing # or a typo, and the tool will convert it once the format is right.' },
     ],
   },
+  'barcode-generator': {
+    title: 'Free Barcode Generator — Code 128, EAN, UPC & More (PNG/SVG)',
+    description: 'Generate barcodes online — Code 128, EAN-13, EAN-8, UPC, Code 39, ITF and more — and download as PNG or SVG. Free and private; everything renders in your browser.',
+    intro: 'This free barcode generator creates retail and logistics barcodes — Code 128, EAN-13, EAN-8, UPC-A, Code 39, ITF-14, MSI, Codabar and Pharmacode — right in your browser. Pick a symbology, type your value, and download a crisp PNG or a scalable SVG. Nothing is uploaded.',
+    howTo: [
+      'Choose a barcode format (e.g. Code 128 or EAN-13).',
+      'Type the value to encode — the hint shows the required length/characters.',
+      'Toggle the human-readable text if you want it under the bars.',
+      'Download the barcode as PNG or SVG.',
+    ],
+    faqs: [
+      { q: 'Which barcode types are supported?', a: 'Code 128, EAN-13, EAN-8, UPC-A, Code 39, ITF-14, MSI, Codabar and Pharmacode.' },
+      { q: 'Is my data uploaded?', a: 'No. Barcodes are rendered entirely in your browser, so your values never leave your device.' },
+      { q: 'Can I download a vector (SVG) barcode?', a: 'Yes. Download as SVG for print or further editing, or PNG for quick use.' },
+      { q: 'Why does EAN-13 need a specific length?', a: 'Retail symbologies encode a fixed number of digits (12–13 for EAN-13) plus a check digit that is added automatically, so the value must match that length.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the generator works with no internet connection.' },
+    ],
+  },
   'contrast-checker': {
     title: 'WCAG Contrast Checker — Color Contrast Ratio (AA & AAA)',
     description: 'Check colour contrast between text and background against WCAG 2.1. See the contrast ratio and AA/AAA pass or fail for normal and large text. Free, in your browser.',
@@ -3103,6 +3121,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah ada yang dikirim ke server?', a: 'Tidak. Konversi berjalan sepenuhnya di browser Anda dengan JavaScript, jadi tidak ada nilai warna atau data yang meninggalkan perangkat Anda.' },
       { q: 'Bisakah saya memilih warna alih-alih mengetiknya?', a: 'Ya. Klik kotak warna untuk membuka pemilih warna sistem Anda, dan nilai HEX, RGB, serta HSL akan diperbarui sesuai pilihan Anda.' },
       { q: 'Mengapa warna saya ditampilkan sebagai tidak valid?', a: 'Masukan harus berupa kode hex yang valid seperti #rrggbb atau nilai rgb(r, g, b). Periksa apakah ada # yang hilang atau salah ketik, dan konversi akan dilakukan begitu formatnya benar.' },
+    ],
+  },
+  'barcode-generator': {
+    title: 'Pembuat Barcode Gratis — Code 128, EAN, UPC & Lainnya (PNG/SVG)',
+    description: 'Buat barcode online — Code 128, EAN-13, EAN-8, UPC, Code 39, ITF, dan lainnya — lalu unduh sebagai PNG atau SVG. Gratis dan privat; semuanya dirender di browser Anda.',
+    intro: 'Pembuat barcode gratis ini membuat barcode ritel dan logistik — Code 128, EAN-13, EAN-8, UPC-A, Code 39, ITF-14, MSI, Codabar, dan Pharmacode — langsung di browser Anda. Pilih simbologi, ketik nilai, lalu unduh PNG yang tajam atau SVG yang skalabel. Tidak ada yang diunggah.',
+    howTo: [
+      'Pilih format barcode (mis. Code 128 atau EAN-13).',
+      'Ketik nilai yang akan dikodekan — petunjuk menampilkan panjang/karakter yang diperlukan.',
+      'Aktifkan teks yang bisa dibaca bila ingin tampil di bawah bar.',
+      'Unduh barcode sebagai PNG atau SVG.',
+    ],
+    faqs: [
+      { q: 'Jenis barcode apa saja yang didukung?', a: 'Code 128, EAN-13, EAN-8, UPC-A, Code 39, ITF-14, MSI, Codabar, dan Pharmacode.' },
+      { q: 'Apakah data saya diunggah?', a: 'Tidak. Barcode dirender sepenuhnya di browser Anda, jadi nilai Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Bisakah mengunduh barcode vektor (SVG)?', a: 'Bisa. Unduh sebagai SVG untuk cetak atau pengeditan lanjutan, atau PNG untuk pemakaian cepat.' },
+      { q: 'Mengapa EAN-13 butuh panjang tertentu?', a: 'Simbologi ritel mengodekan jumlah digit tetap (12–13 untuk EAN-13) plus check digit yang ditambahkan otomatis, jadi nilainya harus sesuai panjang itu.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pembuat bekerja tanpa koneksi internet.' },
     ],
   },
   'contrast-checker': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -618,6 +618,17 @@ export const tools: ToolDef[] = [
     summary: 'Decode a QR code from an image',
     load: () => import('@/islands/dev/QrRead'),
     status: 'stable'
+  },
+  {
+    id: 'barcode-generator',
+    name: 'Barcode Generator',
+    category: 'Dev',
+    route: '/tools/barcode-generator',
+    keywords: ['barcode', 'code 128', 'ean', 'ean13', 'upc', 'code 39', 'itf', 'generate barcode', 'buat barcode'],
+    icon: Barcode,
+    summary: 'Generate Code 128, EAN, UPC and other barcodes as PNG/SVG',
+    load: () => import('@/islands/image/BarcodeGenerator'),
+    status: 'beta'
   },
   {
     id: 'timestamp',

--- a/src/tools/image/barcode.lib.test.ts
+++ b/src/tools/image/barcode.lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { BARCODE_FORMATS, validateValue } from './barcode.lib';
+
+describe('BARCODE_FORMATS', () => {
+  it('lists the common symbologies', () => {
+    const ids = BARCODE_FORMATS.map(f => f.id);
+    expect(ids).toContain('CODE128');
+    expect(ids).toContain('EAN13');
+    expect(ids).toContain('UPC');
+    expect(ids).toContain('CODE39');
+  });
+});
+
+describe('validateValue', () => {
+  it('accepts any non-empty value for CODE128', () => {
+    expect(validateValue('CODE128', 'Hello-123')).toBeNull();
+    expect(validateValue('CODE128', '')).not.toBeNull();
+  });
+
+  it('requires 12–13 digits for EAN13', () => {
+    expect(validateValue('EAN13', '590123412345')).toBeNull();
+    expect(validateValue('EAN13', '5901234123457')).toBeNull();
+    expect(validateValue('EAN13', '12345')).not.toBeNull();
+    expect(validateValue('EAN13', '59012341234A')).not.toBeNull();
+  });
+
+  it('requires 7–8 digits for EAN8', () => {
+    expect(validateValue('EAN8', '9638507')).toBeNull();
+    expect(validateValue('EAN8', '123')).not.toBeNull();
+  });
+
+  it('requires 11–12 digits for UPC', () => {
+    expect(validateValue('UPC', '03600029145')).toBeNull();
+    expect(validateValue('UPC', '9999')).not.toBeNull();
+  });
+
+  it('restricts CODE39 to its character set', () => {
+    expect(validateValue('CODE39', 'ABC-123')).toBeNull();
+    expect(validateValue('CODE39', 'lowercase')).not.toBeNull();
+  });
+});

--- a/src/tools/image/barcode.lib.ts
+++ b/src/tools/image/barcode.lib.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure barcode value validation and the list of supported symbologies. Actual
+ * rendering is done by JsBarcode in the island; this validates input up front so
+ * the user gets a clear message instead of a thrown render error.
+ */
+
+export interface BarcodeFormat {
+  id: string;
+  name: string;
+  hint: string;
+}
+
+export const BARCODE_FORMATS: BarcodeFormat[] = [
+  { id: 'CODE128', name: 'Code 128', hint: 'Any text or digits' },
+  { id: 'EAN13', name: 'EAN-13', hint: '12–13 digits' },
+  { id: 'EAN8', name: 'EAN-8', hint: '7–8 digits' },
+  { id: 'UPC', name: 'UPC-A', hint: '11–12 digits' },
+  { id: 'CODE39', name: 'Code 39', hint: 'A–Z, 0–9, - . $ / + % space' },
+  { id: 'ITF14', name: 'ITF-14', hint: '13–14 digits' },
+  { id: 'MSI', name: 'MSI', hint: 'Digits only' },
+  { id: 'pharmacode', name: 'Pharmacode', hint: 'Number 3–131070' },
+  { id: 'codabar', name: 'Codabar', hint: 'Digits and - $ : / . +' },
+];
+
+/** Returns an error message if the value is invalid for the format, else null. */
+export function validateValue(format: string, value: string): string | null {
+  const v = value ?? '';
+  if (v.trim() === '') return 'Enter a value to encode.';
+  switch (format) {
+    case 'EAN13':
+      return /^\d{12,13}$/.test(v) ? null : 'EAN-13 needs 12 or 13 digits.';
+    case 'EAN8':
+      return /^\d{7,8}$/.test(v) ? null : 'EAN-8 needs 7 or 8 digits.';
+    case 'UPC':
+      return /^\d{11,12}$/.test(v) ? null : 'UPC-A needs 11 or 12 digits.';
+    case 'ITF14':
+      return /^\d{13,14}$/.test(v) ? null : 'ITF-14 needs 13 or 14 digits.';
+    case 'MSI':
+      return /^\d+$/.test(v) ? null : 'MSI accepts digits only.';
+    case 'CODE39':
+      return /^[0-9A-Z\-.$/+% ]+$/.test(v) ? null : 'Code 39 allows A–Z, 0–9 and - . $ / + % space.';
+    case 'codabar':
+      return /^[0-9\-$:/.+]+$/.test(v) ? null : 'Codabar allows digits and - $ : / . +';
+    case 'pharmacode': {
+      const n = Number(v);
+      return Number.isInteger(n) && n >= 3 && n <= 131070 ? null : 'Pharmacode is a number from 3 to 131070.';
+    }
+    case 'CODE128':
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Adds a **Barcode Generator** to the Dev category (`/tools/barcode-generator`), complementing the existing QR tools.

- Symbologies: **Code 128, EAN-13, EAN-8, UPC-A, Code 39, ITF-14, MSI, Codabar, Pharmacode** (via JsBarcode, MIT).
- Per-format input validation with helpful hints; live canvas preview; **PNG and SVG download**; optional human-readable text.
- Pure `barcode.lib.ts` (format list + value validation) unit-tested (6 tests). JsBarcode is lazy-loaded (13 kB gzip). New dep: `jsbarcode`.

Verify: 1243 tests green, lint 0 errors, build OK; both `/tools/barcode-generator/` locales built and listed on the Dev hub.