### PR TITLE
feat(documents): DICOM medical image viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "cmdk": "^0.2.1",
         "comlink": "^4.4.2",
         "csso": "^5.0.5",
+        "dicom-parser": "^1.8.21",
         "docx": "^9.7.1",
         "docx-preview": "^0.4.0",
         "dompurify": "^3.4.12",
@@ -10914,6 +10915,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dicom-parser": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/dicom-parser/-/dicom-parser-1.8.21.tgz",
+      "integrity": "sha512-lYCweHQDsC8UFpXErPlg86Px2A8bay0HiUY+wzoG3xv5GzgqVHU3lziwSc/Gzn7VV7y2KeP072SzCviuOoU02w==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "cmdk": "^0.2.1",
     "comlink": "^4.4.2",
     "csso": "^5.0.5",
+    "dicom-parser": "^1.8.21",
     "docx": "^9.7.1",
     "docx-preview": "^0.4.0",
     "dompurify": "^3.4.12",

--- a/src/islands/documents/DicomViewer.tsx
+++ b/src/islands/documents/DicomViewer.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Alert } from '@/components/ui/Alert';
+import { applyWindowLevel, isUncompressed, rescale } from '@/tools/documents/dicom.lib';
+import type { Lang } from '@/i18n/config';
+
+interface Loaded {
+  rows: number; cols: number; pixels: Int16Array | Uint16Array | Uint8Array; rgb: Uint8Array | null;
+  slope: number; intercept: number; invert: boolean; minC: number; maxW: number;
+  meta: { label: string; value: string }[];
+}
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Open a DICOM medical image (.dcm) from a hospital CD or USB and view it privately — with window/level (brightness/contrast) controls. Your scan is read in your browser and never uploaded.',
+    drop: 'Drop a .dcm file or click to browse', dropSub: 'Opened on your device',
+    failed: 'Could not read this DICOM file.',
+    compressed: 'This DICOM uses a compressed transfer syntax (e.g. JPEG/JPEG 2000/RLE), which this viewer does not decode yet. Uncompressed Little-Endian images are supported.',
+    center: 'Brightness (window center)', width: 'Contrast (window width)', another: 'Another file',
+  },
+  id: {
+    intro: 'Buka citra medis DICOM (.dcm) dari CD atau USB rumah sakit dan lihat secara privat — dengan kontrol window/level (kecerahan/kontras). Pindaian Anda dibaca di browser dan tidak pernah diunggah.',
+    drop: 'Letakkan berkas .dcm atau klik untuk memilih', dropSub: 'Dibuka di perangkat Anda',
+    failed: 'Tidak dapat membaca berkas DICOM ini.',
+    compressed: 'DICOM ini memakai transfer syntax terkompresi (mis. JPEG/JPEG 2000/RLE) yang belum didekode penampil ini. Citra Little-Endian tanpa kompresi didukung.',
+    center: 'Kecerahan (window center)', width: 'Kontras (window width)', another: 'Berkas lain',
+  },
+};
+
+export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+  const [error, setError] = useState('');
+  const [center, setCenter] = useState(128);
+  const [width, setWidth] = useState(256);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const onDrop = async (files: File[]) => {
+    const f = files[0];
+    if (!f) return;
+    setError(''); setLoaded(null);
+    try {
+      const dicomParser = (await import('dicom-parser')).default;
+      const byteArray = new Uint8Array(await f.arrayBuffer());
+      const ds = dicomParser.parseDicom(byteArray);
+      const ts = ds.string('x00020010') || '';
+      if (!isUncompressed(ts) || ts === '1.2.840.10008.1.2.2') { setError(t.compressed); return; }
+
+      const rows = ds.uint16('x00280010') || 0;
+      const cols = ds.uint16('x00280011') || 0;
+      const bits = ds.uint16('x00280100') || 16;
+      const signed = (ds.uint16('x00280103') || 0) === 1;
+      const samples = ds.uint16('x00280002') || 1;
+      const photometric = ds.string('x00280004') || 'MONOCHROME2';
+      const slope = parseFloat(ds.string('x00281053') || '1') || 1;
+      const intercept = parseFloat(ds.string('x00281052') || '0') || 0;
+      const el = ds.elements.x7fe00010;
+      const n = rows * cols;
+
+      let pixels: Int16Array | Uint16Array | Uint8Array;
+      let rgb: Uint8Array | null = null;
+      if (samples === 3) {
+        rgb = new Uint8Array(byteArray.buffer, el.dataOffset, n * 3);
+        pixels = new Uint8Array(0);
+      } else if (bits <= 8) {
+        pixels = new Uint8Array(byteArray.buffer, el.dataOffset, n);
+      } else {
+        // Copy the slice so the typed-array view is always correctly aligned.
+        const buf = byteArray.buffer.slice(el.dataOffset, el.dataOffset + n * 2);
+        pixels = signed ? new Int16Array(buf) : new Uint16Array(buf);
+      }
+
+      // Default window/level: from data if present, else min/max of rescaled values.
+      let wc = parseFloat((ds.string('x00281050') || '').split('\\')[0]);
+      let ww = parseFloat((ds.string('x00281051') || '').split('\\')[0]);
+      if (!Number.isFinite(wc) || !Number.isFinite(ww) || ww <= 0) {
+        let mn = Infinity, mx = -Infinity;
+        if (!rgb) for (let i = 0; i < n; i++) { const v = rescale(pixels[i], slope, intercept); if (v < mn) mn = v; if (v > mx) mx = v; }
+        else { mn = 0; mx = 255; }
+        wc = (mn + mx) / 2; ww = Math.max(1, mx - mn);
+      }
+
+      const meta = [
+        { label: 'Modality', value: ds.string('x00080060') || '—' },
+        { label: 'Study', value: ds.string('x00081030') || '—' },
+        { label: 'Size', value: `${cols} × ${rows}` },
+      ];
+      setLoaded({ rows, cols, pixels, rgb, slope, intercept, invert: photometric === 'MONOCHROME1', minC: wc, maxW: ww, meta });
+      setCenter(wc); setWidth(ww);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    }
+  };
+
+  useEffect(() => {
+    if (!loaded) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = loaded.cols; canvas.height = loaded.rows;
+    const img = ctx.createImageData(loaded.cols, loaded.rows);
+    const n = loaded.rows * loaded.cols;
+    if (loaded.rgb) {
+      for (let i = 0; i < n; i++) {
+        img.data[i * 4] = loaded.rgb[i * 3];
+        img.data[i * 4 + 1] = loaded.rgb[i * 3 + 1];
+        img.data[i * 4 + 2] = loaded.rgb[i * 3 + 2];
+        img.data[i * 4 + 3] = 255;
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        const v = rescale(loaded.pixels[i], loaded.slope, loaded.intercept);
+        const g = applyWindowLevel(v, center, width, loaded.invert);
+        img.data[i * 4] = g; img.data[i * 4 + 1] = g; img.data[i * 4 + 2] = g; img.data[i * 4 + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  }, [loaded, center, width]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!loaded && (
+        <Dropzone onDrop={onDrop} accept=".dcm,application/dicom" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {loaded && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+            {loaded.meta.map(m => <span key={m.label}><span className="font-semibold">{m.label}:</span> {m.value}</span>)}
+          </div>
+          <div className="flex justify-center border-2 border-border bg-black p-2">
+            <canvas ref={canvasRef} className="max-h-[70vh] w-auto max-w-full" style={{ imageRendering: 'pixelated' }} />
+          </div>
+          {!loaded.rgb && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="space-y-1 text-sm"><span className="block font-semibold">{t.center}: {Math.round(center)}</span>
+                <input type="range" min={loaded.minC - loaded.maxW} max={loaded.minC + loaded.maxW} value={center}
+                  onChange={e => setCenter(Number(e.target.value))} className="w-full accent-accent" /></label>
+              <label className="space-y-1 text-sm"><span className="block font-semibold">{t.width}: {Math.round(width)}</span>
+                <input type="range" min={1} max={loaded.maxW * 3} value={width}
+                  onChange={e => setWidth(Number(e.target.value))} className="w-full accent-accent" /></label>
+            </div>
+          )}
+          <button onClick={() => { setLoaded(null); setError(''); }} className="border-2 border-border px-3 py-1.5 text-sm font-medium hover:shadow-brutal">{t.another}</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -562,6 +562,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'dicom-viewer': {
+    title: 'Free DICOM Viewer — Open .dcm Medical Images (MRI, CT, X-ray)',
+    description: 'Open a DICOM (.dcm) medical image from a hospital CD or USB and view it in your browser, with window/level controls. Private — your scan is never uploaded.',
+    intro: 'Hospitals often hand you your MRI, CT or X-ray on a CD or USB with no easy way to open it — and uploading a personal medical scan to a random website is exactly what you should not do. This free DICOM viewer opens uncompressed .dcm images right in your browser, with window/level (brightness/contrast) controls, so your scan never leaves your device.',
+    howTo: [
+      'Drop your .dcm (DICOM) file to open it.',
+      'View the image with the modality and size shown.',
+      'Adjust the brightness (window center) and contrast (window width).',
+      'Open another file any time.',
+    ],
+    faqs: [
+      { q: 'Is my medical scan uploaded?', a: 'No. The DICOM file is parsed and rendered entirely in your browser, so your scan never leaves your device — which matters a lot for medical data.' },
+      { q: 'What are window and level?', a: 'They set the brightness (window center) and contrast (window width) used to map the scan’s wide value range onto the screen — the same controls radiologists use.' },
+      { q: 'Which DICOM files are supported?', a: 'Uncompressed Little-Endian images (grayscale and RGB), the common case for many exports. Compressed DICOM (JPEG/JPEG 2000/RLE) is detected and reported as not yet supported.' },
+      { q: 'Can it show a whole series?', a: 'It opens a single .dcm image at a time. Open each file individually.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the viewer works with no internet connection.' },
+    ],
+  },
   'eml-viewer': {
     title: 'Free EML Viewer — Open .eml Email Files Online (No Outlook)',
     description: 'Open and read .eml email files in your browser — sender, subject, body and attachments — without Outlook or any account. The email is parsed on your device and never uploaded.',
@@ -2839,6 +2857,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'dicom-viewer': {
+    title: 'Penampil DICOM Gratis — Buka Citra Medis .dcm (MRI, CT, Rontgen)',
+    description: 'Buka citra medis DICOM (.dcm) dari CD atau USB rumah sakit dan lihat di browser, dengan kontrol window/level. Privat — pindaian Anda tidak pernah diunggah.',
+    intro: 'Rumah sakit sering memberi Anda MRI, CT, atau rontgen dalam CD atau USB tanpa cara mudah membukanya — dan mengunggah pindaian medis pribadi ke situs sembarangan justru tidak boleh dilakukan. Penampil DICOM gratis ini membuka citra .dcm tanpa kompresi langsung di browser Anda, dengan kontrol window/level (kecerahan/kontras), jadi pindaian Anda tidak pernah meninggalkan perangkat.',
+    howTo: [
+      'Letakkan berkas .dcm (DICOM) Anda untuk membukanya.',
+      'Lihat citra beserta modalitas dan ukurannya.',
+      'Atur kecerahan (window center) dan kontras (window width).',
+      'Buka berkas lain kapan saja.',
+    ],
+    faqs: [
+      { q: 'Apakah pindaian medis saya diunggah?', a: 'Tidak. Berkas DICOM diurai dan dirender sepenuhnya di browser Anda, jadi pindaian tidak pernah meninggalkan perangkat — sangat penting untuk data medis.' },
+      { q: 'Apa itu window dan level?', a: 'Keduanya mengatur kecerahan (window center) dan kontras (window width) untuk memetakan rentang nilai pindaian yang lebar ke layar — kontrol yang sama dipakai radiolog.' },
+      { q: 'Berkas DICOM apa yang didukung?', a: 'Citra Little-Endian tanpa kompresi (grayscale dan RGB), kasus umum untuk banyak ekspor. DICOM terkompresi (JPEG/JPEG 2000/RLE) dideteksi dan dilaporkan belum didukung.' },
+      { q: 'Bisakah menampilkan satu seri penuh?', a: 'Membuka satu citra .dcm setiap kali. Buka tiap berkas satu per satu.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat penampil bekerja tanpa koneksi internet.' },
     ],
   },
   'eml-viewer': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan, Activity } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -309,6 +309,17 @@ export const tools: ToolDef[] = [
     icon: MailOpen,
     summary: 'Open and read .eml email files with attachments',
     load: () => import('@/islands/documents/EmlViewer'),
+    status: 'beta'
+  },
+  {
+    id: 'dicom-viewer',
+    name: 'DICOM Viewer',
+    category: 'Documents',
+    route: '/tools/dicom-viewer',
+    keywords: ['dicom', 'dcm', 'medical image', 'mri', 'ct scan', 'xray', 'x-ray', 'radiology', 'viewer', 'citra medis'],
+    icon: Activity,
+    summary: 'View DICOM medical images (.dcm) with window/level',
+    load: () => import('@/islands/documents/DicomViewer'),
     status: 'beta'
   },
   {

--- a/src/tools/documents/dicom.lib.test.ts
+++ b/src/tools/documents/dicom.lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { applyWindowLevel, isUncompressed, rescale } from './dicom.lib';
+
+describe('rescale', () => {
+  it('applies slope and intercept', () => {
+    expect(rescale(100, 1, -1024)).toBe(-924);
+    expect(rescale(50, 2, 0)).toBe(100);
+  });
+});
+
+describe('applyWindowLevel', () => {
+  const c = 128, w = 256;
+  it('maps the window ends to 0 and 255', () => {
+    expect(applyWindowLevel(0, c, w, false)).toBe(0);
+    expect(applyWindowLevel(255, c, w, false)).toBe(255);
+  });
+  it('maps the centre near mid-grey', () => {
+    expect(applyWindowLevel(128, c, w, false)).toBeGreaterThanOrEqual(127);
+    expect(applyWindowLevel(128, c, w, false)).toBeLessThanOrEqual(129);
+  });
+  it('clamps values outside the window', () => {
+    expect(applyWindowLevel(-50, c, w, false)).toBe(0);
+    expect(applyWindowLevel(400, c, w, false)).toBe(255);
+  });
+  it('inverts for MONOCHROME1', () => {
+    expect(applyWindowLevel(0, c, w, true)).toBe(255);
+    expect(applyWindowLevel(255, c, w, true)).toBe(0);
+  });
+});
+
+describe('isUncompressed', () => {
+  it('accepts the implicit/explicit little- and big-endian syntaxes', () => {
+    expect(isUncompressed('1.2.840.10008.1.2')).toBe(true);
+    expect(isUncompressed('1.2.840.10008.1.2.1')).toBe(true);
+    expect(isUncompressed('1.2.840.10008.1.2.2')).toBe(true);
+  });
+  it('rejects compressed transfer syntaxes', () => {
+    expect(isUncompressed('1.2.840.10008.1.2.4.50')).toBe(false); // JPEG baseline
+    expect(isUncompressed('1.2.840.10008.1.2.4.90')).toBe(false); // JPEG 2000
+    expect(isUncompressed('1.2.840.10008.1.2.5')).toBe(false); // RLE
+    expect(isUncompressed('')).toBe(false);
+  });
+});

--- a/src/tools/documents/dicom.lib.ts
+++ b/src/tools/documents/dicom.lib.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure DICOM pixel helpers: modality rescale, VOI window/level mapping to 8-bit
+ * grey, and a transfer-syntax check. The actual parsing (dicom-parser) and canvas
+ * rendering live in the island; the pixel maths is here and unit-tested.
+ */
+
+/** Uncompressed transfer syntaxes this viewer can render directly. */
+const UNCOMPRESSED = new Set([
+  '1.2.840.10008.1.2', // Implicit VR Little Endian
+  '1.2.840.10008.1.2.1', // Explicit VR Little Endian
+  '1.2.840.10008.1.2.2', // Explicit VR Big Endian
+]);
+
+export function isUncompressed(transferSyntaxUID: string): boolean {
+  return UNCOMPRESSED.has(transferSyntaxUID);
+}
+
+/** Modality rescale: stored value → real-world value. */
+export function rescale(stored: number, slope: number, intercept: number): number {
+  return stored * slope + intercept;
+}
+
+/**
+ * DICOM VOI LUT (linear) mapping a value to 0–255 for the given window centre and
+ * width. `invert` handles MONOCHROME1 (where higher values are darker).
+ */
+export function applyWindowLevel(value: number, center: number, width: number, invert: boolean): number {
+  const w = width < 1 ? 1 : width;
+  const lower = center - 0.5 - (w - 1) / 2;
+  const upper = center - 0.5 + (w - 1) / 2;
+  let out: number;
+  if (value <= lower) out = 0;
+  else if (value > upper) out = 255;
+  else out = ((value - (center - 0.5)) / (w - 1) + 0.5) * 255;
+  out = Math.max(0, Math.min(255, Math.round(out)));
+  return invert ? 255 - out : out;
+}


### PR DESCRIPTION
Adds a **DICOM Viewer** to the Documents category (`/tools/dicom-viewer`).

- Open uncompressed **.dcm** medical images (MRI/CT/X-ray) from a hospital CD/USB and view them **privately** with **window/level** (brightness/contrast) controls — grayscale (8/16-bit, signed), MONOCHROME1 inversion, modality rescale, and RGB.
- Compressed transfer syntaxes (JPEG/JPEG 2000/RLE) are **detected and reported** rather than rendered as garbage. Parsed on-device with **dicom-parser** (lazy-loaded, 7 kB gzip).
- Pure `dicom.lib.ts` (rescale, VOI window/level → 8-bit, transfer-syntax check) unit-tested (7 tests). New dep: `dicom-parser`.

Verify: 1304 tests green, lint 0 errors, build OK; both `/tools/dicom-viewer/` locales built and listed on the Documents hub.