### PR TITLE
feat(image): Meme Generator

### DIFF
--- a/src/islands/image/MemeGenerator.tsx
+++ b/src/islands/image/MemeGenerator.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { wrapText } from '@/tools/image/meme.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Make a classic meme: drop an image, add top and bottom text, and download it. The bold outlined caption style is applied automatically. Everything runs in your browser — nothing is uploaded.',
+    drop: 'Drop an image or click to browse', dropSub: 'JPG, PNG, WebP · or paste an image (⌘V)',
+    top: 'Top text', bottom: 'Bottom text', size: 'Text size', download: 'Download meme', change: 'Change image',
+  },
+  id: {
+    intro: 'Buat meme klasik: letakkan gambar, tambahkan teks atas dan bawah, lalu unduh. Gaya teks tebal bergaris otomatis diterapkan. Semuanya berjalan di browser Anda — tidak ada yang diunggah.',
+    drop: 'Letakkan gambar atau klik untuk memilih', dropSub: 'JPG, PNG, WebP · atau tempel gambar (⌘V)',
+    top: 'Teks atas', bottom: 'Teks bawah', size: 'Ukuran teks', download: 'Unduh meme', change: 'Ganti gambar',
+  },
+};
+
+const MAX_W = 1000;
+
+export default function MemeGenerator({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [img, setImg] = useState<HTMLImageElement | null>(null);
+  const [top, setTop] = useState('');
+  const [bottom, setBottom] = useState('');
+  const [scale, setScale] = useState(1);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const loadImage = (file: File) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => { setImg(image); URL.revokeObjectURL(url); };
+    image.src = url;
+  };
+
+  const onDrop = (files: File[]) => {
+    const f = files.find(x => x.type.startsWith('image/'));
+    if (f) loadImage(f);
+  };
+  usePasteImage(f => loadImage(f));
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !img) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const w = Math.min(img.naturalWidth, MAX_W);
+    const h = (img.naturalHeight / img.naturalWidth) * w;
+    canvas.width = w;
+    canvas.height = h;
+    ctx.drawImage(img, 0, 0, w, h);
+
+    const fontSize = (w / 10) * scale;
+    ctx.font = `bold ${fontSize}px Impact, "Arial Black", sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.fillStyle = '#ffffff';
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = Math.max(2, fontSize / 12);
+    ctx.lineJoin = 'round';
+    const measure = (s: string) => ctx.measureText(s).width;
+    const maxW = w * 0.92;
+    const lineH = fontSize * 1.05;
+
+    const drawBlock = (text: string, position: 'top' | 'bottom') => {
+      const lines = wrapText(text.toUpperCase(), maxW, measure);
+      lines.forEach((line, i) => {
+        const y = position === 'top'
+          ? fontSize + i * lineH
+          : h - 12 - (lines.length - 1 - i) * lineH;
+        ctx.strokeText(line, w / 2, y);
+        ctx.fillText(line, w / 2, y);
+      });
+    };
+    ctx.textBaseline = 'alphabetic';
+    if (top.trim()) drawBlock(top, 'top');
+    if (bottom.trim()) drawBlock(bottom, 'bottom');
+  }, [img, top, bottom, scale]);
+
+  const download = () => {
+    canvasRef.current?.toBlob(blob => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'meme.png';
+      a.click();
+      URL.revokeObjectURL(url);
+    }, 'image/png');
+  };
+
+  const input = 'w-full border-2 border-border bg-muted p-2 text-sm';
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!img ? (
+        <Dropzone onDrop={onDrop} accept="image/*" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+          <div className="flex justify-center border-2 border-border bg-muted p-2">
+            <canvas ref={canvasRef} className="max-h-[70vh] w-auto max-w-full" />
+          </div>
+          <div className="space-y-3">
+            <label className="space-y-1 text-sm"><span className="block font-semibold">{t.top}</span>
+              <input value={top} onChange={e => setTop(e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-sm"><span className="block font-semibold">{t.bottom}</span>
+              <input value={bottom} onChange={e => setBottom(e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-sm"><span className="block font-semibold">{t.size}: {scale.toFixed(1)}×</span>
+              <input type="range" min={0.5} max={1.8} step={0.1} value={scale} onChange={e => setScale(Number(e.target.value))} className="w-full accent-accent" /></label>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={download}>{t.download}</Button>
+              <Button variant="secondary" onClick={() => { setImg(null); setTop(''); setBottom(''); }}>{t.change}</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1454,6 +1454,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Can I use this to watermark a KTP or ID card photo?', a: 'Yes. Drop in a scan or photo of your KTP, SIM, passport or any identity document, type your watermark text (e.g. "COPY" or your name), pick Diagonal or Tiled layout, set the opacity, and download. Everything stays on your device — nothing is uploaded.' },
     ],
   },
+  'meme-generator': {
+    title: 'Free Meme Generator — Add Top & Bottom Text to Images',
+    description: 'Make a meme in seconds: drop an image, add top and bottom captions in the classic bold outlined style, and download the PNG. Free and private — nothing is uploaded.',
+    intro: 'This free meme generator turns any picture into a classic meme. Drop or paste an image, type your top and bottom captions, and the bold white-with-black-outline caption style is applied automatically, wrapping to fit. Adjust the text size and download the finished PNG. Everything runs in your browser, so your images never leave your device.',
+    howTo: [
+      'Drop or paste an image, or click to browse.',
+      'Type the top and bottom captions.',
+      'Adjust the text size if needed.',
+      'Click Download meme to save the PNG.',
+    ],
+    faqs: [
+      { q: 'Is my image uploaded?', a: 'No. The meme is drawn on a canvas in your browser, so your image never leaves your device.' },
+      { q: 'What caption style is used?', a: 'The classic meme look — bold uppercase text in white with a black outline, wrapped to fit the image width.' },
+      { q: 'Can I use my own photo?', a: 'Yes. Any JPG, PNG or WebP works — drop it in or paste from the clipboard.' },
+      { q: 'What format is the meme saved in?', a: 'It downloads as a PNG, which keeps the text crisp.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the meme generator works with no internet connection.' },
+    ],
+  },
   'image-stamp': {
     title: 'Free Image Stamp Tool — Mark CONFIDENTIAL & PAID',
     description: 'A free online image stamp tool to add CONFIDENTIAL, PAID and other marks to a photo — 100% private. The image is stamped in your browser and never uploaded.',
@@ -3588,6 +3606,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah saya mengontrol tampilan watermark?', a: 'Ya. Anda dapat mengatur teks, memilih warna apa pun, dan menggunakan penggeser untuk menyesuaikan skala dan opasitasnya agar sesamar atau setebal yang Anda inginkan.' },
       { q: 'Dalam format apa gambar berwatermark disimpan?', a: 'Unduhan mempertahankan format asli gambar Anda jika memungkinkan, jadi JPEG tetap JPEG dan PNG tetap PNG.' },
       { q: 'Bisakah tool ini digunakan untuk watermark KTP?', a: 'Ya. Unggah scan atau foto KTP, SIM, paspor, atau dokumen identitas lainnya, ketik teks watermark (misalnya "COPY" atau nama Anda), pilih tata letak Diagonal atau Tiled, atur opasitasnya, lalu unduh hasilnya. Semua diproses di perangkat Anda — tidak ada yang diunggah.' },
+    ],
+  },
+  'meme-generator': {
+    title: 'Pembuat Meme Gratis — Tambah Teks Atas & Bawah pada Gambar',
+    description: 'Buat meme dalam hitungan detik: letakkan gambar, tambahkan teks atas dan bawah dengan gaya tebal bergaris klasik, lalu unduh PNG. Gratis dan privat — tidak ada yang diunggah.',
+    intro: 'Pembuat meme gratis ini mengubah gambar apa pun menjadi meme klasik. Letakkan atau tempel gambar, ketik teks atas dan bawah, dan gaya teks putih-bergaris-hitam yang tebal diterapkan otomatis, membungkus agar pas. Sesuaikan ukuran teks dan unduh PNG hasilnya. Semuanya berjalan di browser Anda, jadi gambar Anda tidak pernah meninggalkan perangkat.',
+    howTo: [
+      'Letakkan atau tempel gambar, atau klik untuk memilih.',
+      'Ketik teks atas dan bawah.',
+      'Sesuaikan ukuran teks bila perlu.',
+      'Klik Unduh meme untuk menyimpan PNG.',
+    ],
+    faqs: [
+      { q: 'Apakah gambar saya diunggah?', a: 'Tidak. Meme digambar di canvas dalam browser Anda, jadi gambar Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Gaya teks apa yang dipakai?', a: 'Tampilan meme klasik — teks kapital tebal berwarna putih dengan garis luar hitam, dibungkus agar pas dengan lebar gambar.' },
+      { q: 'Bisakah memakai foto saya sendiri?', a: 'Bisa. JPG, PNG, atau WebP apa pun bisa — letakkan atau tempel dari clipboard.' },
+      { q: 'Dalam format apa meme disimpan?', a: 'Diunduh sebagai PNG, agar teksnya tetap tajam.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pembuat meme bekerja tanpa koneksi internet.' },
     ],
   },
   'image-stamp': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3 } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -948,6 +948,17 @@ export const tools: ToolDef[] = [
     summary: 'Add a text watermark to an image',
     load: () => import('@/islands/image/ImageWatermark'),
     status: 'stable'
+  },
+  {
+    id: 'meme-generator',
+    name: 'Meme Generator',
+    category: 'Image',
+    route: '/tools/meme-generator',
+    keywords: ['meme', 'meme generator', 'caption', 'top text', 'bottom text', 'impact', 'buat meme', 'image macro'],
+    icon: Sticker,
+    summary: 'Add classic top/bottom captions to an image',
+    load: () => import('@/islands/image/MemeGenerator'),
+    status: 'beta'
   },
   {
     id: 'image-stamp',

--- a/src/tools/image/meme.lib.test.ts
+++ b/src/tools/image/meme.lib.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { wrapText } from './meme.lib';
+
+// Fake text measurer: one unit per character.
+const measure = (s: string) => s.length;
+
+describe('wrapText', () => {
+  it('keeps short text on one line', () => {
+    expect(wrapText('HELLO', 10, measure)).toEqual(['HELLO']);
+  });
+
+  it('wraps on word boundaries to fit the width', () => {
+    expect(wrapText('ONE TWO THREE', 7, measure)).toEqual(['ONE TWO', 'THREE']);
+  });
+
+  it('hard-breaks a single word longer than the width', () => {
+    expect(wrapText('SUPERCALI', 4, measure)).toEqual(['SUPE', 'RCAL', 'I']);
+  });
+
+  it('returns [] for empty text', () => {
+    expect(wrapText('', 10, measure)).toEqual([]);
+    expect(wrapText('   ', 10, measure)).toEqual([]);
+  });
+});

--- a/src/tools/image/meme.lib.ts
+++ b/src/tools/image/meme.lib.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure text wrapping for the meme generator. Wraps on word boundaries to fit a
+ * pixel width, hard-breaking any single word that is still too wide. The width
+ * measurement is injected so this stays framework/canvas-free and testable.
+ */
+
+export function wrapText(text: string, maxWidth: number, measure: (s: string) => number): string[] {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let current = '';
+
+  const pushHardBroken = (word: string) => {
+    let chunk = '';
+    for (const ch of word) {
+      if (chunk && measure(chunk + ch) > maxWidth) {
+        lines.push(chunk);
+        chunk = ch;
+      } else {
+        chunk += ch;
+      }
+    }
+    current = chunk;
+  };
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (measure(candidate) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+    if (current) {
+      lines.push(current);
+      current = '';
+    }
+    if (measure(word) > maxWidth) {
+      pushHardBroken(word);
+    } else {
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}


### PR DESCRIPTION
Adds a **Meme Generator** to the Image category (`/tools/meme-generator`).

- Drop/paste an image, add **top and bottom captions** in the classic bold uppercase white-with-black-outline style, auto-wrapped to the image width; adjustable text size; **download PNG**.
- Pure `meme.lib.ts` text wrapper (word-wrap + hard-break, injected width measurer) unit-tested (4 tests). Fully client-side.

Verify: 1254 tests green, lint 0 errors, build OK; both `/tools/meme-generator/` locales built and listed on the Image hub.