### PR TITLE
feat(pdf): PDF Booklet Imposition

### DIFF
--- a/src/islands/pdf/BookletImposition.tsx
+++ b/src/islands/pdf/BookletImposition.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ResultActions } from '@/components/ui/ResultActions';
+import { bookletOrder, paddedCount } from '@/tools/pdf/booklet.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Rearrange a PDF into a saddle-stitch booklet: print it double-sided, fold the stack in half, and the pages read in order. Two pages are placed per sheet side. Everything runs in your browser.',
+    drop: 'Drop a PDF or click to browse', dropSub: 'Imposed on your device',
+    failed: 'Something went wrong.', pages: 'pages', sheets: 'sheets', blanks: 'blank pages added',
+    make: 'Make booklet', working: 'Imposing…',
+    hint: 'Print the result double-sided (flip on the short edge), then fold in half.',
+  },
+  id: {
+    intro: 'Susun ulang PDF menjadi booklet jahit-pelana: cetak bolak-balik, lipat tumpukan jadi dua, dan halaman terbaca berurutan. Dua halaman ditempatkan per sisi lembar. Semuanya berjalan di browser Anda.',
+    drop: 'Letakkan PDF atau klik untuk memilih', dropSub: 'Disusun di perangkat Anda',
+    failed: 'Terjadi kesalahan.', pages: 'halaman', sheets: 'lembar', blanks: 'halaman kosong ditambahkan',
+    make: 'Buat booklet', working: 'Menyusun…',
+    hint: 'Cetak hasilnya bolak-balik (balik pada sisi pendek), lalu lipat jadi dua.',
+  },
+};
+
+export default function BookletImposition({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [file, setFile] = useState<File | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<Blob | null>(null);
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find(x => x.type === 'application/pdf' || x.name.toLowerCase().endsWith('.pdf'));
+    if (!f) return;
+    setFile(f); setResult(null); setError(''); setBusy(true);
+    try {
+      const { PDFDocument } = await import('pdf-lib');
+      const doc = await PDFDocument.load(await f.arrayBuffer());
+      setPageCount(doc.getPageCount());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const make = async () => {
+    if (!file) return;
+    setBusy(true); setError('');
+    try {
+      const { PDFDocument } = await import('pdf-lib');
+      const src = await PDFDocument.load(await file.arrayBuffer());
+      const out = await PDFDocument.create();
+      const order = bookletOrder(src.getPageCount());
+      const first = src.getPage(0);
+      const pw = first.getWidth();
+      const ph = first.getHeight();
+      for (let i = 0; i < order.length; i += 2) {
+        const sheet = out.addPage([pw * 2, ph]);
+        for (let side = 0; side < 2; side++) {
+          const srcNum = order[i + side];
+          if (!srcNum) continue;
+          const embedded = await out.embedPage(src.getPage(srcNum - 1));
+          sheet.drawPage(embedded, { x: side * pw, y: 0, width: pw, height: ph });
+        }
+      }
+      const bytes = await out.save();
+      setResult(new Blob([bytes], { type: 'application/pdf' }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const padded = paddedCount(pageCount);
+  const blanks = padded - pageCount;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!file && (
+        <Dropzone onDrop={onDrop} accept="application/pdf" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {file && pageCount > 0 && !result && (
+        <div className="space-y-3">
+          <p className="text-sm">
+            <span className="font-bold">{file.name}</span>{' '}
+            <span className="text-muted-foreground">· {pageCount} {t.pages} → {padded / 4} {t.sheets}{blanks > 0 ? `, ${blanks} ${t.blanks}` : ''}</span>
+          </p>
+          <p className="text-xs text-muted-foreground">{t.hint}</p>
+          <Button onClick={make} disabled={busy}>{busy ? t.working : t.make}</Button>
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">{t.hint}</p>
+          <ResultActions blob={result} filename={file ? file.name.replace(/\.pdf$/i, '') + '-booklet.pdf' : 'booklet.pdf'} disabled={busy} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -562,6 +562,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'pdf-booklet': {
+    title: 'PDF Booklet Imposition — Print & Fold a Saddle-Stitch Booklet',
+    description: 'Rearrange a PDF into booklet (saddle-stitch) order: print double-sided, fold in half, and the pages read in sequence. Two-up imposition, free and in your browser.',
+    intro: 'This free PDF booklet imposition tool reorders your pages so a home printer can produce a foldable booklet or zine. It places two pages on each side of a sheet in saddle-stitch order and pads to a multiple of four with blank pages, so when you print double-sided and fold the stack in half, everything reads in the right order. Everything runs in your browser; nothing is uploaded.',
+    howTo: [
+      'Drop your PDF to load it and see the sheet count.',
+      'Click Make booklet to impose the pages two-up.',
+      'Download the booklet PDF.',
+      'Print it double-sided (flip on the short edge) and fold in half.',
+    ],
+    faqs: [
+      { q: 'What is saddle-stitch imposition?', a: 'It reorders pages so that, printed two-up double-sided and folded down the middle, the booklet reads 1, 2, 3, … in order. Page counts are padded to a multiple of four with blanks.' },
+      { q: 'How should I print it?', a: 'Print double-sided, flipping on the short edge, at 100% scale. Each output sheet is landscape with two pages side by side; fold the whole stack in half.' },
+      { q: 'Is my PDF uploaded?', a: 'No. The imposition is done in your browser with an on-device PDF library, so your file never leaves your device.' },
+      { q: 'Does it handle any page count?', a: 'Yes. If your document is not a multiple of four, blank pages are added so the fold works out correctly.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the tool works with no internet connection.' },
+    ],
+  },
   'pdf-scrub-metadata': {
     title: 'Free PDF Metadata Scrubber — Remove Author, Dates & XMP',
     description: 'Remove hidden metadata from a PDF — author, original file name, software, timestamps and the XMP block. See what it carries, then scrub it. Private, in your browser.',
@@ -2750,6 +2768,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'pdf-booklet': {
+    title: 'Imposisi Booklet PDF — Cetak & Lipat Booklet Jahit-Pelana',
+    description: 'Susun ulang PDF menjadi urutan booklet (jahit-pelana): cetak bolak-balik, lipat jadi dua, dan halaman terbaca berurutan. Imposisi dua-up, gratis di browser Anda.',
+    intro: 'Tool imposisi booklet PDF gratis ini menyusun ulang halaman Anda agar printer rumahan bisa menghasilkan booklet atau zine yang dapat dilipat. Tool menempatkan dua halaman pada tiap sisi lembar dalam urutan jahit-pelana dan menambah halaman kosong hingga kelipatan empat, sehingga saat dicetak bolak-balik dan tumpukan dilipat jadi dua, semuanya terbaca berurutan. Semuanya berjalan di browser Anda; tidak ada yang diunggah.',
+    howTo: [
+      'Letakkan PDF Anda untuk memuatnya dan melihat jumlah lembar.',
+      'Klik Buat booklet untuk menyusun halaman dua-up.',
+      'Unduh PDF booklet.',
+      'Cetak bolak-balik (balik pada sisi pendek) dan lipat jadi dua.',
+    ],
+    faqs: [
+      { q: 'Apa itu imposisi jahit-pelana?', a: 'Ini menyusun ulang halaman agar, dicetak dua-up bolak-balik dan dilipat di tengah, booklet terbaca 1, 2, 3, … berurutan. Jumlah halaman ditambah hingga kelipatan empat dengan halaman kosong.' },
+      { q: 'Bagaimana cara mencetaknya?', a: 'Cetak bolak-balik, balik pada sisi pendek, pada skala 100%. Tiap lembar keluaran berorientasi lanskap dengan dua halaman berdampingan; lipat seluruh tumpukan jadi dua.' },
+      { q: 'Apakah PDF saya diunggah?', a: 'Tidak. Imposisi dilakukan di browser Anda dengan pustaka PDF di perangkat, jadi berkas tidak pernah meninggalkan perangkat.' },
+      { q: 'Apakah menangani jumlah halaman apa pun?', a: 'Ya. Jika dokumen bukan kelipatan empat, halaman kosong ditambahkan agar lipatan pas.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-scrub-metadata': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -518,6 +518,17 @@ export const tools: ToolDef[] = [
     icon: Tags,
     summary: 'Remove hidden author, dates and XMP metadata from a PDF',
     load: () => import('@/islands/pdf/PdfScrubMetadata'),
+    status: 'beta'
+  },
+  {
+    id: 'pdf-booklet',
+    name: 'PDF Booklet Imposition',
+    category: 'PDF',
+    route: '/tools/pdf-booklet',
+    keywords: ['booklet', 'imposition', 'saddle stitch', 'zine', 'print booklet', 'fold', '2-up', 'signature', 'buku lipat'],
+    icon: BookCopy,
+    summary: 'Rearrange PDF pages to print and fold into a booklet',
+    load: () => import('@/islands/pdf/BookletImposition'),
     status: 'beta'
   },
   {

--- a/src/tools/pdf/booklet.lib.test.ts
+++ b/src/tools/pdf/booklet.lib.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { paddedCount, bookletOrder } from './booklet.lib';
+
+describe('paddedCount', () => {
+  it('rounds up to a multiple of 4', () => {
+    expect(paddedCount(1)).toBe(4);
+    expect(paddedCount(4)).toBe(4);
+    expect(paddedCount(5)).toBe(8);
+    expect(paddedCount(6)).toBe(8);
+  });
+  it('is 0 for no pages', () => {
+    expect(paddedCount(0)).toBe(0);
+  });
+});
+
+describe('bookletOrder', () => {
+  it('orders a 4-page booklet for saddle-stitch', () => {
+    // sheet front [4,1], back [2,3] → folds to 1,2,3,4
+    expect(bookletOrder(4)).toEqual([4, 1, 2, 3]);
+  });
+
+  it('orders an 8-page booklet', () => {
+    expect(bookletOrder(8)).toEqual([8, 1, 2, 7, 6, 3, 4, 5]);
+  });
+
+  it('pads with blanks (0) when not a multiple of 4', () => {
+    // 6 pages → padded to 8; pages 7 and 8 become blanks (0)
+    expect(bookletOrder(6)).toEqual([0, 1, 2, 0, 6, 3, 4, 5]);
+  });
+
+  it('is empty for zero pages', () => {
+    expect(bookletOrder(0)).toEqual([]);
+  });
+});

--- a/src/tools/pdf/booklet.lib.ts
+++ b/src/tools/pdf/booklet.lib.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure saddle-stitch booklet imposition order. Given a page count, returns the
+ * sequence of 1-based source page numbers to place two-up on each sheet side so
+ * that, once printed double-sided and folded, the pages read in order. 0 marks a
+ * blank (padding) page. The actual PDF assembly (via pdf-lib) lives in the island.
+ */
+
+/** Round a page count up to the nearest multiple of 4 (a full saddle-stitch sheet). */
+export function paddedCount(pageCount: number): number {
+  if (pageCount <= 0) return 0;
+  return Math.ceil(pageCount / 4) * 4;
+}
+
+export function bookletOrder(pageCount: number): number[] {
+  if (pageCount <= 0) return [];
+  const total = paddedCount(pageCount);
+  const order: number[] = [];
+  let left = total;
+  let right = 1;
+  while (right < left) {
+    order.push(left, right); // front side of the sheet
+    right++; left--;
+    order.push(right, left); // back side of the sheet
+    right++; left--;
+  }
+  // Pages beyond the real count are blanks.
+  return order.map(p => (p <= pageCount ? p : 0));
+}


### PR DESCRIPTION
Adds a **PDF Booklet Imposition** tool to the PDF category (`/tools/pdf-booklet`).

- Reorders pages into **saddle-stitch booklet order** — two-up per sheet side, padded to a multiple of four with blanks — so printing double-sided and folding in half yields pages in sequence.
- Built with pdf-lib `embedPage`; shows sheet count and blanks added.
- Pure `booklet.lib.ts` (`paddedCount` + `bookletOrder`) unit-tested (6 tests, incl. 4/6/8-page cases). Fully client-side.

Verify: 1271 tests green, lint 0 errors, build OK; both `/tools/pdf-booklet/` locales built and listed on the PDF hub.