### PR TITLE
feat(documents): GEDCOM family-tree viewer

### DIFF
--- a/src/islands/documents/GedcomViewer.tsx
+++ b/src/islands/documents/GedcomViewer.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Alert } from '@/components/ui/Alert';
+import { parseGedcom, displayName, type Gedcom, type Individual } from '@/tools/documents/gedcom.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Open a GEDCOM family-tree file (.ged) and browse it privately. Search people, and click anyone to see their parents, spouse and children. Your file is read in your browser and never uploaded.',
+    drop: 'Drop a .ged file or click to browse', dropSub: 'Opened on your device',
+    failed: 'Could not read this GEDCOM file.', search: 'Search people…', people: 'people',
+    born: 'Born', died: 'Died', parents: 'Parents', spouse: 'Spouse', children: 'Children', none: 'No records found.',
+  },
+  id: {
+    intro: 'Buka berkas silsilah keluarga GEDCOM (.ged) dan telusuri secara privat. Cari orang, dan klik siapa pun untuk melihat orang tua, pasangan, dan anak. Berkas Anda dibaca di browser dan tidak pernah diunggah.',
+    drop: 'Letakkan berkas .ged atau klik untuk memilih', dropSub: 'Dibuka di perangkat Anda',
+    failed: 'Tidak dapat membaca berkas GEDCOM ini.', search: 'Cari orang…', people: 'orang',
+    born: 'Lahir', died: 'Wafat', parents: 'Orang tua', spouse: 'Pasangan', children: 'Anak', none: 'Tidak ada data.',
+  },
+};
+
+export default function GedcomViewer({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [ged, setGed] = useState<Gedcom | null>(null);
+  const [error, setError] = useState('');
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const onDrop = async (files: File[]) => {
+    const f = files[0];
+    if (!f) return;
+    setError('');
+    try {
+      const text = await f.text();
+      const g = parseGedcom(text);
+      setGed(g);
+      setSelected(g.individuals.keys().next().value ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    }
+  };
+
+  const list = useMemo(() => {
+    if (!ged) return [];
+    const q = query.trim().toLowerCase();
+    return [...ged.individuals.values()]
+      .filter(i => !q || displayName(i).toLowerCase().includes(q))
+      .sort((a, b) => displayName(a).localeCompare(displayName(b)));
+  }, [ged, query]);
+
+  const person = selected && ged ? ged.individuals.get(selected) : null;
+
+  const relations = useMemo(() => {
+    if (!ged || !person) return null;
+    const parents: Individual[] = [];
+    const spouses: Individual[] = [];
+    const children: Individual[] = [];
+    for (const fam of ged.families.values()) {
+      if (fam.husband === person.id || fam.wife === person.id) {
+        const other = fam.husband === person.id ? fam.wife : fam.husband;
+        if (other && ged.individuals.has(other)) spouses.push(ged.individuals.get(other)!);
+        for (const c of fam.children) if (ged.individuals.has(c)) children.push(ged.individuals.get(c)!);
+      }
+      if (fam.children.includes(person.id)) {
+        for (const p of [fam.husband, fam.wife]) if (p && ged.individuals.has(p)) parents.push(ged.individuals.get(p)!);
+      }
+    }
+    return { parents, spouses, children };
+  }, [ged, person]);
+
+  const chip = (i: Individual) => (
+    <button key={i.id} onClick={() => setSelected(i.id)}
+      className="border-2 border-border px-2 py-1 text-sm hover:shadow-brutal">{displayName(i)}</button>
+  );
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!ged && (
+        <Dropzone onDrop={onDrop} accept=".ged,text/plain" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {ged && (
+        <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
+          <div className="space-y-2">
+            <input value={query} onChange={e => setQuery(e.target.value)} placeholder={t.search}
+              className="w-full border-2 border-border bg-muted p-2 text-sm" />
+            <div className="text-xs text-muted-foreground">{list.length} {t.people}</div>
+            <div className="max-h-[60vh] divide-y-2 divide-border overflow-auto border-2 border-border">
+              {list.map(i => (
+                <button key={i.id} onClick={() => setSelected(i.id)} aria-pressed={selected === i.id}
+                  className={`block w-full px-3 py-2 text-left text-sm ${selected === i.id ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'}`}>
+                  <span className="font-semibold">{displayName(i)}</span>
+                  {i.birth?.date && <span className="text-xs text-muted-foreground"> · {i.birth.date}</span>}
+                </button>
+              ))}
+              {list.length === 0 && <div className="p-3 text-sm text-muted-foreground">{t.none}</div>}
+            </div>
+          </div>
+
+          {person && relations && (
+            <div className="space-y-4">
+              <div className="border-2 border-border p-4 shadow-brutal">
+                <div className="text-2xl font-black">{displayName(person)}</div>
+                <div className="mt-1 space-y-0.5 text-sm text-muted-foreground">
+                  {person.birth && <div>{t.born}: {person.birth.date}{person.birth.place ? `, ${person.birth.place}` : ''}</div>}
+                  {person.death && <div>{t.died}: {person.death.date}{person.death.place ? `, ${person.death.place}` : ''}</div>}
+                </div>
+              </div>
+              {relations.parents.length > 0 && (
+                <div><div className="mb-1 text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.parents}</div>
+                  <div className="flex flex-wrap gap-2">{relations.parents.map(chip)}</div></div>
+              )}
+              {relations.spouses.length > 0 && (
+                <div><div className="mb-1 text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.spouse}</div>
+                  <div className="flex flex-wrap gap-2">{relations.spouses.map(chip)}</div></div>
+              )}
+              {relations.children.length > 0 && (
+                <div><div className="mb-1 text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.children}</div>
+                  <div className="flex flex-wrap gap-2">{relations.children.map(chip)}</div></div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -562,6 +562,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'gedcom-viewer': {
+    title: 'Free GEDCOM Viewer — Open a Family Tree (.ged) File Online',
+    description: 'Open and browse a GEDCOM (.ged) family-tree file privately in your browser — search people and see parents, spouses and children. No sign-up, nothing uploaded.',
+    intro: 'This free GEDCOM viewer opens a family-tree file (.ged) exported from genealogy software and lets you browse it without a paid subscription. Search individuals, and click anyone to see their parents, spouse and children. Your file — which often contains personal family data — is read entirely in your browser and never uploaded.',
+    howTo: [
+      'Drop your .ged (GEDCOM) file to open it.',
+      'Search or scroll the list of people.',
+      'Click a person to see their birth/death, parents, spouse and children.',
+      'Click any related name to jump to that person.',
+    ],
+    faqs: [
+      { q: 'Is my family tree uploaded?', a: 'No. The GEDCOM file is parsed in your browser, so your family data never leaves your device — important for personal genealogy records.' },
+      { q: 'Do I need a genealogy subscription?', a: 'No. This viewer opens standard .ged files with no account and no sign-up.' },
+      { q: 'What does it show?', a: 'Individuals with their names, sex, birth and death dates/places, plus family links — parents, spouse and children.' },
+      { q: 'Which GEDCOM versions work?', a: 'It reads the common line-based GEDCOM format (INDI and FAM records) exported by most genealogy programs.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the viewer works with no internet connection.' },
+    ],
+  },
   'pdf-booklet': {
     title: 'PDF Booklet Imposition — Print & Fold a Saddle-Stitch Booklet',
     description: 'Rearrange a PDF into booklet (saddle-stitch) order: print double-sided, fold in half, and the pages read in sequence. Two-up imposition, free and in your browser.',
@@ -2768,6 +2786,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'gedcom-viewer': {
+    title: 'Penampil GEDCOM Gratis — Buka Berkas Silsilah (.ged) Online',
+    description: 'Buka dan telusuri berkas silsilah keluarga GEDCOM (.ged) secara privat di browser Anda — cari orang dan lihat orang tua, pasangan, dan anak. Tanpa daftar, tidak ada yang diunggah.',
+    intro: 'Penampil GEDCOM gratis ini membuka berkas silsilah keluarga (.ged) hasil ekspor dari software genealogi dan memungkinkan Anda menelusurinya tanpa langganan berbayar. Cari individu, dan klik siapa pun untuk melihat orang tua, pasangan, dan anak mereka. Berkas Anda — yang sering memuat data keluarga pribadi — dibaca sepenuhnya di browser dan tidak pernah diunggah.',
+    howTo: [
+      'Letakkan berkas .ged (GEDCOM) Anda untuk membukanya.',
+      'Cari atau gulir daftar orang.',
+      'Klik seseorang untuk melihat kelahiran/wafat, orang tua, pasangan, dan anak.',
+      'Klik nama terkait mana pun untuk lompat ke orang itu.',
+    ],
+    faqs: [
+      { q: 'Apakah silsilah saya diunggah?', a: 'Tidak. Berkas GEDCOM diurai di browser Anda, jadi data keluarga Anda tidak pernah meninggalkan perangkat — penting untuk catatan genealogi pribadi.' },
+      { q: 'Apakah perlu langganan genealogi?', a: 'Tidak. Penampil ini membuka berkas .ged standar tanpa akun dan tanpa pendaftaran.' },
+      { q: 'Apa yang ditampilkan?', a: 'Individu beserta nama, jenis kelamin, tanggal/tempat lahir dan wafat, plus tautan keluarga — orang tua, pasangan, dan anak.' },
+      { q: 'Versi GEDCOM apa yang didukung?', a: 'Membaca format GEDCOM berbasis baris yang umum (record INDI dan FAM) hasil ekspor sebagian besar program genealogi.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat penampil bekerja tanpa koneksi internet.' },
     ],
   },
   'pdf-booklet': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -287,6 +287,17 @@ export const tools: ToolDef[] = [
     icon: Presentation,
     summary: 'Open and read PowerPoint slides in your browser',
     load: () => import('@/islands/documents/PptxViewer'),
+    status: 'beta'
+  },
+  {
+    id: 'gedcom-viewer',
+    name: 'GEDCOM Viewer',
+    category: 'Documents',
+    route: '/tools/gedcom-viewer',
+    keywords: ['gedcom', 'ged', 'family tree', 'genealogy', 'ancestry', 'silsilah', 'keluarga', 'family history'],
+    icon: Users,
+    summary: 'Open and browse a GEDCOM family-tree file privately',
+    load: () => import('@/islands/documents/GedcomViewer'),
     status: 'beta'
   },
   {

--- a/src/tools/documents/gedcom.lib.test.ts
+++ b/src/tools/documents/gedcom.lib.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseGedcom, displayName } from './gedcom.lib';
+
+const SAMPLE = `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John /Smith/
+1 SEX M
+1 BIRT
+2 DATE 1 JAN 1900
+2 PLAC London
+1 DEAT
+2 DATE 1970
+1 FAMS @F1@
+0 @I2@ INDI
+1 NAME Mary /Jones/
+1 SEX F
+0 @I3@ INDI
+1 NAME Baby /Smith/
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+1 CHIL @I3@
+0 TRLR`;
+
+describe('parseGedcom', () => {
+  it('extracts individuals with name, sex and events', () => {
+    const g = parseGedcom(SAMPLE);
+    expect(g.individuals.size).toBe(3);
+    const i1 = g.individuals.get('@I1@')!;
+    expect(displayName(i1)).toBe('John Smith');
+    expect(i1.sex).toBe('M');
+    expect(i1.birth?.date).toBe('1 JAN 1900');
+    expect(i1.birth?.place).toBe('London');
+    expect(i1.death?.date).toBe('1970');
+  });
+
+  it('extracts families with husband, wife and children', () => {
+    const g = parseGedcom(SAMPLE);
+    const f1 = g.families.get('@F1@')!;
+    expect(f1.husband).toBe('@I1@');
+    expect(f1.wife).toBe('@I2@');
+    expect(f1.children).toEqual(['@I3@']);
+  });
+
+  it('handles empty input', () => {
+    const g = parseGedcom('');
+    expect(g.individuals.size).toBe(0);
+    expect(g.families.size).toBe(0);
+  });
+});
+
+describe('displayName', () => {
+  it('strips the surname slashes', () => {
+    expect(displayName({ id: 'x', name: 'Anna /Van Dam/', sex: '' })).toBe('Anna Van Dam');
+  });
+  it('falls back to the id-less placeholder when no name', () => {
+    expect(displayName({ id: '@I9@', name: '', sex: '' })).toBe('(unknown)');
+  });
+});

--- a/src/tools/documents/gedcom.lib.ts
+++ b/src/tools/documents/gedcom.lib.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure GEDCOM (family-tree) parser. GEDCOM is a line-based format:
+ * `LEVEL [@XREF@] TAG [VALUE]`. We extract INDI (individual) and FAM (family)
+ * records — enough to render a readable tree. No I/O.
+ */
+
+export interface GedEvent { date?: string; place?: string; }
+
+export interface Individual {
+  id: string;
+  name: string;
+  sex: string;
+  birth?: GedEvent;
+  death?: GedEvent;
+}
+
+export interface Family {
+  id: string;
+  husband?: string;
+  wife?: string;
+  children: string[];
+}
+
+export interface Gedcom {
+  individuals: Map<string, Individual>;
+  families: Map<string, Family>;
+}
+
+interface Line { level: number; xref?: string; tag: string; value: string; }
+
+function parseLine(raw: string): Line | null {
+  const m = /^\s*(\d+)\s+(@[^@]+@\s+)?(\S+)(?:\s(.*))?$/.exec(raw);
+  if (!m) return null;
+  return {
+    level: Number(m[1]),
+    xref: m[2] ? m[2].trim() : undefined,
+    tag: m[3],
+    value: (m[4] ?? '').trim(),
+  };
+}
+
+export function parseGedcom(text: string): Gedcom {
+  const individuals = new Map<string, Individual>();
+  const families = new Map<string, Family>();
+  const lines = text.split(/\r?\n/).map(parseLine).filter((l): l is Line => l !== null);
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.level !== 0 || !line.xref) { i++; continue; }
+
+    // Collect this record's child lines (level > 0 until the next level-0 line).
+    const start = i + 1;
+    let end = start;
+    while (end < lines.length && lines[end].level > 0) end++;
+    const body = lines.slice(start, end);
+
+    if (line.tag === 'INDI') {
+      const indi: Individual = { id: line.xref, name: '', sex: '' };
+      let event: 'birth' | 'death' | null = null;
+      for (const b of body) {
+        if (b.level === 1) {
+          event = null;
+          if (b.tag === 'NAME') indi.name = b.value;
+          else if (b.tag === 'SEX') indi.sex = b.value;
+          else if (b.tag === 'BIRT') { indi.birth = {}; event = 'birth'; }
+          else if (b.tag === 'DEAT') { indi.death = {}; event = 'death'; }
+        } else if (b.level === 2 && event) {
+          const target = event === 'birth' ? indi.birth! : indi.death!;
+          if (b.tag === 'DATE') target.date = b.value;
+          else if (b.tag === 'PLAC') target.place = b.value;
+        }
+      }
+      individuals.set(indi.id, indi);
+    } else if (line.tag === 'FAM') {
+      const fam: Family = { id: line.xref, children: [] };
+      for (const b of body) {
+        if (b.level !== 1) continue;
+        if (b.tag === 'HUSB') fam.husband = b.value;
+        else if (b.tag === 'WIFE') fam.wife = b.value;
+        else if (b.tag === 'CHIL') fam.children.push(b.value);
+      }
+      families.set(fam.id, fam);
+    }
+    i = end;
+  }
+
+  return { individuals, families };
+}
+
+/** Human-readable name: drop the GEDCOM surname slashes; placeholder if empty. */
+export function displayName(indi: Pick<Individual, 'id' | 'name' | 'sex'>): string {
+  const clean = indi.name.replace(/\//g, '').replace(/\s+/g, ' ').trim();
+  return clean || '(unknown)';
+}


### PR DESCRIPTION
Adds a **GEDCOM Viewer** to the Documents category (`/tools/gedcom-viewer`).

- Open a **.ged** family-tree file exported from genealogy software and browse it with **no subscription** — search people, click anyone to see birth/death and their **parents, spouse and children** as clickable chips.
- Pure `gedcom.lib.ts` parser (line-based INDI/FAM records → name, sex, birth/death events, family links) unit-tested (5 tests). Fully client-side — personal family data never leaves the device.

Verify: 1277 tests green, lint 0 errors, build OK; both `/tools/gedcom-viewer/` locales built and listed on the Documents hub.