### PR TITLE
feat(files): Emergency Medical Card

### DIFF
--- a/src/islands/dev/EmergencyCard.tsx
+++ b/src/islands/dev/EmergencyCard.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+import { Button } from '@/components/ui/Button';
+import { buildCardText, type MedCardData, type MedContact } from '@/tools/dev/medcard.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Make an emergency medical card for your wallet or bag. Fill in your details and a QR code is generated with everything — allergies, blood type, contacts. It works with no signal and no account; nothing is uploaded.',
+    name: 'Full name', dob: 'Date of birth', blood: 'Blood type', allergies: 'Allergies',
+    conditions: 'Medical conditions', medications: 'Medications', organ: 'Organ donor',
+    notes: 'Notes', contacts: 'Emergency contacts', cname: 'Name', relation: 'Relation', phone: 'Phone',
+    addContact: 'Add contact', print: 'Print / Save as PDF', scan: 'Scan for full details', title: 'EMERGENCY MEDICAL CARD',
+  },
+  id: {
+    intro: 'Buat kartu medis darurat untuk dompet atau tas Anda. Isi detail Anda dan QR code dibuat berisi semuanya — alergi, golongan darah, kontak. Bekerja tanpa sinyal dan tanpa akun; tidak ada yang diunggah.',
+    name: 'Nama lengkap', dob: 'Tanggal lahir', blood: 'Golongan darah', allergies: 'Alergi',
+    conditions: 'Kondisi medis', medications: 'Obat-obatan', organ: 'Pendonor organ',
+    notes: 'Catatan', contacts: 'Kontak darurat', cname: 'Nama', relation: 'Hubungan', phone: 'Telepon',
+    addContact: 'Tambah kontak', print: 'Cetak / Simpan PDF', scan: 'Pindai untuk detail lengkap', title: 'KARTU MEDIS DARURAT',
+  },
+};
+
+const BLOOD = ['', 'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'];
+const esc = (s: string) => s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+
+export default function EmergencyCard({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [d, setD] = useState<MedCardData>({
+    name: '', dob: '', bloodType: '', allergies: '', conditions: '', medications: '',
+    organDonor: false, notes: '', contacts: [{ name: '', relation: '', phone: '' }],
+  });
+  const [qr, setQr] = useState('');
+
+  const set = <K extends keyof MedCardData>(key: K, value: MedCardData[K]) => setD(p => ({ ...p, [key]: value }));
+  const setContact = (i: number, key: keyof MedContact, value: string) =>
+    setD(p => ({ ...p, contacts: p.contacts.map((c, idx) => (idx === i ? { ...c, [key]: value } : c)) }));
+  const addContact = () => setD(p => ({ ...p, contacts: [...p.contacts, { name: '', relation: '', phone: '' }] }));
+
+  const text = buildCardText(d);
+
+  useEffect(() => {
+    QRCode.toDataURL(text, { margin: 1, width: 320 }).then(setQr).catch(() => setQr(''));
+  }, [text]);
+
+  const print = () => {
+    const w = window.open('', '_blank');
+    if (!w) return;
+    const rows = text.split('\n').slice(1).map(l => `<div>${esc(l)}</div>`).join('');
+    w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(t.title)}</title>
+<style>*{box-sizing:border-box}body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;margin:0;padding:24px}
+.card{border:2px solid #b91c1c;border-radius:10px;max-width:420px;padding:16px;display:flex;gap:16px}
+.info{flex:1;font-size:12px;line-height:1.5} h1{color:#b91c1c;font-size:15px;margin:0 0 8px} img{width:120px;height:120px}
+.scan{font-size:10px;color:#666;text-align:center;margin-top:4px}</style></head><body>
+<div class="card"><div class="info"><h1>🚑 ${esc(t.title)}</h1>${rows}</div>
+<div><img src="${qr}" alt="QR"/><div class="scan">${esc(t.scan)}</div></div></div>
+</body></html>`);
+    w.document.close(); w.focus();
+    setTimeout(() => w.print(), 300);
+  };
+
+  const input = 'w-full border-2 border-border bg-muted p-2 text-sm';
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <label className="col-span-2 space-y-1 text-xs"><span className="font-semibold">{t.name}</span>
+              <input value={d.name} onChange={e => set('name', e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.dob}</span>
+              <input type="date" value={d.dob} onChange={e => set('dob', e.target.value)} className={input} /></label>
+            <label className="space-y-1 text-xs"><span className="font-semibold">{t.blood}</span>
+              <select value={d.bloodType} onChange={e => set('bloodType', e.target.value)} className={input}>
+                {BLOOD.map(b => <option key={b} value={b}>{b || '—'}</option>)}
+              </select></label>
+          </div>
+          <label className="space-y-1 text-xs block"><span className="font-semibold">{t.allergies}</span>
+            <input value={d.allergies} onChange={e => set('allergies', e.target.value)} className={input} /></label>
+          <label className="space-y-1 text-xs block"><span className="font-semibold">{t.conditions}</span>
+            <input value={d.conditions} onChange={e => set('conditions', e.target.value)} className={input} /></label>
+          <label className="space-y-1 text-xs block"><span className="font-semibold">{t.medications}</span>
+            <input value={d.medications} onChange={e => set('medications', e.target.value)} className={input} /></label>
+
+          <div className="space-y-2">
+            <span className="text-xs font-semibold">{t.contacts}</span>
+            {d.contacts.map((c, i) => (
+              <div key={i} className="grid grid-cols-3 gap-1">
+                <input value={c.name} onChange={e => setContact(i, 'name', e.target.value)} placeholder={t.cname} className={input} />
+                <input value={c.relation} onChange={e => setContact(i, 'relation', e.target.value)} placeholder={t.relation} className={input} />
+                <input value={c.phone} onChange={e => setContact(i, 'phone', e.target.value)} placeholder={t.phone} inputMode="tel" className={input} />
+              </div>
+            ))}
+            <Button variant="secondary" onClick={addContact} className="text-xs">+ {t.addContact}</Button>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={d.organDonor} onChange={e => set('organDonor', e.target.checked)} />
+            <span>{t.organ}</span>
+          </label>
+          <label className="space-y-1 text-xs block"><span className="font-semibold">{t.notes}</span>
+            <textarea value={d.notes} onChange={e => set('notes', e.target.value)} rows={2} className={input} /></label>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex gap-4 rounded-lg border-2 border-red-600 p-4">
+            <div className="flex-1 text-xs leading-relaxed">
+              <div className="mb-2 font-black text-red-600">🚑 {t.title}</div>
+              {text.split('\n').slice(1).map((l, i) => <div key={i} className="break-words">{l}</div>)}
+            </div>
+            {qr && <div className="text-center"><img src={qr} alt="QR" className="h-28 w-28" /><div className="mt-1 text-[10px] text-muted-foreground">{t.scan}</div></div>}
+          </div>
+          <Button onClick={print}>{t.print}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -349,6 +349,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded it keeps compressing with no internet connection.' },
     ],
   },
+  'emergency-medical-card': {
+    title: 'Emergency Medical Card Maker — Free Printable ICE Card with QR',
+    description: 'Create a printable emergency medical (ICE) card for your wallet — allergies, blood type, conditions and contacts, encoded in a QR that works with no signal. Free, private.',
+    intro: 'This free emergency medical card maker creates a wallet-sized ICE (In Case of Emergency) card. Fill in your blood type, allergies, medical conditions, medications and emergency contacts, and a QR code is generated containing everything, so a responder can read it even with no signal. Print it for your wallet or bag. It works with no account and nothing is uploaded — your health data stays on your device.',
+    howTo: [
+      'Fill in your name, blood type, allergies, conditions and medications.',
+      'Add one or more emergency contacts.',
+      'Check the live card preview and its QR code.',
+      'Click Print / Save as PDF and keep a copy in your wallet.',
+    ],
+    faqs: [
+      { q: 'Is my health information uploaded?', a: 'No. The card and QR are generated entirely in your browser; your medical details never leave your device.' },
+      { q: 'Does the QR code need internet to read?', a: 'No. The QR contains the information itself as plain text, so any scanner shows it offline — no app or signal required.' },
+      { q: 'What should I put on it?', a: 'The essentials a first responder needs fast: blood type, serious allergies, key conditions, current medications, and who to call.' },
+      { q: 'How do I save it as a PDF?', a: 'Click Print / Save as PDF and choose “Save as PDF” in the print dialog, or print it straight to paper.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the card maker works with no internet connection.' },
+    ],
+  },
   'age-calculator': {
     title: 'Age Calculator + Javanese Weton & Neptu — Free',
     description: 'Work out your exact age in years, months and days, total months/weeks/days/hours, the weekday you were born, next birthday, plus your Javanese weton and neptu. Runs in your browser.',
@@ -2519,6 +2537,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bagaimana cara kompres PDF ke ukuran target?', a: 'Letakkan PDF dan pilih target. Tool mengompres lossless dulu (mempertahankan teks yang bisa diseleksi); bila masih terlalu besar, halaman diratakan menjadi gambar pada resolusi lebih rendah hingga pas — cara umum untuk mencapai batas ukuran PDF yang ketat.' },
       { q: 'Bagaimana jika target tidak tercapai?', a: 'Jika target lebih kecil dari yang bisa dicapai, tool mengembalikan versi terkecil yang bisa dibuat dan memberi tahu Anda — cukup pilih target sedikit lebih besar.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tetap bisa mengompres tanpa koneksi internet.' },
+    ],
+  },
+  'emergency-medical-card': {
+    title: 'Pembuat Kartu Medis Darurat — Kartu ICE dengan QR, Gratis',
+    description: 'Buat kartu medis darurat (ICE) untuk dompet — alergi, golongan darah, kondisi, dan kontak, dikodekan dalam QR yang bekerja tanpa sinyal. Gratis, privat.',
+    intro: 'Pembuat kartu medis darurat gratis ini membuat kartu ICE (In Case of Emergency) seukuran dompet. Isi golongan darah, alergi, kondisi medis, obat-obatan, dan kontak darurat Anda, dan QR code dibuat berisi semuanya, sehingga penolong bisa membacanya bahkan tanpa sinyal. Cetak untuk dompet atau tas Anda. Bekerja tanpa akun dan tidak ada yang diunggah — data kesehatan Anda tetap di perangkat.',
+    howTo: [
+      'Isi nama, golongan darah, alergi, kondisi, dan obat Anda.',
+      'Tambahkan satu atau beberapa kontak darurat.',
+      'Periksa pratinjau kartu langsung beserta QR code-nya.',
+      'Klik Cetak / Simpan PDF dan simpan salinannya di dompet.',
+    ],
+    faqs: [
+      { q: 'Apakah informasi kesehatan saya diunggah?', a: 'Tidak. Kartu dan QR dibuat sepenuhnya di browser Anda; detail medis Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Apakah QR butuh internet untuk dibaca?', a: 'Tidak. QR memuat informasinya sendiri sebagai teks biasa, jadi pemindai apa pun menampilkannya offline — tanpa aplikasi atau sinyal.' },
+      { q: 'Apa yang sebaiknya dicantumkan?', a: 'Hal penting yang perlu cepat diketahui penolong: golongan darah, alergi serius, kondisi utama, obat yang dikonsumsi, dan siapa yang dihubungi.' },
+      { q: 'Bagaimana menyimpannya sebagai PDF?', a: 'Klik Cetak / Simpan PDF dan pilih “Simpan sebagai PDF” di dialog cetak, atau cetak langsung ke kertas.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat pembuat kartu bekerja tanpa koneksi internet.' },
     ],
   },
   'age-calculator': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -375,6 +375,17 @@ export const tools: ToolDef[] = [
     icon: Shrink,
     summary: 'Compress an image or PDF to a target file size (e.g. 100 KB)',
     load: () => import('@/islands/files/CompressToSize'),
+    status: 'beta'
+  },
+  {
+    id: 'emergency-medical-card',
+    name: 'Emergency Medical Card',
+    category: 'Files',
+    route: '/tools/emergency-medical-card',
+    keywords: ['emergency', 'medical card', 'ice', 'in case of emergency', 'allergies', 'blood type', 'medical id', 'kartu medis', 'darurat', 'qr'],
+    icon: HeartPulse,
+    summary: 'Make a printable emergency medical card with a QR code',
+    load: () => import('@/islands/dev/EmergencyCard'),
     status: 'beta'
   },
   {

--- a/src/tools/dev/medcard.lib.test.ts
+++ b/src/tools/dev/medcard.lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildCardText, type MedCardData } from './medcard.lib';
+
+const base: MedCardData = {
+  name: 'Aditya',
+  dob: '1990-08-17',
+  bloodType: 'O+',
+  allergies: 'Penicillin',
+  conditions: 'Asthma',
+  medications: 'Salbutamol',
+  organDonor: true,
+  notes: '',
+  contacts: [{ name: 'Sinta', relation: 'Spouse', phone: '0812' }],
+};
+
+describe('buildCardText', () => {
+  it('includes filled fields with labels', () => {
+    const text = buildCardText(base);
+    expect(text).toContain('EMERGENCY MEDICAL CARD');
+    expect(text).toContain('Name: Aditya');
+    expect(text).toContain('Blood: O+');
+    expect(text).toContain('Allergies: Penicillin');
+    expect(text).toContain('Sinta (Spouse): 0812');
+    expect(text).toContain('Organ donor: Yes');
+  });
+
+  it('omits empty fields', () => {
+    const text = buildCardText({ ...base, allergies: '', conditions: '', notes: '' });
+    expect(text).not.toContain('Allergies:');
+    expect(text).not.toContain('Conditions:');
+    expect(text).not.toContain('Notes:');
+  });
+
+  it('omits contacts without a phone', () => {
+    const text = buildCardText({ ...base, contacts: [{ name: 'X', relation: '', phone: '' }] });
+    expect(text).not.toContain('X (');
+  });
+
+  it('shows organ donor No when false', () => {
+    expect(buildCardText({ ...base, organDonor: false })).toContain('Organ donor: No');
+  });
+});

--- a/src/tools/dev/medcard.lib.ts
+++ b/src/tools/dev/medcard.lib.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure builder for the emergency medical card's text payload (used for both the
+ * printed card and the QR code). Only non-empty fields are included. No I/O.
+ */
+
+export interface MedContact {
+  name: string;
+  relation: string;
+  phone: string;
+}
+
+export interface MedCardData {
+  name: string;
+  dob: string;
+  bloodType: string;
+  allergies: string;
+  conditions: string;
+  medications: string;
+  organDonor: boolean;
+  notes: string;
+  contacts: MedContact[];
+}
+
+export function buildCardText(d: MedCardData): string {
+  const lines: string[] = ['EMERGENCY MEDICAL CARD'];
+  const add = (label: string, value: string) => {
+    if (value && value.trim()) lines.push(`${label}: ${value.trim()}`);
+  };
+  add('Name', d.name);
+  add('DOB', d.dob);
+  add('Blood', d.bloodType);
+  add('Allergies', d.allergies);
+  add('Conditions', d.conditions);
+  add('Medications', d.medications);
+
+  const contacts = d.contacts.filter(c => c.phone && c.phone.trim());
+  if (contacts.length) {
+    lines.push('Emergency contacts:');
+    for (const c of contacts) {
+      const who = c.relation && c.relation.trim() ? `${c.name} (${c.relation.trim()})` : c.name;
+      lines.push(`- ${who}: ${c.phone.trim()}`);
+    }
+  }
+
+  lines.push(`Organ donor: ${d.organDonor ? 'Yes' : 'No'}`);
+  add('Notes', d.notes);
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds an **Emergency Medical Card** maker to the Files category (`/tools/emergency-medical-card`).

- Fill in blood type, allergies, conditions, medications and emergency contacts → a wallet-sized **ICE card** with a **QR code** that holds the info as plain text (readable offline, no app needed).
- Live preview + **Print / Save as PDF**. QR via the existing `qrcode` dep.
- Pure `medcard.lib.ts` (card-text builder, omits empty fields) unit-tested (4 tests). Fully client-side — health data never leaves the device.

Verify: 1264 tests green, lint 0 errors, build OK; both `/tools/emergency-medical-card/` locales built and listed on the Files hub.