### PR TITLE
feat(games): Wheel Spinner / Random Picker + Games category

### DIFF
--- a/src/islands/games/WheelSpinner.tsx
+++ b/src/islands/games/WheelSpinner.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { parseEntries, sliceForAngle } from '@/tools/games/wheel.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Spin the wheel to pick a name or option at random — great for giveaways, picking who goes first, or making a decision. Add one entry per line. Runs entirely in your browser.',
+    entries: 'Entries (one per line)', spin: 'Spin', spinning: 'Spinning…', winner: 'Winner', needTwo: 'Add at least two entries to spin.',
+  },
+  id: {
+    intro: 'Putar roda untuk memilih nama atau opsi secara acak — cocok untuk giveaway, menentukan giliran, atau mengambil keputusan. Tambahkan satu entri per baris. Berjalan sepenuhnya di browser Anda.',
+    entries: 'Entri (satu per baris)', spin: 'Putar', spinning: 'Memutar…', winner: 'Pemenang', needTwo: 'Tambahkan minimal dua entri untuk memutar.',
+  },
+};
+
+const COLORS = ['#ef4444', '#f59e0b', '#84cc16', '#10b981', '#06b6d4', '#6366f1', '#a855f7', '#ec4899'];
+const TAU = Math.PI * 2;
+
+export default function WheelSpinner({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [text, setText] = useState('Alice\nBob\nCarol\nDave');
+  const [angle, setAngle] = useState(0); // degrees
+  const [spinning, setSpinning] = useState(false);
+  const [winner, setWinner] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const entries = parseEntries(text);
+
+  const draw = (rotationDeg: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const size = canvas.width;
+    const cx = size / 2;
+    const cy = size / 2;
+    const radius = size / 2 - 4;
+    ctx.clearRect(0, 0, size, size);
+    const n = entries.length;
+    if (n === 0) return;
+    const per = TAU / n;
+    const offset = (rotationDeg * Math.PI) / 180 - Math.PI / 2 - per / 2;
+    for (let i = 0; i < n; i++) {
+      const start = offset + i * per;
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.arc(cx, cy, radius, start, start + per);
+      ctx.closePath();
+      ctx.fillStyle = COLORS[i % COLORS.length];
+      ctx.fill();
+      // label
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(start + per / 2);
+      ctx.textAlign = 'right';
+      ctx.fillStyle = '#111';
+      ctx.font = 'bold 14px sans-serif';
+      const label = entries[i].length > 16 ? entries[i].slice(0, 15) + '…' : entries[i];
+      ctx.fillText(label, radius - 10, 5);
+      ctx.restore();
+    }
+    // hub
+    ctx.beginPath();
+    ctx.arc(cx, cy, 14, 0, TAU);
+    ctx.fillStyle = '#111';
+    ctx.fill();
+  };
+
+  useEffect(() => {
+    draw(angle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, angle]);
+
+  useEffect(() => () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); }, []);
+
+  const spin = () => {
+    const n = entries.length;
+    if (n < 2 || spinning) return;
+    setSpinning(true);
+    setWinner(null);
+    const start = angle;
+    const spins = 5 + Math.floor(Math.random() * 4);
+    const target = start + spins * 360 + Math.random() * 360;
+    const duration = 4200;
+    let startTime = 0;
+    const step = (ts: number) => {
+      if (!startTime) startTime = ts;
+      const p = Math.min(1, (ts - startTime) / duration);
+      const eased = 1 - Math.pow(1 - p, 3); // ease-out cubic
+      const current = start + (target - start) * eased;
+      setAngle(current);
+      if (p < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      } else {
+        setSpinning(false);
+        // Slice 0 is centred at the top, so shift by half a slice before mapping.
+        const idx = sliceForAngle(180 / n - current, n);
+        setWinner(entries[idx] ?? null);
+      }
+    };
+    rafRef.current = requestAnimationFrame(step);
+  };
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1fr_300px]">
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t.intro}</p>
+        <div className="relative mx-auto w-full max-w-md">
+          {/* pointer */}
+          <div className="absolute left-1/2 top-0 z-10 -translate-x-1/2 -translate-y-1"
+            style={{ width: 0, height: 0, borderLeft: '12px solid transparent', borderRight: '12px solid transparent', borderTop: '20px solid #111' }} />
+          <canvas ref={canvasRef} width={420} height={420} className="w-full rounded-full border-2 border-border" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Button onClick={spin} disabled={spinning || entries.length < 2}>{spinning ? t.spinning : t.spin}</Button>
+          {entries.length < 2 && <p className="text-xs text-muted-foreground">{t.needTwo}</p>}
+          {winner && !spinning && (
+            <div className="border-2 border-border bg-fuchsia-200 px-4 py-2 text-center text-black shadow-brutal dark:bg-fuchsia-900/50 dark:text-white">
+              <div className="text-xs font-bold uppercase tracking-wide">{t.winner}</div>
+              <div className="text-2xl font-black">{winner}</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <label className="space-y-1 text-sm">
+        <span className="block font-semibold">{t.entries}</span>
+        <textarea value={text} onChange={e => setText(e.target.value)} rows={12}
+          className="w-full resize-y border-2 border-border bg-muted p-3 text-sm" />
+      </label>
+    </div>
+  );
+}

--- a/src/registry/categories.ts
+++ b/src/registry/categories.ts
@@ -12,6 +12,7 @@ export const categories: Category[] = [
   'Network',
   'Maps',
   'Calculators',
+  'Games',
   'Legacy',
   'Playground'
 ];
@@ -27,6 +28,7 @@ export const categoryColors: Record<Category, string> = {
   Network: 'bg-cyan-500',
   Maps: 'bg-emerald-500',
   Calculators: 'bg-lime-500',
+  Games: 'bg-fuchsia-500',
   Legacy: 'bg-indigo-500',
   Playground: 'bg-orange-500'
 };
@@ -64,6 +66,7 @@ export const categoryDescriptionsId: Record<Category, string> = {
   Network: 'Tool peer-to-peer yang menghubungkan dua perangkat secara langsung untuk mentransfer berkas atau berkomunikasi — data Anda mengalir antar perangkat, bukan melalui server.',
   Maps: 'Tool pemetaan sumber terbuka — konversi koordinat, jelajahi dan ekspor peta, serta lihat berkas GeoJSON, GPX, dan KML. Dibangun di atas data peta terbuka, berjalan di browser Anda.',
   Calculators: 'Tool kalkulator sehari-hari yang berjalan di browser Anda — hitung usia dan weton, konversi satuan, serta hitung KPR, zakat, dan THR. Semua perhitungan terjadi di perangkat Anda.',
+  Games: 'Tool seru dan pengambil keputusan acak yang berjalan di browser Anda — putar roda, pilih nama, dan undi secara acak. Tanpa unggahan, langsung main.',
   Legacy: 'Titipkan pesan dan kata sandi penting untuk keluarga — dienkripsi di perangkat Anda dan hanya bisa dibuka saat waktunya tiba. Tidak ada yang diunggah ke server.',
   Playground: 'Playground interaktif dan eksperimen untuk menjelajah dan belajar — semuanya berjalan di sisi klien di browser Anda.',
 };
@@ -80,6 +83,7 @@ const categoryFacts: Record<Category, { en: { noun: string; actions: string }; i
   Network: { en: { noun: 'files', actions: 'transferring files and communicating device to device' }, id: { noun: 'berkas', actions: 'mentransfer berkas dan berkomunikasi antar perangkat' } },
   Maps: { en: { noun: 'map data', actions: 'converting coordinates and viewing GeoJSON, GPX and KML' }, id: { noun: 'data peta', actions: 'mengonversi koordinat dan melihat GeoJSON, GPX, dan KML' } },
   Calculators: { en: { noun: 'numbers', actions: 'calculating age and weton, converting units and working out finances' }, id: { noun: 'angka', actions: 'menghitung usia dan weton, mengonversi satuan, dan menghitung keuangan' } },
+  Games: { en: { noun: 'entries', actions: 'spinning a wheel and picking names at random' }, id: { noun: 'entri', actions: 'memutar roda dan memilih nama secara acak' } },
   Legacy: { en: { noun: 'messages', actions: 'encrypting messages and passwords for your family' }, id: { noun: 'pesan', actions: 'mengenkripsi pesan dan kata sandi untuk keluarga' } },
   Playground: { en: { noun: 'inputs', actions: 'experimenting and learning interactively' }, id: { noun: 'input', actions: 'bereksperimen dan belajar secara interaktif' } },
 };
@@ -115,6 +119,7 @@ export const categoryDescriptions: Record<Category, string> = {
   Network: 'Peer-to-peer tools that connect two devices directly to transfer files or communicate — your data flows device to device, not through a server.',
   Maps: 'Open-source mapping tools — convert coordinates, explore and export maps, and view GeoJSON, GPX and KML files. Built on open map data, running in your browser.',
   Calculators: 'Everyday calculators that run in your browser — work out age and Javanese weton, convert units, and calculate mortgage, zakat and THR. Every calculation happens on your device.',
+  Games: 'Fun tools and random decision-makers that run in your browser — spin a wheel, pick a name, and draw at random. No uploads, just play.',
   Legacy: 'Entrust messages and important passwords to your family — encrypted on your device and openable only when the time comes. Nothing is uploaded to any server.',
   Playground: 'Interactive playgrounds and experiments to explore and learn — all running client-side in your browser.',
 };

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -367,6 +367,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the calculator works with no internet connection.' },
     ],
   },
+  'wheel-spinner': {
+    title: 'Wheel Spinner — Random Name Picker & Decision Wheel',
+    description: 'Spin a wheel of names to pick a winner at random — for giveaways, classrooms, or deciding who goes first. Add your entries and spin. Free, in your browser.',
+    intro: 'This free wheel spinner picks a name or option at random. Type your entries (one per line), hit Spin, and watch the wheel land on a winner — perfect for giveaways, choosing who goes first, team assignments or settling a decision. Everything runs in your browser, so it works offline and nothing is uploaded.',
+    howTo: [
+      'Type your entries in the box, one per line.',
+      'Click Spin and let the wheel slow to a stop.',
+      'Read the highlighted winner under the pointer.',
+      'Spin again as many times as you like.',
+    ],
+    faqs: [
+      { q: 'Is the result really random?', a: 'Yes. Each spin uses your browser’s random generator to choose where the wheel stops, so every entry has an equal chance.' },
+      { q: 'How many entries can I add?', a: 'As many as you like — labels are trimmed to fit each slice on the wheel.' },
+      { q: 'Is anything uploaded?', a: 'No. The wheel runs entirely in your browser; your entries never leave your device.' },
+      { q: 'Can I use it for giveaways?', a: 'Yes. Add each participant on its own line and spin to draw a winner fairly in front of your audience.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the wheel works with no internet connection.' },
+    ],
+  },
   'kpr-calculator': {
     title: 'KPR & Mortgage Calculator — Monthly Installment & Amortisation',
     description: 'Calculate your monthly home-loan (KPR) installment from the property price, down payment, interest rate and tenor. See total interest and a full amortisation table. Free, in your browser.',
@@ -2483,6 +2501,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apa itu weton dan neptu?', a: 'Weton adalah perpaduan Jawa antara siklus 7 hari dengan siklus pasaran 5 hari (Legi, Pahing, Pon, Wage, Kliwon) — misalnya “Jumat Legi”. Neptu adalah nilai angka tiap bagian; jumlahnya dipakai dalam tradisi Jawa.' },
       { q: 'Bisakah menghitung usia pada tanggal lampau atau mendatang?', a: 'Bisa. Ubah kolom “Usia pada tanggal” ke tanggal mana pun untuk melihat usia, total, dan weton relatif terhadap hari itu.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat kalkulator bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'wheel-spinner': {
+    title: 'Roda Putar — Pemilih Nama Acak & Roda Keputusan',
+    description: 'Putar roda berisi nama untuk memilih pemenang secara acak — untuk giveaway, kelas, atau menentukan giliran. Tambahkan entri lalu putar. Gratis, di browser Anda.',
+    intro: 'Roda putar gratis ini memilih nama atau opsi secara acak. Ketik entri Anda (satu per baris), tekan Putar, dan lihat roda berhenti di pemenang — cocok untuk giveaway, menentukan giliran, pembagian tim, atau mengambil keputusan. Semuanya berjalan di browser Anda, jadi bekerja offline dan tidak ada yang diunggah.',
+    howTo: [
+      'Ketik entri Anda di kotak, satu per baris.',
+      'Klik Putar dan biarkan roda melambat hingga berhenti.',
+      'Baca pemenang yang tersorot di bawah penunjuk.',
+      'Putar lagi sebanyak yang Anda mau.',
+    ],
+    faqs: [
+      { q: 'Apakah hasilnya benar-benar acak?', a: 'Ya. Setiap putaran memakai generator acak browser Anda untuk menentukan berhentinya roda, jadi setiap entri berpeluang sama.' },
+      { q: 'Berapa banyak entri yang bisa ditambahkan?', a: 'Sebanyak yang Anda mau — label dipangkas agar pas di tiap irisan roda.' },
+      { q: 'Apakah ada yang diunggah?', a: 'Tidak. Roda berjalan sepenuhnya di browser Anda; entri Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Bisakah dipakai untuk giveaway?', a: 'Bisa. Tambahkan tiap peserta di barisnya sendiri dan putar untuk mengundi pemenang secara adil di depan audiens.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat roda bekerja tanpa koneksi internet.' },
     ],
   },
   'kpr-calculator': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3 } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -452,6 +452,17 @@ export const tools: ToolDef[] = [
     icon: Gift,
     summary: 'Calculate THR (holiday allowance), full or prorated',
     load: () => import('@/islands/calculators/ThrCalculator'),
+    status: 'beta'
+  },
+  {
+    id: 'wheel-spinner',
+    name: 'Wheel Spinner / Random Picker',
+    category: 'Games',
+    route: '/tools/wheel-spinner',
+    keywords: ['wheel', 'spinner', 'random picker', 'wheel of names', 'random name', 'giveaway', 'decision', 'roda putar', 'undian', 'pemilih acak'],
+    icon: Disc3,
+    summary: 'Spin a wheel to pick a name or option at random',
+    load: () => import('@/islands/games/WheelSpinner'),
     status: 'beta'
   },
   {

--- a/src/tools/games/wheel.lib.test.ts
+++ b/src/tools/games/wheel.lib.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseEntries, chooseIndex, sliceForAngle } from './wheel.lib';
+
+describe('parseEntries', () => {
+  it('splits non-empty trimmed lines', () => {
+    expect(parseEntries('Alice\n Bob \n\n  \nCarol')).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+  it('returns [] for empty input', () => {
+    expect(parseEntries('   \n  ')).toEqual([]);
+  });
+});
+
+describe('chooseIndex', () => {
+  it('maps a [0,1) value to an index', () => {
+    expect(chooseIndex(4, 0)).toBe(0);
+    expect(chooseIndex(4, 0.5)).toBe(2);
+    expect(chooseIndex(4, 0.999)).toBe(3);
+  });
+  it('is safe at the upper bound and for empty', () => {
+    expect(chooseIndex(4, 1)).toBe(3);
+    expect(chooseIndex(0, 0.5)).toBe(-1);
+  });
+});
+
+describe('sliceForAngle', () => {
+  it('maps the pointer angle (at top) to the slice under it', () => {
+    // 4 slices of 90°. Pointer at top; angle 0 → first slice.
+    expect(sliceForAngle(0, 4)).toBe(0);
+    expect(sliceForAngle(95, 4)).toBe(1);
+    expect(sliceForAngle(360, 4)).toBe(0); // wraps
+  });
+});

--- a/src/tools/games/wheel.lib.ts
+++ b/src/tools/games/wheel.lib.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for the wheel / random picker: parse entries, pick an index from
+ * a random value, and map a rotation angle to the slice under the pointer. The
+ * canvas drawing and spin animation live in the island.
+ */
+
+export function parseEntries(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/** Map a random value in [0,1] to an index in [0, count). Returns -1 if empty. */
+export function chooseIndex(count: number, r: number): number {
+  if (count <= 0) return -1;
+  const clamped = Math.min(Math.max(r, 0), 0.9999999);
+  return Math.floor(clamped * count);
+}
+
+/**
+ * Given the wheel's rotation angle (degrees) and the slice count, return the
+ * index of the slice currently under the top pointer. Slice 0 starts at the top.
+ */
+export function sliceForAngle(angleDeg: number, count: number): number {
+  if (count <= 0) return -1;
+  const per = 360 / count;
+  // The wheel rotates by angleDeg; the slice under the fixed top pointer is the
+  // one whose original position rotated to the top.
+  const normalized = ((angleDeg % 360) + 360) % 360;
+  return Math.floor(normalized / per) % count;
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 
-export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Documents' | 'Draw' | 'Media' | 'Network' | 'Maps' | 'Calculators' | 'Legacy' | 'Playground';
+export type Category = 'Dev' | 'PDF' | 'Image' | 'Files' | 'Documents' | 'Draw' | 'Media' | 'Network' | 'Maps' | 'Calculators' | 'Games' | 'Legacy' | 'Playground';
 
 export interface AssetRef {
   url: string;


### PR DESCRIPTION
Adds a new **Games** category (fuchsia) and its first tool.

**Wheel Spinner / Random Picker** (`/tools/wheel-spinner`)
- Type entries (one per line); spin a colourful canvas wheel with an ease-out animation that lands on a random winner — for giveaways, picking who goes first, decisions.
- Pure `wheel.lib.ts` (parse entries, random index, angle→slice mapping) unit-tested (5 tests). Fully client-side.
- New category wired through the type + all category maps; `/category/games` hub auto-generates. EN + ID SEO.

Verify: 1249 tests green, lint 0 errors, build OK; `/tools/wheel-spinner/`, `/id/tools/wheel-spinner/`, `/category/games/` all built.