### PR TITLE
feat(dev): Braille Converter (Grade 1)

### DIFF
--- a/src/islands/dev/BrailleConverter.tsx
+++ b/src/islands/dev/BrailleConverter.tsx
@@ -1,0 +1,61 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { toBraille } from '@/tools/dev/braille.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Convert text to Grade 1 (uncontracted) Unicode braille — letters, numbers and common punctuation, with capital and number signs. Copy the braille or download it. Everything runs in your browser.',
+    input: 'Text', output: 'Braille (Grade 1)', placeholder: 'Type or paste text…',
+    download: 'Download .txt', note: 'This is uncontracted Grade 1 braille as Unicode cells. Contracted Grade 2 and BRF embosser files are not produced.',
+  },
+  id: {
+    intro: 'Konversi teks ke braille Unicode Grade 1 (tanpa kontraksi) — huruf, angka, dan tanda baca umum, dengan tanda kapital dan angka. Salin braille-nya atau unduh. Semuanya berjalan di browser Anda.',
+    input: 'Teks', output: 'Braille (Grade 1)', placeholder: 'Ketik atau tempel teks…',
+    download: 'Unduh .txt', note: 'Ini braille Grade 1 tanpa kontraksi sebagai sel Unicode. Grade 2 terkontraksi dan berkas embosser BRF tidak dihasilkan.',
+  },
+};
+
+export default function BrailleConverter({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [text, setText] = useState('');
+  const braille = useMemo(() => toBraille(text), [text]);
+
+  const download = () => {
+    const blob = new Blob([braille], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'braille.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <label className="space-y-1 text-sm block">
+        <span className="font-semibold">{t.input}</span>
+        <textarea value={text} onChange={e => setText(e.target.value)} rows={4} placeholder={t.placeholder}
+          className="w-full resize-y border-2 border-border bg-muted p-3 text-sm" />
+      </label>
+
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold">{t.output}</span>
+          <div className="flex gap-2">
+            <CopyButton value={braille} />
+            <Button variant="secondary" onClick={download} disabled={!braille}>{t.download}</Button>
+          </div>
+        </div>
+        <div className="min-h-[4rem] whitespace-pre-wrap break-words border-2 border-border bg-background p-3 text-2xl leading-relaxed">
+          {braille}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t.note}</p>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1077,6 +1077,23 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Why is my color showing as invalid?', a: 'The input has to be a valid hex code like #rrggbb or an rgb(r, g, b) value. Check for a missing # or a typo, and the tool will convert it once the format is right.' },
     ],
   },
+  'braille-converter': {
+    title: 'Free Braille Converter — Text to Grade 1 Unicode Braille',
+    description: 'Convert text to Grade 1 (uncontracted) Unicode braille — letters, numbers and punctuation, with capital and number signs. Copy or download. Free, in your browser.',
+    intro: 'This free braille converter turns text into Grade 1 (uncontracted) Unicode braille. It maps letters, digits and common punctuation to braille cells and adds the capital and number indicators, so you can copy the braille or download it as a text file. Everything runs in your browser; nothing is uploaded.',
+    howTo: [
+      'Type or paste your text.',
+      'The Grade 1 braille appears instantly below.',
+      'Copy the braille, or download it as a .txt file.',
+    ],
+    faqs: [
+      { q: 'What kind of braille is this?', a: 'Uncontracted Grade 1 English braille, output as Unicode braille cells (the U+2800 block). Each letter, digit and punctuation mark maps to its cell, with capital and number signs.' },
+      { q: 'Does it do contracted Grade 2 braille?', a: 'No. Grade 2 uses hundreds of contractions and is not produced here; this tool is Grade 1 (letter-for-letter).' },
+      { q: 'Can I produce a BRF file for an embosser?', a: 'Not currently — the output is Unicode braille text for on-screen use and copying, not an embosser-ready BRF file.' },
+      { q: 'Is my text uploaded?', a: 'No. The conversion runs entirely in your browser; your text never leaves your device.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the converter works with no internet connection.' },
+    ],
+  },
   'barcode-generator': {
     title: 'Free Barcode Generator — Code 128, EAN, UPC & More (PNG/SVG)',
     description: 'Generate barcodes online — Code 128, EAN-13, EAN-8, UPC, Code 39, ITF and more — and download as PNG or SVG. Free and private; everything renders in your browser.',
@@ -3301,6 +3318,23 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah ada yang dikirim ke server?', a: 'Tidak. Konversi berjalan sepenuhnya di browser Anda dengan JavaScript, jadi tidak ada nilai warna atau data yang meninggalkan perangkat Anda.' },
       { q: 'Bisakah saya memilih warna alih-alih mengetiknya?', a: 'Ya. Klik kotak warna untuk membuka pemilih warna sistem Anda, dan nilai HEX, RGB, serta HSL akan diperbarui sesuai pilihan Anda.' },
       { q: 'Mengapa warna saya ditampilkan sebagai tidak valid?', a: 'Masukan harus berupa kode hex yang valid seperti #rrggbb atau nilai rgb(r, g, b). Periksa apakah ada # yang hilang atau salah ketik, dan konversi akan dilakukan begitu formatnya benar.' },
+    ],
+  },
+  'braille-converter': {
+    title: 'Konverter Braille Gratis — Teks ke Braille Unicode Grade 1',
+    description: 'Konversi teks ke braille Unicode Grade 1 (tanpa kontraksi) — huruf, angka, dan tanda baca, dengan tanda kapital dan angka. Salin atau unduh. Gratis, di browser Anda.',
+    intro: 'Konverter braille gratis ini mengubah teks menjadi braille Unicode Grade 1 (tanpa kontraksi). Tool memetakan huruf, angka, dan tanda baca umum ke sel braille serta menambahkan tanda kapital dan angka, sehingga Anda bisa menyalin braille-nya atau mengunduh sebagai berkas teks. Semuanya berjalan di browser Anda; tidak ada yang diunggah.',
+    howTo: [
+      'Ketik atau tempel teks Anda.',
+      'Braille Grade 1 muncul seketika di bawah.',
+      'Salin braille-nya, atau unduh sebagai berkas .txt.',
+    ],
+    faqs: [
+      { q: 'Braille jenis apa ini?', a: 'Braille Inggris Grade 1 tanpa kontraksi, dikeluarkan sebagai sel braille Unicode (blok U+2800). Tiap huruf, angka, dan tanda baca dipetakan ke selnya, dengan tanda kapital dan angka.' },
+      { q: 'Apakah menghasilkan braille Grade 2 terkontraksi?', a: 'Tidak. Grade 2 memakai ratusan kontraksi dan tidak dihasilkan di sini; tool ini Grade 1 (huruf per huruf).' },
+      { q: 'Bisakah membuat berkas BRF untuk embosser?', a: 'Belum — keluarannya adalah teks braille Unicode untuk tampilan layar dan penyalinan, bukan berkas BRF siap embosser.' },
+      { q: 'Apakah teks saya diunggah?', a: 'Tidak. Konversi berjalan sepenuhnya di browser Anda; teks Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat konverter bekerja tanpa koneksi internet.' },
     ],
   },
   'barcode-generator': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -716,6 +716,17 @@ export const tools: ToolDef[] = [
     icon: Accessibility,
     summary: 'Check text/background colour contrast against WCAG AA & AAA',
     load: () => import('@/islands/dev/ContrastChecker'),
+    status: 'beta'
+  },
+  {
+    id: 'braille-converter',
+    name: 'Braille Converter',
+    category: 'Dev',
+    route: '/tools/braille-converter',
+    keywords: ['braille', 'braille converter', 'text to braille', 'grade 1', 'unicode braille', 'accessibility', 'huruf braille'],
+    icon: Grip,
+    summary: 'Convert text to Grade 1 Unicode braille',
+    load: () => import('@/islands/dev/BrailleConverter'),
     status: 'beta'
   },
   {

--- a/src/tools/dev/braille.lib.test.ts
+++ b/src/tools/dev/braille.lib.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { toBraille } from './braille.lib';
+
+describe('toBraille (Grade 1)', () => {
+  it('maps lowercase letters', () => {
+    expect(toBraille('abc')).toBe('⠁⠃⠉');
+    expect(toBraille('xyz')).toBe('⠭⠽⠵');
+  });
+
+  it('prefixes a capital sign for uppercase letters', () => {
+    expect(toBraille('A')).toBe('⠠⠁');
+    expect(toBraille('Hi')).toBe('⠠⠓⠊');
+  });
+
+  it('prefixes a number sign and uses a–j for digits', () => {
+    expect(toBraille('1')).toBe('⠼⠁');
+    expect(toBraille('10')).toBe('⠼⠁⠚');
+    // number sign only once for a run of digits
+    expect(toBraille('123')).toBe('⠼⠁⠃⠉');
+  });
+
+  it('resets number mode after a space', () => {
+    expect(toBraille('1 a')).toBe('⠼⠁ ⠁');
+  });
+
+  it('maps common punctuation and preserves spaces', () => {
+    expect(toBraille('a, b.')).toBe('⠁⠂ ⠃⠲');
+  });
+
+  it('leaves unknown characters out but keeps flow', () => {
+    // A tilde has no Grade-1 cell; it is dropped, letters still map.
+    expect(toBraille('a~b')).toBe('⠁⠃');
+  });
+});

--- a/src/tools/dev/braille.lib.ts
+++ b/src/tools/dev/braille.lib.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure Grade 1 (uncontracted) English Braille translator. Maps letters, digits
+ * and common punctuation to Unicode braille cells (U+2800 block), with capital
+ * and number indicators. Contracted Grade 2 and BRF embosser output are out of
+ * scope. No I/O.
+ */
+
+const DOT_VALUE: Record<number, number> = { 1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32 };
+
+function cell(dots: number[]): string {
+  return String.fromCodePoint(0x2800 + dots.reduce((sum, d) => sum + DOT_VALUE[d], 0));
+}
+
+const LETTERS: Record<string, number[]> = {
+  a: [1], b: [1, 2], c: [1, 4], d: [1, 4, 5], e: [1, 5], f: [1, 2, 4], g: [1, 2, 4, 5],
+  h: [1, 2, 5], i: [2, 4], j: [2, 4, 5], k: [1, 3], l: [1, 2, 3], m: [1, 3, 4], n: [1, 3, 4, 5],
+  o: [1, 3, 5], p: [1, 2, 3, 4], q: [1, 2, 3, 4, 5], r: [1, 2, 3, 5], s: [2, 3, 4], t: [2, 3, 4, 5],
+  u: [1, 3, 6], v: [1, 2, 3, 6], w: [2, 4, 5, 6], x: [1, 3, 4, 6], y: [1, 3, 4, 5, 6], z: [1, 3, 5, 6],
+};
+
+const DIGIT_TO_LETTER: Record<string, string> = {
+  '1': 'a', '2': 'b', '3': 'c', '4': 'd', '5': 'e', '6': 'f', '7': 'g', '8': 'h', '9': 'i', '0': 'j',
+};
+
+const PUNCT: Record<string, number[]> = {
+  ',': [2], ';': [2, 3], ':': [2, 5], '.': [2, 5, 6], '?': [2, 3, 6], '!': [2, 3, 5],
+  "'": [3], '-': [3, 6],
+};
+
+const CAPITAL = cell([6]);
+const NUMBER = cell([3, 4, 5, 6]);
+
+export function toBraille(text: string): string {
+  let out = '';
+  let numberMode = false;
+  for (const ch of text) {
+    if (ch === ' ' || ch === '\n' || ch === '\t') {
+      out += ch;
+      numberMode = false;
+      continue;
+    }
+    if (ch >= '0' && ch <= '9') {
+      if (!numberMode) { out += NUMBER; numberMode = true; }
+      out += cell(LETTERS[DIGIT_TO_LETTER[ch]]);
+      continue;
+    }
+    numberMode = false;
+    const lower = ch.toLowerCase();
+    if (LETTERS[lower]) {
+      if (ch !== lower && ch === ch.toUpperCase()) out += CAPITAL;
+      out += cell(LETTERS[lower]);
+    } else if (PUNCT[ch]) {
+      out += cell(PUNCT[ch]);
+    }
+    // Unsupported characters are dropped.
+  }
+  return out;
+}


### PR DESCRIPTION
Adds a **Braille Converter** to the Dev category (`/tools/braille-converter`).

- Converts text to **Grade 1 (uncontracted) Unicode braille** — letters, digits and common punctuation, with capital and number indicators; copy or download as .txt.
- Pure `braille.lib.ts` unit-tested (6 tests). Grade 2 (contracted) and BRF embosser output are explicitly out of scope and noted in the UI/FAQ. Fully client-side.

Verify: 1284 tests green, lint 0 errors, build OK; both `/tools/braille-converter/` locales built and listed on the Dev hub.