### PR TITLE
feat(documents): EML email viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "onnxruntime-web": "^1.27.0",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^6.1.200",
+        "postal-mime": "^3.0.0",
         "ppu-paddle-ocr": "^6.2.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
@@ -17198,6 +17199,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/postal-mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-3.0.0.tgz",
+      "integrity": "sha512-Z4a9ar2Bv3YpK3IXag+Yda30k7bMZfpRuUGyqtHnZ2pjHG8Bl62EhZIk4n1dzv00gfzP9g+94e9kd8+XmjVWLA==",
+      "license": "MIT-0"
     },
     "node_modules/postcss": {
       "version": "8.5.16",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "onnxruntime-web": "^1.27.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^6.1.200",
+    "postal-mime": "^3.0.0",
     "ppu-paddle-ocr": "^6.2.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",

--- a/src/islands/documents/EmlViewer.tsx
+++ b/src/islands/documents/EmlViewer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Alert } from '@/components/ui/Alert';
+import { formatAddress, formatAddressList } from '@/tools/documents/eml.lib';
+import type { Lang } from '@/i18n/config';
+
+interface ParsedEmail {
+  from?: { name?: string; address?: string };
+  to?: { name?: string; address?: string }[];
+  cc?: { name?: string; address?: string }[];
+  subject?: string;
+  date?: string;
+  html?: string;
+  text?: string;
+  attachments: { filename: string | null; mimeType: string; content: ArrayBuffer | Uint8Array | string }[];
+}
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Open an .eml email file (from Outlook, Apple Mail, Gmail export, etc.) and read it privately — sender, subject, body and attachments. The file is parsed in your browser and never uploaded.',
+    drop: 'Drop an .eml file or click to browse', dropSub: 'Opened on your device',
+    failed: 'Could not read this email file.',
+    from: 'From', to: 'To', cc: 'Cc', subject: 'Subject', date: 'Date', attachments: 'Attachments', open: 'Another email',
+  },
+  id: {
+    intro: 'Buka berkas email .eml (dari Outlook, Apple Mail, ekspor Gmail, dll.) dan baca secara privat — pengirim, subjek, isi, dan lampiran. Berkas diurai di browser dan tidak pernah diunggah.',
+    drop: 'Letakkan berkas .eml atau klik untuk memilih', dropSub: 'Dibuka di perangkat Anda',
+    failed: 'Tidak dapat membaca berkas email ini.',
+    from: 'Dari', to: 'Ke', cc: 'Cc', subject: 'Subjek', date: 'Tanggal', attachments: 'Lampiran', open: 'Email lain',
+  },
+};
+
+export default function EmlViewer({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [email, setEmail] = useState<ParsedEmail | null>(null);
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => () => { /* revoke handled inline */ }, []);
+
+  const onDrop = async (files: File[]) => {
+    const f = files.find(x => x.name.toLowerCase().endsWith('.eml') || x.type === 'message/rfc822' || x.type === 'text/plain');
+    if (!f) return;
+    setBusy(true); setError(''); setEmail(null);
+    try {
+      const PostalMime = (await import('postal-mime')).default;
+      const parsed = await PostalMime.parse(await f.arrayBuffer());
+      setEmail(parsed as ParsedEmail);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const downloadAttachment = (a: ParsedEmail['attachments'][number]) => {
+    const part = typeof a.content === 'string' ? new TextEncoder().encode(a.content) : new Uint8Array(a.content as ArrayBuffer);
+    const blob = new Blob([part], { type: a.mimeType || 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = a.filename || 'attachment';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const row = (label: string, value: string) => value ? (
+    <div className="grid grid-cols-[5rem_1fr] gap-2 py-1 text-sm">
+      <span className="font-semibold text-muted-foreground">{label}</span>
+      <span className="break-words">{value}</span>
+    </div>
+  ) : null;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!email && (
+        <Dropzone onDrop={onDrop} accept=".eml,message/rfc822,text/plain" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {busy && <p className="text-sm text-muted-foreground">…</p>}
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {email && (
+        <div className="space-y-4">
+          <div className="border-2 border-border p-3">
+            {row(t.from, formatAddress(email.from))}
+            {row(t.to, formatAddressList(email.to))}
+            {row(t.cc, formatAddressList(email.cc))}
+            {row(t.subject, email.subject ?? '')}
+            {row(t.date, email.date ? new Date(email.date).toLocaleString() : '')}
+          </div>
+
+          {email.attachments.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.attachments}</span>
+              <div className="flex flex-wrap gap-2">
+                {email.attachments.map((a, i) => (
+                  <button key={i} onClick={() => downloadAttachment(a)}
+                    className="border-2 border-border px-2 py-1 text-sm hover:shadow-brutal">
+                    📎 {a.filename || `attachment-${i + 1}`}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {email.html ? (
+            <iframe title="email" sandbox="" className="h-[60vh] w-full border-2 border-border bg-white" srcDoc={email.html} />
+          ) : (
+            <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words border-2 border-border bg-muted p-3 text-sm">{email.text}</pre>
+          )}
+
+          <button onClick={() => setEmail(null)} className="border-2 border-border px-3 py-1.5 text-sm font-medium hover:shadow-brutal">{t.open}</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -562,6 +562,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'eml-viewer': {
+    title: 'Free EML Viewer — Open .eml Email Files Online (No Outlook)',
+    description: 'Open and read .eml email files in your browser — sender, subject, body and attachments — without Outlook or any account. The email is parsed on your device and never uploaded.',
+    intro: 'Someone forwarded you a .eml file and you don’t have Outlook? This free EML viewer opens email files (RFC 822 / .eml, exported from Outlook, Apple Mail, Thunderbird or Gmail) right in your browser. It shows the sender, recipients, subject, date, the message body and any attachments you can download. The email — often confidential — is parsed entirely on your device and never uploaded, and its HTML is shown in a sandbox so nothing can run.',
+    howTo: [
+      'Drop your .eml file to open it.',
+      'Read the header (From, To, Subject, Date) and the message body.',
+      'Download any attachments you need.',
+      'Open another email any time.',
+    ],
+    faqs: [
+      { q: 'Is my email uploaded?', a: 'No. The .eml file is parsed in your browser, so its contents and attachments never leave your device — important for confidential mail.' },
+      { q: 'Do I need Outlook or an account?', a: 'No. This viewer opens standard .eml (RFC 822) files with no software and no sign-up.' },
+      { q: 'Is it safe to open an email’s HTML?', a: 'Yes. The message is rendered in a sandboxed frame with scripts disabled, so tracking pixels and scripts in the email cannot run.' },
+      { q: 'Can it open .msg (Outlook) files?', a: 'Not yet — .msg uses a different (compound) format. Export or save the message as .eml and open that instead.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the viewer works with no internet connection.' },
+    ],
+  },
   'gedcom-viewer': {
     title: 'Free GEDCOM Viewer — Open a Family Tree (.ged) File Online',
     description: 'Open and browse a GEDCOM (.ged) family-tree file privately in your browser — search people and see parents, spouses and children. No sign-up, nothing uploaded.',
@@ -2803,6 +2821,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'eml-viewer': {
+    title: 'Penampil EML Gratis — Buka Berkas Email .eml Online (Tanpa Outlook)',
+    description: 'Buka dan baca berkas email .eml di browser Anda — pengirim, subjek, isi, dan lampiran — tanpa Outlook atau akun. Email diurai di perangkat dan tidak pernah diunggah.',
+    intro: 'Ada yang meneruskan berkas .eml dan Anda tidak punya Outlook? Penampil EML gratis ini membuka berkas email (RFC 822 / .eml, hasil ekspor Outlook, Apple Mail, Thunderbird, atau Gmail) langsung di browser Anda. Menampilkan pengirim, penerima, subjek, tanggal, isi pesan, dan lampiran yang bisa diunduh. Email — yang sering rahasia — diurai sepenuhnya di perangkat Anda dan tidak pernah diunggah, dan HTML-nya ditampilkan dalam sandbox sehingga tidak ada yang bisa berjalan.',
+    howTo: [
+      'Letakkan berkas .eml Anda untuk membukanya.',
+      'Baca header (Dari, Ke, Subjek, Tanggal) dan isi pesan.',
+      'Unduh lampiran yang Anda perlukan.',
+      'Buka email lain kapan saja.',
+    ],
+    faqs: [
+      { q: 'Apakah email saya diunggah?', a: 'Tidak. Berkas .eml diurai di browser Anda, jadi isinya dan lampiran tidak pernah meninggalkan perangkat — penting untuk surat rahasia.' },
+      { q: 'Apakah perlu Outlook atau akun?', a: 'Tidak. Penampil ini membuka berkas .eml (RFC 822) standar tanpa software dan tanpa pendaftaran.' },
+      { q: 'Apakah aman membuka HTML email?', a: 'Ya. Pesan dirender dalam frame sandbox dengan skrip dinonaktifkan, sehingga pixel pelacak dan skrip di email tidak bisa berjalan.' },
+      { q: 'Bisakah membuka berkas .msg (Outlook)?', a: 'Belum — .msg memakai format (compound) berbeda. Ekspor atau simpan pesan sebagai .eml lalu buka itu.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat penampil bekerja tanpa koneksi internet.' },
     ],
   },
   'gedcom-viewer': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -298,6 +298,17 @@ export const tools: ToolDef[] = [
     icon: Users,
     summary: 'Open and browse a GEDCOM family-tree file privately',
     load: () => import('@/islands/documents/GedcomViewer'),
+    status: 'beta'
+  },
+  {
+    id: 'eml-viewer',
+    name: 'EML Email Viewer',
+    category: 'Documents',
+    route: '/tools/eml-viewer',
+    keywords: ['eml', 'email viewer', 'open eml', 'outlook', 'message', 'rfc822', 'mail', 'buka eml', 'baca email'],
+    icon: MailOpen,
+    summary: 'Open and read .eml email files with attachments',
+    load: () => import('@/islands/documents/EmlViewer'),
     status: 'beta'
   },
   {

--- a/src/tools/documents/eml.lib.test.ts
+++ b/src/tools/documents/eml.lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatAddress, formatAddressList } from './eml.lib';
+
+describe('formatAddress', () => {
+  it('shows "Name <email>" when both are present', () => {
+    expect(formatAddress({ name: 'Jane Doe', address: 'jane@example.com' })).toBe('Jane Doe <jane@example.com>');
+  });
+  it('shows just the address when there is no name', () => {
+    expect(formatAddress({ name: '', address: 'bob@example.com' })).toBe('bob@example.com');
+  });
+  it('shows just the name when there is no address', () => {
+    expect(formatAddress({ name: 'Mailer', address: '' })).toBe('Mailer');
+  });
+  it('returns empty for nullish input', () => {
+    expect(formatAddress(undefined)).toBe('');
+    expect(formatAddress(null)).toBe('');
+  });
+});
+
+describe('formatAddressList', () => {
+  it('joins multiple addresses with commas', () => {
+    expect(formatAddressList([
+      { name: 'A', address: 'a@x.com' },
+      { name: '', address: 'b@x.com' },
+    ])).toBe('A <a@x.com>, b@x.com');
+  });
+  it('handles an empty or missing list', () => {
+    expect(formatAddressList([])).toBe('');
+    expect(formatAddressList(undefined)).toBe('');
+  });
+});

--- a/src/tools/documents/eml.lib.ts
+++ b/src/tools/documents/eml.lib.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure formatting helpers for the EML viewer. The MIME parsing itself is done by
+ * postal-mime in the island; these turn its parsed address objects into readable
+ * strings. No I/O.
+ */
+
+export interface EmailAddress {
+  name?: string;
+  address?: string;
+}
+
+export function formatAddress(addr: EmailAddress | null | undefined): string {
+  if (!addr) return '';
+  const name = (addr.name ?? '').trim();
+  const address = (addr.address ?? '').trim();
+  if (name && address) return `${name} <${address}>`;
+  return address || name;
+}
+
+export function formatAddressList(list: EmailAddress[] | null | undefined): string {
+  if (!list || list.length === 0) return '';
+  return list.map(formatAddress).filter(Boolean).join(', ');
+}


### PR DESCRIPTION
Adds an **EML Email Viewer** to the Documents category (`/tools/eml-viewer`).

- Open **.eml (RFC 822)** files (Outlook/Apple Mail/Thunderbird/Gmail exports) — shows **From/To/Cc/Subject/Date**, the body, and **downloadable attachments**.
- HTML body rendered in a **sandboxed iframe with scripts disabled**, so tracking pixels/scripts can't run. Parsed on-device with **postal-mime** (lazy-loaded, 22 kB gzip). .msg noted as not-yet-supported.
- Pure `eml.lib.ts` address formatters unit-tested (6 tests). New dep: `postal-mime`.

Verify: 1291 tests green, lint 0 errors, build OK; both `/tools/eml-viewer/` locales built and listed on the Documents hub.