### PR TITLE
feat(image): Color Blindness Simulator

### DIFF
--- a/src/islands/image/ColorBlindSim.tsx
+++ b/src/islands/image/ColorBlindSim.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { CVD_TYPES, simulateImageData } from '@/tools/image/colorblind.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'See how your design looks to someone with colour blindness. Drop an image and switch between types of colour-vision deficiency, side by side with the original. Everything runs in your browser.',
+    drop: 'Drop an image or click to browse', dropSub: 'JPG, PNG, WebP · or paste an image (⌘V)',
+    type: 'Simulation', original: 'Original', download: 'Download simulated', change: 'Change image',
+  },
+  id: {
+    intro: 'Lihat bagaimana desain Anda tampak bagi penyandang buta warna. Letakkan gambar dan beralih antar jenis defisiensi penglihatan warna, berdampingan dengan aslinya. Semuanya berjalan di browser Anda.',
+    drop: 'Letakkan gambar atau klik untuk memilih', dropSub: 'JPG, PNG, WebP · atau tempel gambar (⌘V)',
+    type: 'Simulasi', original: 'Asli', download: 'Unduh hasil simulasi', change: 'Ganti gambar',
+  },
+};
+
+const MAX_W = 900;
+
+export default function ColorBlindSim({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [img, setImg] = useState<HTMLImageElement | null>(null);
+  const [type, setType] = useState('deuteranopia');
+  const origRef = useRef<HTMLCanvasElement | null>(null);
+  const simRef = useRef<HTMLCanvasElement | null>(null);
+
+  const loadImage = (file: File) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => { setImg(image); URL.revokeObjectURL(url); };
+    image.src = url;
+  };
+  const onDrop = (files: File[]) => { const f = files.find(x => x.type.startsWith('image/')); if (f) loadImage(f); };
+  usePasteImage(f => loadImage(f));
+
+  useEffect(() => {
+    if (!img) return;
+    const w = Math.min(img.naturalWidth, MAX_W);
+    const h = (img.naturalHeight / img.naturalWidth) * w;
+    const orig = origRef.current;
+    const sim = simRef.current;
+    if (!orig || !sim) return;
+    for (const c of [orig, sim]) { c.width = w; c.height = h; }
+    const octx = orig.getContext('2d');
+    const sctx = sim.getContext('2d');
+    if (!octx || !sctx) return;
+    octx.drawImage(img, 0, 0, w, h);
+    sctx.drawImage(img, 0, 0, w, h);
+    const data = sctx.getImageData(0, 0, w, h);
+    simulateImageData(data.data, type);
+    sctx.putImageData(data, 0, 0);
+  }, [img, type]);
+
+  const download = () => {
+    simRef.current?.toBlob(blob => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `colorblind-${type}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+    }, 'image/png');
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!img ? (
+        <Dropzone onDrop={onDrop} accept="image/*" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      ) : (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <span className="block text-sm font-semibold">{t.type}</span>
+            <div className="flex flex-wrap gap-2">
+              {CVD_TYPES.map(c => (
+                <button key={c.id} onClick={() => setType(c.id)} aria-pressed={type === c.id}
+                  className={`border-2 px-2.5 py-1 text-xs font-medium transition-all ${type === c.id ? 'border-border bg-accent text-accent-foreground shadow-brutal' : 'border-border hover:shadow-brutal'}`}>
+                  {c.name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <span className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.original}</span>
+              <canvas ref={origRef} className="w-full border-2 border-border" />
+            </div>
+            <div className="space-y-1">
+              <span className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{CVD_TYPES.find(c => c.id === type)?.name}</span>
+              <canvas ref={simRef} className="w-full border-2 border-border" />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={download}>{t.download}</Button>
+            <Button variant="secondary" onClick={() => setImg(null)}>{t.change}</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1454,6 +1454,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Can I use this to watermark a KTP or ID card photo?', a: 'Yes. Drop in a scan or photo of your KTP, SIM, passport or any identity document, type your watermark text (e.g. "COPY" or your name), pick Diagonal or Tiled layout, set the opacity, and download. Everything stays on your device — nothing is uploaded.' },
     ],
   },
+  'color-blindness-sim': {
+    title: 'Color Blindness Simulator — Preview Protanopia, Deuteranopia, Tritanopia',
+    description: 'See how an image or design looks with colour-vision deficiencies — protanopia, deuteranopia, tritanopia and more — side by side with the original. Free, in your browser.',
+    intro: 'This free colour blindness simulator shows how your image or design appears to people with colour-vision deficiencies. Drop an image and compare the original with protanopia, deuteranopia, tritanopia (and their milder anomalous forms) plus full achromatopsia, side by side. Use it to check that charts, maps and UI stay readable for everyone. Everything runs in your browser.',
+    howTo: [
+      'Drop or paste an image (a chart, design or screenshot).',
+      'Pick a colour-vision deficiency to simulate.',
+      'Compare the original and simulated views side by side.',
+      'Download the simulated image if you need it.',
+    ],
+    faqs: [
+      { q: 'Which types can I simulate?', a: 'Protanopia, deuteranopia and tritanopia (the three dichromacies), their milder anomalous versions, and achromatopsia (no colour at all).' },
+      { q: 'Is my image uploaded?', a: 'No. The simulation runs on a canvas in your browser, so your image never leaves your device.' },
+      { q: 'How accurate is it?', a: 'It uses the widely used dichromacy approximation matrices. They are a strong guide for design review, not a medical diagnostic.' },
+      { q: 'Why does this matter for accessibility?', a: 'About 1 in 12 men has some colour-vision deficiency. Simulating it helps ensure charts, maps and status colours are distinguishable without relying on colour alone.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the simulator works with no internet connection.' },
+    ],
+  },
   'meme-generator': {
     title: 'Free Meme Generator — Add Top & Bottom Text to Images',
     description: 'Make a meme in seconds: drop an image, add top and bottom captions in the classic bold outlined style, and download the PNG. Free and private — nothing is uploaded.',
@@ -3606,6 +3624,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah saya mengontrol tampilan watermark?', a: 'Ya. Anda dapat mengatur teks, memilih warna apa pun, dan menggunakan penggeser untuk menyesuaikan skala dan opasitasnya agar sesamar atau setebal yang Anda inginkan.' },
       { q: 'Dalam format apa gambar berwatermark disimpan?', a: 'Unduhan mempertahankan format asli gambar Anda jika memungkinkan, jadi JPEG tetap JPEG dan PNG tetap PNG.' },
       { q: 'Bisakah tool ini digunakan untuk watermark KTP?', a: 'Ya. Unggah scan atau foto KTP, SIM, paspor, atau dokumen identitas lainnya, ketik teks watermark (misalnya "COPY" atau nama Anda), pilih tata letak Diagonal atau Tiled, atur opasitasnya, lalu unduh hasilnya. Semua diproses di perangkat Anda — tidak ada yang diunggah.' },
+    ],
+  },
+  'color-blindness-sim': {
+    title: 'Simulator Buta Warna — Pratinjau Protanopia, Deuteranopia, Tritanopia',
+    description: 'Lihat bagaimana gambar atau desain tampak dengan defisiensi penglihatan warna — protanopia, deuteranopia, tritanopia, dan lainnya — berdampingan dengan aslinya. Gratis, di browser.',
+    intro: 'Simulator buta warna gratis ini menunjukkan bagaimana gambar atau desain Anda tampak bagi penyandang defisiensi penglihatan warna. Letakkan gambar dan bandingkan aslinya dengan protanopia, deuteranopia, tritanopia (serta versi ringannya) plus achromatopsia penuh, berdampingan. Gunakan untuk memastikan grafik, peta, dan UI tetap terbaca oleh semua orang. Semuanya berjalan di browser Anda.',
+    howTo: [
+      'Letakkan atau tempel gambar (grafik, desain, atau tangkapan layar).',
+      'Pilih jenis defisiensi penglihatan warna untuk disimulasikan.',
+      'Bandingkan tampilan asli dan simulasi berdampingan.',
+      'Unduh gambar hasil simulasi bila diperlukan.',
+    ],
+    faqs: [
+      { q: 'Jenis apa saja yang bisa disimulasikan?', a: 'Protanopia, deuteranopia, dan tritanopia (tiga dikromasi), versi anomali yang lebih ringan, serta achromatopsia (tanpa warna sama sekali).' },
+      { q: 'Apakah gambar saya diunggah?', a: 'Tidak. Simulasi berjalan di canvas dalam browser Anda, jadi gambar tidak pernah meninggalkan perangkat.' },
+      { q: 'Seberapa akurat?', a: 'Menggunakan matriks aproksimasi dikromasi yang umum dipakai. Ini panduan kuat untuk tinjauan desain, bukan diagnosis medis.' },
+      { q: 'Mengapa ini penting untuk aksesibilitas?', a: 'Sekitar 1 dari 12 pria memiliki defisiensi penglihatan warna. Simulasi membantu memastikan grafik, peta, dan warna status dapat dibedakan tanpa hanya mengandalkan warna.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat simulator bekerja tanpa koneksi internet.' },
     ],
   },
   'meme-generator': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -958,6 +958,17 @@ export const tools: ToolDef[] = [
     icon: Sticker,
     summary: 'Add classic top/bottom captions to an image',
     load: () => import('@/islands/image/MemeGenerator'),
+    status: 'beta'
+  },
+  {
+    id: 'color-blindness-sim',
+    name: 'Color Blindness Simulator',
+    category: 'Image',
+    route: '/tools/color-blindness-sim',
+    keywords: ['color blindness', 'colour blind', 'protanopia', 'deuteranopia', 'tritanopia', 'accessibility', 'a11y', 'cvd', 'simulator', 'buta warna'],
+    icon: Glasses,
+    summary: 'Preview an image as seen with colour-vision deficiencies',
+    load: () => import('@/islands/image/ColorBlindSim'),
     status: 'beta'
   },
   {

--- a/src/tools/image/colorblind.lib.test.ts
+++ b/src/tools/image/colorblind.lib.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { CVD_TYPES, simulateRGB } from './colorblind.lib';
+
+describe('CVD_TYPES', () => {
+  it('covers the three dichromacies plus achromatopsia', () => {
+    const ids = CVD_TYPES.map(t => t.id);
+    expect(ids).toEqual(expect.arrayContaining(['protanopia', 'deuteranopia', 'tritanopia', 'achromatopsia']));
+  });
+});
+
+describe('simulateRGB', () => {
+  it('leaves white and black unchanged (matrix rows sum to 1)', () => {
+    for (const type of CVD_TYPES) {
+      expect(simulateRGB([255, 255, 255], type.id)).toEqual([255, 255, 255]);
+      expect(simulateRGB([0, 0, 0], type.id)).toEqual([0, 0, 0]);
+    }
+  });
+
+  it('turns colour into grey for achromatopsia', () => {
+    const [r, g, b] = simulateRGB([255, 0, 0], 'achromatopsia');
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+  });
+
+  it('clamps to the 0–255 range and returns integers', () => {
+    const out = simulateRGB([255, 128, 0], 'protanopia');
+    for (const c of out) {
+      expect(Number.isInteger(c)).toBe(true);
+      expect(c).toBeGreaterThanOrEqual(0);
+      expect(c).toBeLessThanOrEqual(255);
+    }
+  });
+});

--- a/src/tools/image/colorblind.lib.ts
+++ b/src/tools/image/colorblind.lib.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure colour-vision-deficiency simulation via 3×3 RGB matrices. Each matrix row
+ * sums to 1 so greys/white/black are preserved. Matrices are the widely used
+ * dichromacy approximations (as in Coblis / GIMP). No I/O.
+ */
+
+export interface CvdType {
+  id: string;
+  name: string;
+  matrix: number[]; // row-major 3×3
+}
+
+export const CVD_TYPES: CvdType[] = [
+  { id: 'protanopia', name: 'Protanopia (no red)', matrix: [0.567, 0.433, 0, 0.558, 0.442, 0, 0, 0.242, 0.758] },
+  { id: 'protanomaly', name: 'Protanomaly (weak red)', matrix: [0.817, 0.183, 0, 0.333, 0.667, 0, 0, 0.125, 0.875] },
+  { id: 'deuteranopia', name: 'Deuteranopia (no green)', matrix: [0.625, 0.375, 0, 0.7, 0.3, 0, 0, 0.3, 0.7] },
+  { id: 'deuteranomaly', name: 'Deuteranomaly (weak green)', matrix: [0.8, 0.2, 0, 0.258, 0.742, 0, 0, 0.142, 0.858] },
+  { id: 'tritanopia', name: 'Tritanopia (no blue)', matrix: [0.95, 0.05, 0, 0, 0.433, 0.567, 0, 0.475, 0.525] },
+  { id: 'tritanomaly', name: 'Tritanomaly (weak blue)', matrix: [0.967, 0.033, 0, 0, 0.733, 0.267, 0, 0.183, 0.817] },
+  { id: 'achromatopsia', name: 'Achromatopsia (no colour)', matrix: [0.299, 0.587, 0.114, 0.299, 0.587, 0.114, 0.299, 0.587, 0.114] },
+];
+
+const clampByte = (v: number) => Math.max(0, Math.min(255, Math.round(v)));
+
+export function simulateRGB(rgb: [number, number, number], typeId: string): [number, number, number] {
+  const type = CVD_TYPES.find(t => t.id === typeId);
+  if (!type) return rgb;
+  const [r, g, b] = rgb;
+  const m = type.matrix;
+  return [
+    clampByte(m[0] * r + m[1] * g + m[2] * b),
+    clampByte(m[3] * r + m[4] * g + m[5] * b),
+    clampByte(m[6] * r + m[7] * g + m[8] * b),
+  ];
+}
+
+/** Apply the simulation in place to an RGBA pixel buffer. */
+export function simulateImageData(data: Uint8ClampedArray, typeId: string): void {
+  const type = CVD_TYPES.find(t => t.id === typeId);
+  if (!type) return;
+  const m = type.matrix;
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    data[i] = clampByte(m[0] * r + m[1] * g + m[2] * b);
+    data[i + 1] = clampByte(m[3] * r + m[4] * g + m[5] * b);
+    data[i + 2] = clampByte(m[6] * r + m[7] * g + m[8] * b);
+  }
+}


### PR DESCRIPTION
Adds a **Color Blindness Simulator** to the Image category (`/tools/color-blindness-sim`).

- Drop an image and compare the **original vs simulated** view for protanopia, deuteranopia, tritanopia, their anomalous forms, and achromatopsia — side by side; download the simulated PNG.
- Pure `colorblind.lib.ts` (CVD matrices, pixel + ImageData transforms; rows sum to 1 so greys are preserved) unit-tested (4 tests). Fully client-side.

Verify: 1259 tests green, lint 0 errors, build OK; both `/tools/color-blindness-sim/` locales built and listed on the Image hub.