### PR TITLE
feat: Live Captions + PPTX to PDF

### DIFF
--- a/src/islands/documents/PptxToPdf.tsx
+++ b/src/islands/documents/PptxToPdf.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from 'react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { ResultActions } from '@/components/ui/ResultActions';
+import type { PptxDoc, Shape } from '@/tools/documents/pptx.lib';
+import type { Lang } from '@/i18n/config';
+
+const PT_TO_PX = 1.3333;
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Convert a PowerPoint (.pptx) into a PDF — one slide per page, laid out with its real positions, text and images. Everything runs in your browser; nothing is uploaded.',
+    drop: 'Drop a .pptx file or click to browse', dropSub: 'Converted on your device',
+    failed: 'Could not convert this file.', slides: 'slides', convert: 'Convert to PDF', working: 'Converting…',
+    note: 'Slides are rendered to images, so the PDF text is not selectable.',
+  },
+  id: {
+    intro: 'Konversi PowerPoint (.pptx) menjadi PDF — satu slide per halaman, ditata sesuai posisi, teks, dan gambar aslinya. Semuanya berjalan di browser Anda; tidak ada yang diunggah.',
+    drop: 'Letakkan berkas .pptx atau klik untuk memilih', dropSub: 'Dikonversi di perangkat Anda',
+    failed: 'Tidak dapat mengonversi berkas ini.', slides: 'slide', convert: 'Konversi ke PDF', working: 'Mengonversi…',
+    note: 'Slide dirender menjadi gambar, jadi teks PDF tidak bisa diseleksi.',
+  },
+};
+
+function ShapeView({ shape, url }: { shape: Shape; url?: string }) {
+  const box: React.CSSProperties = { position: 'absolute', left: shape.x, top: shape.y, width: shape.w, height: shape.h, overflow: 'hidden' };
+  if (shape.kind === 'image') return url ? <img src={url} alt="" style={{ ...box, objectFit: 'contain' }} /> : null;
+  return (
+    <div style={{ ...box, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      {shape.paragraphs!.map((p, pi) => (
+        <p key={pi} style={{ textAlign: p.align, margin: 0, lineHeight: 1.2 }}>
+          {p.runs.map((r, ri) => (
+            <span key={ri} style={{ fontWeight: r.bold ? 700 : 400, fontStyle: r.italic ? 'italic' : 'normal', fontSize: (r.sizePt ?? 18) * PT_TO_PX, color: r.color ?? '#000' }}>{r.text}</span>
+          ))}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default function PptxToPdf({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [doc, setDoc] = useState<PptxDoc | null>(null);
+  const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<Blob | null>(null);
+  const slideRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => () => { Object.values(mediaUrls).forEach(URL.revokeObjectURL); }, [mediaUrls]);
+
+  const onDrop = async (files: File[]) => {
+    const file = files.find(f => f.name.toLowerCase().endsWith('.pptx'));
+    if (!file) return;
+    setBusy(true); setError(''); setResult(null);
+    Object.values(mediaUrls).forEach(URL.revokeObjectURL);
+    setDoc(null); setMediaUrls({});
+    try {
+      const { parsePptx } = await import('@/tools/documents/pptx.lib');
+      const parsed = parsePptx(new Uint8Array(await file.arrayBuffer()));
+      const urls: Record<string, string> = {};
+      for (const [key, bytes] of Object.entries(parsed.media)) urls[key] = URL.createObjectURL(new Blob([bytes]));
+      setDoc(parsed); setMediaUrls(urls);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const convert = async () => {
+    if (!doc) return;
+    setBusy(true); setError('');
+    try {
+      const [{ default: html2canvas }, { PDFDocument }] = await Promise.all([import('html2canvas'), import('pdf-lib')]);
+      const out = await PDFDocument.create();
+      for (let i = 0; i < doc.slides.length; i++) {
+        const node = slideRefs.current[i];
+        if (!node) continue;
+        const canvas = await html2canvas(node, { scale: 2, backgroundColor: '#ffffff', useCORS: true, logging: false });
+        const png = await out.embedPng(canvas.toDataURL('image/png'));
+        const page = out.addPage([doc.widthPx, doc.heightPx]);
+        page.drawImage(png, { x: 0, y: 0, width: doc.widthPx, height: doc.heightPx });
+      }
+      setResult(new Blob([await out.save()], { type: 'application/pdf' }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t.failed);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      {!doc && (
+        <Dropzone onDrop={onDrop} accept=".pptx" multiple={false}>
+          <div className="space-y-1">
+            <p className="text-lg font-bold">{t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      )}
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {doc && !result && (
+        <div className="space-y-3">
+          <p className="text-sm"><span className="font-bold">{doc.slides.length}</span> {t.slides}</p>
+          <p className="text-xs text-muted-foreground">{t.note}</p>
+          <Button onClick={convert} disabled={busy}>{busy ? t.working : t.convert}</Button>
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">{t.note}</p>
+          <ResultActions blob={result} filename="slides.pdf" disabled={busy} />
+        </div>
+      )}
+
+      {/* Off-screen slides at native size for capture. */}
+      {doc && (
+        <div style={{ position: 'fixed', left: -99999, top: 0, pointerEvents: 'none' }} aria-hidden>
+          {doc.slides.map((slide, i) => (
+            <div key={i} ref={el => { slideRefs.current[i] = el; }}
+              style={{ position: 'relative', width: doc.widthPx, height: doc.heightPx, background: '#fff', overflow: 'hidden' }}>
+              {slide.shapes.map((shape, si) => (
+                <ShapeView key={si} shape={shape} url={shape.imageKey ? mediaUrls[shape.imageKey] : undefined} />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/islands/media/LiveCaptions.tsx
+++ b/src/islands/media/LiveCaptions.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { appendFinal } from '@/tools/media/captions.lib';
+import type { Lang } from '@/i18n/config';
+
+interface RecognitionResult { isFinal: boolean; 0: { transcript: string }; }
+interface RecognitionEvent { resultIndex: number; results: { length: number;[i: number]: RecognitionResult }; }
+interface RecognitionLike {
+  continuous: boolean; interimResults: boolean; lang: string;
+  start(): void; stop(): void;
+  onresult: ((e: RecognitionEvent) => void) | null;
+  onerror: ((e: { error: string }) => void) | null;
+  onend: (() => void) | null;
+}
+
+const LANGS = [
+  { id: 'en-US', label: 'English (US)' }, { id: 'en-GB', label: 'English (UK)' },
+  { id: 'id-ID', label: 'Bahasa Indonesia' }, { id: 'es-ES', label: 'Español' },
+  { id: 'fr-FR', label: 'Français' }, { id: 'de-DE', label: 'Deutsch' },
+  { id: 'ja-JP', label: '日本語' }, { id: 'zh-CN', label: '中文' },
+];
+
+const TR: Record<Lang, Record<string, string>> = {
+  en: {
+    intro: 'Large, live captions of what’s spoken — put a laptop on the table so someone hard-of-hearing can follow along.',
+    privacy: 'Privacy note: unlike our other tools, this uses your browser’s built-in speech recognition. In Chrome and Edge that sends microphone audio to the browser’s speech service (e.g. Google) to transcribe. Don’t use it for sensitive conversations.',
+    unsupported: 'Your browser does not support live speech recognition. Try Chrome or Edge on desktop.',
+    language: 'Language', start: 'Start captions', stop: 'Stop', clear: 'Clear',
+    listening: 'Listening…', denied: 'Microphone permission was denied.',
+  },
+  id: {
+    intro: 'Teks langsung berukuran besar dari yang diucapkan — letakkan laptop di meja agar penyandang gangguan pendengaran bisa mengikuti.',
+    privacy: 'Catatan privasi: berbeda dari tool kami lainnya, ini memakai pengenalan suara bawaan browser. Di Chrome dan Edge, audio mikrofon dikirim ke layanan suara browser (mis. Google) untuk ditranskripsi. Jangan gunakan untuk percakapan sensitif.',
+    unsupported: 'Browser Anda tidak mendukung pengenalan suara langsung. Coba Chrome atau Edge di desktop.',
+    language: 'Bahasa', start: 'Mulai teks', stop: 'Berhenti', clear: 'Bersihkan',
+    listening: 'Mendengarkan…', denied: 'Izin mikrofon ditolak.',
+  },
+};
+
+export default function LiveCaptions({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [supported, setSupported] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [language, setLanguage] = useState(lang === 'id' ? 'id-ID' : 'en-US');
+  const [finalText, setFinalText] = useState('');
+  const [interim, setInterim] = useState('');
+  const [error, setError] = useState('');
+  const recRef = useRef<RecognitionLike | null>(null);
+
+  useEffect(() => {
+    const Ctor = (window as unknown as { SpeechRecognition?: new () => RecognitionLike; webkitSpeechRecognition?: new () => RecognitionLike });
+    if (!Ctor.SpeechRecognition && !Ctor.webkitSpeechRecognition) setSupported(false);
+    return () => { recRef.current?.stop(); };
+  }, []);
+
+  const start = () => {
+    const Ctor = (window as unknown as { SpeechRecognition?: new () => RecognitionLike; webkitSpeechRecognition?: new () => RecognitionLike });
+    const Impl = Ctor.SpeechRecognition || Ctor.webkitSpeechRecognition;
+    if (!Impl) { setSupported(false); return; }
+    const rec = new Impl();
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang = language;
+    rec.onresult = (e) => {
+      let interimChunk = '';
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const r = e.results[i];
+        if (r.isFinal) setFinalText(prev => appendFinal(prev, r[0].transcript));
+        else interimChunk += r[0].transcript;
+      }
+      setInterim(interimChunk);
+    };
+    rec.onerror = (ev) => { if (ev.error === 'not-allowed') setError(t.denied); };
+    rec.onend = () => { if (recRef.current) recRef.current.start(); }; // keep going until stopped
+    recRef.current = rec;
+    setError('');
+    try { rec.start(); setRunning(true); } catch { /* already started */ }
+  };
+
+  const stop = () => {
+    const rec = recRef.current;
+    recRef.current = null;
+    rec?.stop();
+    setRunning(false);
+    setInterim('');
+  };
+
+  const clear = () => { setFinalText(''); setInterim(''); };
+
+  if (!supported) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">{t.intro}</p>
+        <Alert variant="error">{t.unsupported}</Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="border-2 border-border bg-yellow-300 p-3 text-sm font-medium text-black shadow-brutal-sm">
+        ⚠️ {t.privacy}
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="space-y-1 text-sm">
+          <span className="block font-semibold">{t.language}</span>
+          <select value={language} onChange={e => setLanguage(e.target.value)} disabled={running}
+            className="border-2 border-border bg-background p-2 text-sm">
+            {LANGS.map(l => <option key={l.id} value={l.id}>{l.label}</option>)}
+          </select>
+        </label>
+        {!running ? <Button onClick={start}>{t.start}</Button> : <Button variant="secondary" onClick={stop}>{t.stop}</Button>}
+        <Button variant="ghost" onClick={clear}>{t.clear}</Button>
+      </div>
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      <div className="min-h-[40vh] rounded border-2 border-border bg-black p-6 text-3xl font-bold leading-snug text-white sm:text-4xl">
+        {finalText} <span className="text-gray-400">{interim}</span>
+        {running && !finalText && !interim && <span className="text-gray-500">{t.listening}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -562,6 +562,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the redaction tool works with no internet connection.' },
     ],
   },
+  'pptx-to-pdf': {
+    title: 'Free PPTX to PDF — Convert PowerPoint to PDF Online',
+    description: 'Convert a PowerPoint (.pptx) to PDF in your browser — one slide per page with real positions, text and images. Free and private; nothing is uploaded.',
+    intro: 'This free PPTX-to-PDF converter turns a PowerPoint presentation into a PDF, one slide per page, laid out with each slide’s real geometry — text, images and positions. It runs entirely in your browser, so your presentation is never uploaded. Slides are rendered to images, so the resulting PDF looks like the slides (the text is not selectable).',
+    howTo: [
+      'Drop your .pptx file to load it.',
+      'Check the slide count.',
+      'Click Convert to PDF.',
+      'Download the PDF — one slide per page.',
+    ],
+    faqs: [
+      { q: 'Is my presentation uploaded?', a: 'No. The .pptx is parsed and rendered to a PDF entirely in your browser, so it never leaves your device.' },
+      { q: 'Is the PDF text selectable?', a: 'No. Each slide is rendered to an image to preserve the layout, so the PDF is a faithful picture of the slides rather than selectable text.' },
+      { q: 'Does it keep images and layout?', a: 'Yes. Slides are laid out with their real positions, text styling and images before being placed on the page.' },
+      { q: 'Does it support .ppt (old format)?', a: 'It converts modern .pptx files. Older binary .ppt files are not supported — save them as .pptx first.' },
+      { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the converter works with no internet connection.' },
+    ],
+  },
   'iwork-viewer': {
     title: 'Free iWork Viewer — Open Pages, Numbers & Keynote on Windows',
     description: 'Open Apple Pages (.pages), Numbers (.numbers) and Keynote (.key) files on any device, including Windows, with no iWork or account. Private — parsed in your browser.',
@@ -2078,6 +2096,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Why does the first run take a while?', a: 'The AI model is downloaded and cached on first use, and larger or \'Better\' models are slower — especially on phones. After the initial download it loads from cache, and transcription runs locally on your device.' },
     ],
   },
+  'live-captions': {
+    title: 'Live Captions — Real-Time Speech-to-Text on a Big Screen',
+    description: 'Show large, live captions of what’s spoken — put a laptop on the table so someone hard-of-hearing can follow a meeting or conversation. Uses your browser’s speech recognition.',
+    intro: 'Live Captions turns spoken words into large, real-time text on your screen — put a laptop or phone on the table in a meeting room so someone hard-of-hearing can follow along. Please note: unlike the rest of GoodWebTools, this relies on your browser’s built-in speech recognition, which in Chrome and Edge sends microphone audio to the browser’s speech service to transcribe. It is not fully on-device, so avoid using it for sensitive conversations.',
+    howTo: [
+      'Choose the spoken language.',
+      'Click Start captions and allow microphone access.',
+      'Read the large live captions as people speak.',
+      'Click Stop when you’re done.',
+    ],
+    faqs: [
+      { q: 'Does this run fully on my device?', a: 'No — and that is different from our other tools. It uses your browser’s speech recognition, which in Chrome and Edge streams microphone audio to the browser’s online speech service (e.g. Google) to transcribe.' },
+      { q: 'Should I use it for private conversations?', a: 'No. Because audio is sent to the browser’s speech service, avoid using it for confidential or sensitive conversations.' },
+      { q: 'Which browsers work?', a: 'Chrome and Edge on desktop support live speech recognition. Safari and Firefox generally do not.' },
+      { q: 'Which languages are supported?', a: 'Several, including English, Bahasa Indonesia, Spanish, French, German, Japanese and Chinese — pick the spoken language before starting.' },
+      { q: 'Is a transcript saved?', a: 'The captions stay on screen until you clear them or leave the page; nothing is stored by us.' },
+    ],
+  },
   'text-to-speech': {
     title: 'Free Text to Speech — Read Any Text Aloud Online',
     description: 'Convert text to speech in your browser using built-in voices. Choose a voice, adjust speed and pitch, and listen instantly. Free, private — nothing is uploaded.',
@@ -2875,6 +2911,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah sensor dibatalkan?', a: 'Tidak. Karena konten dihapus dari berkas, ia tidak bisa dipulihkan dari hasilnya. Simpan berkas asli dan periksa salinan yang disensor sebelum dibagikan.' },
       { q: 'Apakah menyensor gambar juga, bukan hanya teks?', a: 'Ya. Apa pun di bawah kotak — teks, gambar, dan grafik garis/vektor — dihapus, dan kotak hitam dibakar di tempatnya.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat tool sensor bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'pptx-to-pdf': {
+    title: 'PPTX ke PDF Gratis — Konversi PowerPoint ke PDF Online',
+    description: 'Konversi PowerPoint (.pptx) ke PDF di browser Anda — satu slide per halaman dengan posisi, teks, dan gambar aslinya. Gratis dan privat; tidak ada yang diunggah.',
+    intro: 'Konverter PPTX-ke-PDF gratis ini mengubah presentasi PowerPoint menjadi PDF, satu slide per halaman, ditata sesuai geometri asli tiap slide — teks, gambar, dan posisi. Berjalan sepenuhnya di browser Anda, jadi presentasi tidak pernah diunggah. Slide dirender menjadi gambar, sehingga PDF hasilnya tampak seperti slide (teksnya tidak bisa diseleksi).',
+    howTo: [
+      'Letakkan berkas .pptx Anda untuk memuatnya.',
+      'Periksa jumlah slide.',
+      'Klik Konversi ke PDF.',
+      'Unduh PDF — satu slide per halaman.',
+    ],
+    faqs: [
+      { q: 'Apakah presentasi saya diunggah?', a: 'Tidak. Berkas .pptx diurai dan dirender menjadi PDF sepenuhnya di browser Anda, jadi tidak pernah meninggalkan perangkat.' },
+      { q: 'Apakah teks PDF bisa diseleksi?', a: 'Tidak. Tiap slide dirender menjadi gambar untuk mempertahankan tata letak, jadi PDF adalah gambar setia dari slide, bukan teks yang bisa diseleksi.' },
+      { q: 'Apakah gambar dan tata letak dipertahankan?', a: 'Ya. Slide ditata dengan posisi, gaya teks, dan gambar aslinya sebelum ditempatkan di halaman.' },
+      { q: 'Apakah mendukung .ppt (format lama)?', a: 'Mengonversi berkas .pptx modern. Berkas biner .ppt lama tidak didukung — simpan sebagai .pptx dulu.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat konverter bekerja tanpa koneksi internet.' },
     ],
   },
   'iwork-viewer': {
@@ -4391,6 +4445,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah ini mentranskripsi bahasa selain English?', a: 'Ya. Pilih salah satu model multibahasa dan pilih bahasa yang diucapkan — Indonesia, Melayu, Jepang, Spanyol, dan banyak lagi — untuk akurasi terbaik. Deteksi otomatis juga tersedia.' },
       { q: 'Bisakah saya mengekspor subtitle?', a: 'Ya. Buka tab Subtitles dan unduh berkas SRT atau VTT dengan timestamp, atau ambil teks biasa (.txt) atau versi dengan timestamp sebagai gantinya.' },
       { q: 'Mengapa penggunaan pertama memakan waktu?', a: 'Model AI diunduh dan disimpan di cache pada penggunaan pertama, dan model yang lebih besar atau \'Better\' lebih lambat — terutama di ponsel. Setelah unduhan awal, ia dimuat dari cache, dan transkripsi berjalan secara lokal di perangkat Anda.' },
+    ],
+  },
+  'live-captions': {
+    title: 'Teks Langsung (Live Captions) — Ucapan ke Teks Real-Time Layar Besar',
+    description: 'Tampilkan teks langsung berukuran besar dari yang diucapkan — letakkan laptop di meja agar penyandang gangguan pendengaran bisa mengikuti rapat. Memakai pengenalan suara browser.',
+    intro: 'Live Captions mengubah kata yang diucapkan menjadi teks besar secara real-time di layar Anda — letakkan laptop atau ponsel di meja ruang rapat agar penyandang gangguan pendengaran bisa mengikuti. Perlu diketahui: berbeda dari tool GoodWebTools lainnya, ini mengandalkan pengenalan suara bawaan browser, yang di Chrome dan Edge mengirim audio mikrofon ke layanan suara browser untuk ditranskripsi. Ini tidak sepenuhnya di perangkat, jadi hindari untuk percakapan sensitif.',
+    howTo: [
+      'Pilih bahasa yang diucapkan.',
+      'Klik Mulai teks dan izinkan akses mikrofon.',
+      'Baca teks langsung berukuran besar saat orang berbicara.',
+      'Klik Berhenti saat selesai.',
+    ],
+    faqs: [
+      { q: 'Apakah ini berjalan sepenuhnya di perangkat saya?', a: 'Tidak — dan ini berbeda dari tool kami lainnya. Ini memakai pengenalan suara browser, yang di Chrome dan Edge mengalirkan audio mikrofon ke layanan suara daring browser (mis. Google) untuk ditranskripsi.' },
+      { q: 'Apakah boleh dipakai untuk percakapan pribadi?', a: 'Tidak. Karena audio dikirim ke layanan suara browser, hindari memakainya untuk percakapan rahasia atau sensitif.' },
+      { q: 'Browser apa yang bisa?', a: 'Chrome dan Edge di desktop mendukung pengenalan suara langsung. Safari dan Firefox umumnya tidak.' },
+      { q: 'Bahasa apa yang didukung?', a: 'Beberapa, termasuk Inggris, Bahasa Indonesia, Spanyol, Prancis, Jerman, Jepang, dan Mandarin — pilih bahasa yang diucapkan sebelum memulai.' },
+      { q: 'Apakah transkrip disimpan?', a: 'Teks tetap di layar sampai Anda bersihkan atau meninggalkan halaman; tidak ada yang kami simpan.' },
     ],
   },
   'text-to-speech': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -290,6 +290,17 @@ export const tools: ToolDef[] = [
     status: 'beta'
   },
   {
+    id: 'pptx-to-pdf',
+    name: 'PPTX to PDF',
+    category: 'Documents',
+    route: '/tools/pptx-to-pdf',
+    keywords: ['pptx to pdf', 'powerpoint to pdf', 'ppt to pdf', 'convert', 'slides to pdf', 'presentation', 'pptx ke pdf'],
+    icon: FileOutput,
+    summary: 'Convert PowerPoint slides (.pptx) to a PDF',
+    load: () => import('@/islands/documents/PptxToPdf'),
+    status: 'beta'
+  },
+  {
     id: 'gedcom-viewer',
     name: 'GEDCOM Viewer',
     category: 'Documents',
@@ -1365,6 +1376,17 @@ export const tools: ToolDef[] = [
     icon: Speech,
     summary: 'Read text aloud with your browser’s built-in voices',
     load: () => import('@/islands/media/TextToSpeech'),
+    status: 'beta'
+  },
+  {
+    id: 'live-captions',
+    name: 'Live Captions',
+    category: 'Media',
+    route: '/tools/live-captions',
+    keywords: ['live captions', 'captions', 'subtitles', 'speech to text', 'accessibility', 'hard of hearing', 'teks langsung', 'transkrip langsung'],
+    icon: Subtitles,
+    summary: 'Large live captions of spoken speech (uses browser speech recognition)',
+    load: () => import('@/islands/media/LiveCaptions'),
     status: 'beta'
   },
   {

--- a/src/tools/media/captions.lib.test.ts
+++ b/src/tools/media/captions.lib.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { appendFinal, trimToMaxChars } from './captions.lib';
+
+describe('appendFinal', () => {
+  it('joins chunks with a single space', () => {
+    expect(appendFinal('Hello', 'world')).toBe('Hello world');
+  });
+  it('starts fresh from an empty buffer', () => {
+    expect(appendFinal('', 'Hi there')).toBe('Hi there');
+  });
+  it('ignores empty/whitespace chunks', () => {
+    expect(appendFinal('Hello', '   ')).toBe('Hello');
+  });
+});
+
+describe('trimToMaxChars', () => {
+  it('keeps text under the limit unchanged', () => {
+    expect(trimToMaxChars('short text', 100)).toBe('short text');
+  });
+  it('keeps only the tail when over the limit, breaking on a word', () => {
+    const out = trimToMaxChars('one two three four five', 12);
+    expect(out.length).toBeLessThanOrEqual(12);
+    expect('one two three four five'.endsWith(out)).toBe(true);
+    expect(out.startsWith(' ')).toBe(false);
+  });
+});

--- a/src/tools/media/captions.lib.ts
+++ b/src/tools/media/captions.lib.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure caption-buffer helpers for the live-captions tool. The speech recognition
+ * itself (browser Web Speech API) lives in the island; this manages the rolling
+ * transcript text. No I/O.
+ */
+
+/** Append a finalized chunk to the running transcript, ignoring empty chunks. */
+export function appendFinal(buffer: string, chunk: string): string {
+  const c = chunk.trim();
+  if (!c) return buffer;
+  return buffer ? `${buffer} ${c}` : c;
+}
+
+/** Keep only the last `maxChars` characters, trimmed to a word boundary. */
+export function trimToMaxChars(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const tail = text.slice(text.length - maxChars);
+  const space = tail.indexOf(' ');
+  return space >= 0 ? tail.slice(space + 1) : tail;
+}


### PR DESCRIPTION
Final two tools of the batch.

**Live Captions** (`/tools/live-captions`, Media)
- Large real-time speech-to-text (put a laptop on the table for someone hard-of-hearing). Uses the browser Web Speech API.
- **Prominent privacy disclaimer**: unlike the rest of the site, Chrome/Edge stream mic audio to their speech service — clearly stated in a banner and the SEO/FAQ. Pure `captions.lib.ts` buffer helpers unit-tested (5 tests).

**PPTX to PDF** (`/tools/pptx-to-pdf`, Documents)
- Convert .pptx → PDF, one slide per page, reusing the geometry-aware slide render captured with **html2canvas** (already a dep) into pdf-lib. Raster output (text not selectable), noted in-UI.

Verify: 1316 tests green, lint 0 errors, build OK; both tools' EN+ID pages built.