### PR TITLE
feat(image): Scan Deskew & Crop

### DIFF
--- a/src/islands/image/DeskewTool.tsx
+++ b/src/islands/image/DeskewTool.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { computeHomography, applyHomography, type Point } from '@/tools/image/perspective.lib';
+import type { Lang } from '@/i18n/config';
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Straighten and crop a photo of a document. Drag the four corners onto the document’s edges, then Straighten to get a flat, deskewed scan — ideal before OCR. Everything runs in your browser.',
+    drop: 'Drop a photo or click to browse', dropSub: 'JPG, PNG, WebP · or paste an image (⌘V)',
+    hint: 'Drag each corner onto a corner of the document.',
+    straighten: 'Straighten', working: 'Processing…', download: 'Download', change: 'New photo', result: 'Result',
+  },
+  id: {
+    intro: 'Luruskan dan potong foto dokumen. Seret empat sudut ke tepi dokumen, lalu Luruskan untuk mendapat pindaian rata dan tegak — ideal sebelum OCR. Semuanya berjalan di browser Anda.',
+    drop: 'Letakkan foto atau klik untuk memilih', dropSub: 'JPG, PNG, WebP · atau tempel gambar (⌘V)',
+    hint: 'Seret tiap sudut ke sudut dokumen.',
+    straighten: 'Luruskan', working: 'Memproses…', download: 'Unduh', change: 'Foto baru', result: 'Hasil',
+  },
+};
+
+const MAX_DIM = 1600;
+type Corners = [Point, Point, Point, Point];
+
+export default function DeskewTool({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [srcDims, setSrcDims] = useState<{ w: number; h: number } | null>(null);
+  const [corners, setCorners] = useState<Corners | null>(null);
+  const [result, setResult] = useState<Blob | null>(null);
+  const [resultUrl, setResultUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const srcCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const dragRef = useRef<number | null>(null);
+
+  const srcCanvas = () => {
+    if (!srcCanvasRef.current) srcCanvasRef.current = document.createElement('canvas');
+    return srcCanvasRef.current;
+  };
+
+  useEffect(() => () => { if (resultUrl) URL.revokeObjectURL(resultUrl); }, [resultUrl]);
+
+  const loadImage = (file: File) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      let w = image.naturalWidth;
+      let h = image.naturalHeight;
+      const scale = Math.min(1, MAX_DIM / Math.max(w, h));
+      w = Math.round(w * scale);
+      h = Math.round(h * scale);
+      const c = srcCanvas();
+      c.width = w; c.height = h;
+      c.getContext('2d')!.drawImage(image, 0, 0, w, h);
+      setSrcDims({ w, h });
+      setCorners([[w * 0.1, h * 0.1], [w * 0.9, h * 0.1], [w * 0.9, h * 0.9], [w * 0.1, h * 0.9]]);
+      setResult(null);
+    };
+    image.src = url;
+  };
+
+  const onDrop = (files: File[]) => { const f = files.find(x => x.type.startsWith('image/')); if (f) loadImage(f); };
+  usePasteImage(f => loadImage(f));
+
+  // Draw the source preview into the visible img via data URL when dims change.
+  const [previewUrl, setPreviewUrl] = useState('');
+  useEffect(() => {
+    if (!srcDims) return;
+    setPreviewUrl(srcCanvas().toDataURL('image/png'));
+  }, [srcDims]);
+
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const toDisplay = (p: Point): { x: number; y: number } => {
+    const rect = boxRef.current?.getBoundingClientRect();
+    if (!rect || !srcDims) return { x: 0, y: 0 };
+    return { x: (p[0] / srcDims.w) * rect.width, y: (p[1] / srcDims.h) * rect.height };
+  };
+
+  const onMove = (e: React.PointerEvent) => {
+    if (dragRef.current === null || !srcDims || !corners) return;
+    const rect = boxRef.current!.getBoundingClientRect();
+    const x = Math.min(Math.max((e.clientX - rect.left) / rect.width, 0), 1) * srcDims.w;
+    const y = Math.min(Math.max((e.clientY - rect.top) / rect.height, 0), 1) * srcDims.h;
+    setCorners(c => { const next = [...c!] as Corners; next[dragRef.current!] = [x, y]; return next; });
+  };
+
+  const straighten = async () => {
+    if (!srcDims || !corners) return;
+    setBusy(true);
+    // Yield so the busy state paints before the heavy loop.
+    await new Promise(r => setTimeout(r, 0));
+    try {
+      const dist = (a: Point, b: Point) => Math.hypot(a[0] - b[0], a[1] - b[1]);
+      const outW = Math.round((dist(corners[0], corners[1]) + dist(corners[3], corners[2])) / 2);
+      const outH = Math.round((dist(corners[0], corners[3]) + dist(corners[1], corners[2])) / 2);
+      const rect: Point[] = [[0, 0], [outW, 0], [outW, outH], [0, outH]];
+      const H = computeHomography(rect, corners); // output pixel → source pixel
+      const sctx = srcCanvas().getContext('2d')!;
+      const src = sctx.getImageData(0, 0, srcDims.w, srcDims.h);
+      const out = new ImageData(outW, outH);
+      const sw = srcDims.w, sh = srcDims.h;
+      for (let v = 0; v < outH; v++) {
+        for (let u = 0; u < outW; u++) {
+          const [sx, sy] = applyHomography(H, u + 0.5, v + 0.5);
+          const ix = sx | 0, iy = sy | 0;
+          const o = (v * outW + u) * 4;
+          if (ix >= 0 && ix < sw && iy >= 0 && iy < sh) {
+            const s = (iy * sw + ix) * 4;
+            out.data[o] = src.data[s]; out.data[o + 1] = src.data[s + 1];
+            out.data[o + 2] = src.data[s + 2]; out.data[o + 3] = 255;
+          } else {
+            out.data[o] = 255; out.data[o + 1] = 255; out.data[o + 2] = 255; out.data[o + 3] = 255;
+          }
+        }
+      }
+      const rc = document.createElement('canvas');
+      rc.width = outW; rc.height = outH;
+      rc.getContext('2d')!.putImageData(out, 0, 0);
+      const blob = await new Promise<Blob | null>(res => rc.toBlob(res, 'image/png'));
+      if (blob) {
+        setResult(blob);
+        setResultUrl(prev => { if (prev) URL.revokeObjectURL(prev); return URL.createObjectURL(blob); });
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const download = () => {
+    if (!resultUrl) return;
+    const a = document.createElement('a');
+    a.href = resultUrl; a.download = 'deskewed.png'; a.click();
+  };
+
+  const backToEdit = () => { setResult(null); setResultUrl(''); };
+  const reset = () => { setSrcDims(null); setCorners(null); setResult(null); setResultUrl(''); setPreviewUrl(''); };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!srcDims && (
+        <Dropzone onDrop={onDrop} accept="image/*" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {srcDims && corners && !result && (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">{t.hint}</p>
+          <div ref={boxRef} className="relative mx-auto inline-block max-w-full touch-none select-none"
+            onPointerMove={onMove} onPointerUp={() => { dragRef.current = null; }}>
+            {previewUrl && <img ref={imgRef} src={previewUrl} alt="source" className="block max-h-[70vh] w-auto max-w-full" draggable={false} />}
+            <svg className="pointer-events-none absolute inset-0 h-full w-full">
+              <polygon points={corners.map(toDisplay).map(p => `${p.x},${p.y}`).join(' ')}
+                fill="rgba(132,204,22,0.15)" stroke="#84cc16" strokeWidth="2" />
+            </svg>
+            {corners.map((c, i) => {
+              const d = toDisplay(c);
+              return <div key={i} onPointerDown={e => { dragRef.current = i; (e.target as HTMLElement).setPointerCapture(e.pointerId); }}
+                className="absolute h-6 w-6 -translate-x-1/2 -translate-y-1/2 cursor-move rounded-full border-2 border-black bg-lime-400"
+                style={{ left: d.x, top: d.y, touchAction: 'none' }} />;
+            })}
+          </div>
+          <Button onClick={straighten} disabled={busy}>{busy ? t.working : t.straighten}</Button>
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-3">
+          <span className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{t.result}</span>
+          <img src={resultUrl} alt="result" className="max-h-[70vh] w-auto max-w-full border-2 border-border" />
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={download}>{t.download}</Button>
+            <Button variant="secondary" onClick={backToEdit}>{t.straighten}</Button>
+            <Button variant="ghost" onClick={reset}>{t.change}</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1543,6 +1543,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Can I use this to watermark a KTP or ID card photo?', a: 'Yes. Drop in a scan or photo of your KTP, SIM, passport or any identity document, type your watermark text (e.g. "COPY" or your name), pick Diagonal or Tiled layout, set the opacity, and download. Everything stays on your device — nothing is uploaded.' },
     ],
   },
+  'scan-deskew': {
+    title: 'Scan Deskew & Crop — Straighten a Photo of a Document',
+    description: 'Turn a phone photo of a document into a flat, straight scan. Drag the four corners and the perspective is corrected and cropped. Free, private — nothing is uploaded.',
+    intro: 'This free deskew tool turns a skewed phone photo of a document, receipt or whiteboard into a flat, straight scan. Drag the four corner handles onto the document’s corners and it corrects the perspective and crops to just the page — perfect to run before OCR or the Pas Foto maker. Everything runs in your browser; your photo is never uploaded.',
+    howTo: [
+      'Drop or paste a photo of the document.',
+      'Drag each of the four corners onto a corner of the page.',
+      'Click Straighten to correct the perspective and crop.',
+      'Download the flattened scan (PNG).',
+    ],
+    faqs: [
+      { q: 'Is my photo uploaded?', a: 'No. The perspective correction runs on a canvas in your browser, so your photo never leaves your device.' },
+      { q: 'How do I get the best result?', a: 'Place each corner handle exactly on a corner of the document, and make sure the whole page is in the photo with some contrast against the background.' },
+      { q: 'Does it auto-detect the document edges?', a: 'You place the four corners yourself, which is reliable across lighting and backgrounds; the tool then does the perspective maths and crop.' },
+      { q: 'What can I use it for?', a: 'Flattening receipts, forms, book pages or whiteboards — a great first step before OCR or before making an ID photo.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the tool works with no internet connection.' },
+    ],
+  },
   'color-blindness-sim': {
     title: 'Color Blindness Simulator — Preview Protanopia, Deuteranopia, Tritanopia',
     description: 'See how an image or design looks with colour-vision deficiencies — protanopia, deuteranopia, tritanopia and more — side by side with the original. Free, in your browser.',
@@ -3802,6 +3820,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah saya mengontrol tampilan watermark?', a: 'Ya. Anda dapat mengatur teks, memilih warna apa pun, dan menggunakan penggeser untuk menyesuaikan skala dan opasitasnya agar sesamar atau setebal yang Anda inginkan.' },
       { q: 'Dalam format apa gambar berwatermark disimpan?', a: 'Unduhan mempertahankan format asli gambar Anda jika memungkinkan, jadi JPEG tetap JPEG dan PNG tetap PNG.' },
       { q: 'Bisakah tool ini digunakan untuk watermark KTP?', a: 'Ya. Unggah scan atau foto KTP, SIM, paspor, atau dokumen identitas lainnya, ketik teks watermark (misalnya "COPY" atau nama Anda), pilih tata letak Diagonal atau Tiled, atur opasitasnya, lalu unduh hasilnya. Semua diproses di perangkat Anda — tidak ada yang diunggah.' },
+    ],
+  },
+  'scan-deskew': {
+    title: 'Luruskan & Potong Pindaian — Ratakan Foto Dokumen',
+    description: 'Ubah foto dokumen dari ponsel menjadi pindaian rata dan lurus. Seret empat sudut dan perspektif dikoreksi lalu dipotong. Gratis, privat — tidak ada yang diunggah.',
+    intro: 'Tool deskew gratis ini mengubah foto dokumen, struk, atau papan tulis yang miring menjadi pindaian rata dan lurus. Seret empat pegangan sudut ke sudut dokumen dan tool mengoreksi perspektif serta memotong hanya halamannya — pas dijalankan sebelum OCR atau Pas Foto. Semuanya berjalan di browser Anda; foto Anda tidak pernah diunggah.',
+    howTo: [
+      'Letakkan atau tempel foto dokumen.',
+      'Seret tiap dari empat sudut ke sudut halaman.',
+      'Klik Luruskan untuk mengoreksi perspektif dan memotong.',
+      'Unduh pindaian yang sudah rata (PNG).',
+    ],
+    faqs: [
+      { q: 'Apakah foto saya diunggah?', a: 'Tidak. Koreksi perspektif berjalan di canvas dalam browser Anda, jadi foto tidak pernah meninggalkan perangkat.' },
+      { q: 'Bagaimana hasil terbaiknya?', a: 'Letakkan tiap pegangan sudut tepat di sudut dokumen, dan pastikan seluruh halaman ada di foto dengan kontras terhadap latar.' },
+      { q: 'Apakah mendeteksi tepi dokumen otomatis?', a: 'Anda menempatkan empat sudut sendiri, yang andal di berbagai pencahayaan dan latar; tool lalu melakukan perhitungan perspektif dan pemotongan.' },
+      { q: 'Bisa dipakai untuk apa?', a: 'Meratakan struk, formulir, halaman buku, atau papan tulis — langkah awal yang bagus sebelum OCR atau membuat pas foto.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool bekerja tanpa koneksi internet.' },
     ],
   },
   'color-blindness-sim': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -1024,6 +1024,17 @@ export const tools: ToolDef[] = [
     icon: Glasses,
     summary: 'Preview an image as seen with colour-vision deficiencies',
     load: () => import('@/islands/image/ColorBlindSim'),
+    status: 'beta'
+  },
+  {
+    id: 'scan-deskew',
+    name: 'Scan Deskew & Crop',
+    category: 'Image',
+    route: '/tools/scan-deskew',
+    keywords: ['deskew', 'perspective', 'crop', 'straighten', 'document scan', 'scanner', 'auto crop', 'luruskan', 'pindai dokumen'],
+    icon: Scan,
+    summary: 'Straighten and crop a photo of a document (perspective fix)',
+    load: () => import('@/islands/image/DeskewTool'),
     status: 'beta'
   },
   {

--- a/src/tools/image/perspective.lib.test.ts
+++ b/src/tools/image/perspective.lib.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { computeHomography, applyHomography, type Point } from './perspective.lib';
+
+const unit: Point[] = [[0, 0], [1, 0], [1, 1], [0, 1]];
+
+describe('computeHomography / applyHomography', () => {
+  it('identity maps a unit square to itself', () => {
+    const H = computeHomography(unit, unit);
+    const [x, y] = applyHomography(H, 0.5, 0.5);
+    expect(x).toBeCloseTo(0.5, 6);
+    expect(y).toBeCloseTo(0.5, 6);
+  });
+
+  it('scales a unit square to a 2× square', () => {
+    const dst: Point[] = [[0, 0], [2, 0], [2, 2], [0, 2]];
+    const H = computeHomography(unit, dst);
+    const [x, y] = applyHomography(H, 0.5, 0.5);
+    expect(x).toBeCloseTo(1, 6);
+    expect(y).toBeCloseTo(1, 6);
+  });
+
+  it('translates', () => {
+    const dst: Point[] = [[10, 20], [11, 20], [11, 21], [10, 21]];
+    const H = computeHomography(unit, dst);
+    const [x, y] = applyHomography(H, 0, 0);
+    expect(x).toBeCloseTo(10, 6);
+    expect(y).toBeCloseTo(20, 6);
+  });
+
+  it('maps corners exactly for a projective (trapezoid) target', () => {
+    const dst: Point[] = [[0, 0], [100, 10], [90, 80], [5, 95]];
+    const H = computeHomography(unit, dst);
+    unit.forEach((src, i) => {
+      const [x, y] = applyHomography(H, src[0], src[1]);
+      expect(x).toBeCloseTo(dst[i][0], 4);
+      expect(y).toBeCloseTo(dst[i][1], 4);
+    });
+  });
+});

--- a/src/tools/image/perspective.lib.ts
+++ b/src/tools/image/perspective.lib.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure projective (homography) transform math for the deskew/perspective-crop
+ * tool. Solves the 8-parameter homography that maps four source points to four
+ * destination points, and applies it. No I/O.
+ */
+
+export type Point = [number, number];
+
+/** Solve A·x = b for an n×n system by Gaussian elimination with partial pivoting. */
+function solve(A: number[][], b: number[]): number[] {
+  const n = b.length;
+  const M = A.map((row, i) => [...row, b[i]]);
+  for (let col = 0; col < n; col++) {
+    // pivot
+    let pivot = col;
+    for (let r = col + 1; r < n; r++) if (Math.abs(M[r][col]) > Math.abs(M[pivot][col])) pivot = r;
+    [M[col], M[pivot]] = [M[pivot], M[col]];
+    const div = M[col][col] || 1e-12;
+    for (let c = col; c <= n; c++) M[col][c] /= div;
+    for (let r = 0; r < n; r++) {
+      if (r === col) continue;
+      const factor = M[r][col];
+      for (let c = col; c <= n; c++) M[r][c] -= factor * M[col][c];
+    }
+  }
+  return M.map(row => row[n]);
+}
+
+/**
+ * Homography (row-major 3×3, h33 = 1) mapping the four `src` points to the four
+ * `dst` points, in order. Points are [top-left, top-right, bottom-right, bottom-left].
+ */
+export function computeHomography(src: Point[], dst: Point[]): number[] {
+  const A: number[][] = [];
+  const b: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    const [x, y] = src[i];
+    const [X, Y] = dst[i];
+    A.push([x, y, 1, 0, 0, 0, -X * x, -X * y]);
+    b.push(X);
+    A.push([0, 0, 0, x, y, 1, -Y * x, -Y * y]);
+    b.push(Y);
+  }
+  const h = solve(A, b);
+  return [h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], 1];
+}
+
+/** Apply a homography to a point. */
+export function applyHomography(H: number[], x: number, y: number): Point {
+  const w = H[6] * x + H[7] * y + H[8];
+  return [
+    (H[0] * x + H[1] * y + H[2]) / w,
+    (H[3] * x + H[4] * y + H[5]) / w,
+  ];
+}


### PR DESCRIPTION
Adds a **Scan Deskew & Crop** tool to the Image category (`/tools/scan-deskew`).

- Turn a skewed phone photo of a document into a flat scan: drag the **four corner handles** onto the page, then **Straighten** applies a perspective (homography) warp and crops to the page — great before OCR or the Pas Foto maker.
- Pure `perspective.lib.ts` (4-point homography solve via Gaussian elimination + apply) unit-tested (4 cases incl. identity/scale/translate/trapezoid). Fully client-side; source capped to 1600px for speed.

Verify: 1296 tests green, lint 0 errors, build OK; both `/tools/scan-deskew/` locales built and listed on the Image hub.