### PR TITLE
feat(dev): Barcode Scanner — decode 1D & 2D codes from camera or image

### DIFF
--- a/src/islands/dev/BarcodeScanner.tsx
+++ b/src/islands/dev/BarcodeScanner.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from 'react';
+import { ScanBarcode, Camera, Square } from 'lucide-react';
+import { Dropzone } from '@/components/ui/Dropzone';
+import { Button } from '@/components/ui/Button';
+import { Alert } from '@/components/ui/Alert';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { usePasteImage } from '@/hooks/usePasteImage';
+import { decodeBarcodeFromFile, decodeWithDetector, decodeWithZxing, formatKind, type BarcodeResult } from '@/tools/dev/barcode.lib';
+import type { Lang } from '@/i18n/config';
+
+type Mode = 'upload' | 'camera';
+
+const TR: Record<Lang, {
+  intro: string; upload: string; camera: string; drop: string; dropSub: string;
+  start: string; stop: string; scanning: string; result: string; format: string; none: string; again: string;
+  errRead: string; errCam: string;
+}> = {
+  en: {
+    intro: 'Scan and decode barcodes and QR codes — EAN, UPC, Code 128/39, ITF, QR, Data Matrix, PDF417, Aztec and more — from your camera or an uploaded image. Everything is decoded in your browser; nothing is uploaded.',
+    upload: 'Upload / paste', camera: 'Camera',
+    drop: 'Drop a barcode image or click to browse', dropSub: 'Decoded in your browser · or paste (⌘V)',
+    start: 'Start camera', stop: 'Stop', scanning: 'Point a barcode at the camera…',
+    result: 'Decoded value', format: 'Format', none: 'No barcode found in this image.', again: 'Scan again',
+    errRead: 'Could not read the image file.', errCam: 'Camera access was blocked. Allow it and try again, or use Upload.',
+  },
+  id: {
+    intro: 'Pindai dan dekode barcode serta kode QR — EAN, UPC, Code 128/39, ITF, QR, Data Matrix, PDF417, Aztec, dan lainnya — dari kamera atau gambar yang diunggah. Semuanya didekode di browser Anda; tidak ada yang diunggah.',
+    upload: 'Unggah / tempel', camera: 'Kamera',
+    drop: 'Letakkan gambar barcode atau klik untuk menelusuri', dropSub: 'Didekode di browser Anda · atau tempel (⌘V)',
+    start: 'Mulai kamera', stop: 'Berhenti', scanning: 'Arahkan barcode ke kamera…',
+    result: 'Nilai hasil dekode', format: 'Format', none: 'Tidak ada barcode ditemukan pada gambar ini.', again: 'Pindai lagi',
+    errRead: 'Tidak dapat membaca file gambar.', errCam: 'Akses kamera diblokir. Izinkan lalu coba lagi, atau gunakan Unggah.',
+  },
+};
+
+export default function BarcodeScanner({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [mode, setMode] = useState<Mode>('upload');
+  const [result, setResult] = useState<BarcodeResult | null>(null);
+  const [error, setError] = useState('');
+  const [scanning, setScanning] = useState(false);
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const busyRef = useRef(false);
+
+  const stopCamera = () => {
+    if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+    streamRef.current?.getTracks().forEach(tr => tr.stop());
+    streamRef.current = null;
+    if (videoRef.current) videoRef.current.srcObject = null;
+    setScanning(false);
+  };
+
+  useEffect(() => stopCamera, []);
+  // Leaving camera mode releases the stream.
+  useEffect(() => { if (mode !== 'camera') stopCamera(); }, [mode]);
+
+  const handleFile = async (files: File[]) => {
+    setError(''); setResult(null);
+    if (!files.length) return;
+    try {
+      const r = await decodeBarcodeFromFile(files[0]);
+      if (r) setResult(r); else setError(t.none);
+    } catch {
+      setError(t.errRead);
+    }
+  };
+
+  usePasteImage(file => { if (mode === 'upload') handleFile([file]); });
+
+  const scanFrame = async () => {
+    const video = videoRef.current;
+    if (!video || video.readyState < 2 || busyRef.current) return;
+    busyRef.current = true;
+    try {
+      let r = await decodeWithDetector(video);
+      if (!r) {
+        // Fallback for browsers without BarcodeDetector (e.g. iOS Safari): grab a
+        // frame and run zxing-wasm on it.
+        const canvas = canvasRef.current ?? document.createElement('canvas');
+        canvasRef.current = canvas;
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext('2d');
+        if (ctx && canvas.width) {
+          ctx.drawImage(video, 0, 0);
+          const blob = await new Promise<Blob | null>(res => canvas.toBlob(b => res(b), 'image/png'));
+          if (blob) r = await decodeWithZxing(blob);
+        }
+      }
+      if (r) { setResult(r); stopCamera(); }
+    } finally {
+      busyRef.current = false;
+    }
+  };
+
+  const startCamera = async () => {
+    setError(''); setResult(null);
+    stopCamera();
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play().catch(() => {});
+      }
+      setScanning(true);
+      timerRef.current = setInterval(scanFrame, 350);
+    } catch {
+      setError(t.errCam);
+      setScanning(false);
+    }
+  };
+
+  const isUrl = result && /^https?:\/\//i.test(result.text);
+
+  const resultBlock = result && (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          {t.result}
+          <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold text-accent">{result.format} · {formatKind(result.format)}</span>
+        </span>
+        <CopyButton value={result.text} />
+      </div>
+      <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm break-all">
+        {isUrl
+          ? <a href={result.text} target="_blank" rel="noopener noreferrer" className="text-accent underline">{result.text}</a>
+          : <code>{result.text}</code>}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+
+      <div className="flex gap-2">
+        <Button variant={mode === 'upload' ? 'primary' : 'secondary'} onClick={() => setMode('upload')}><ScanBarcode className="h-4 w-4" /> {t.upload}</Button>
+        <Button variant={mode === 'camera' ? 'primary' : 'secondary'} onClick={() => setMode('camera')}><Camera className="h-4 w-4" /> {t.camera}</Button>
+      </div>
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {mode === 'upload' ? (
+        <Dropzone onDrop={handleFile} accept="image/*" multiple={false}>
+          <div className="space-y-2">
+            <p className="flex items-center justify-center gap-2 text-lg font-bold"><ScanBarcode className="h-5 w-5" /> {t.drop}</p>
+            <p className="text-sm text-muted-foreground">{t.dropSub}</p>
+          </div>
+        </Dropzone>
+      ) : (
+        <div className="space-y-2">
+          <div className="overflow-hidden rounded-lg border-2 border-border bg-black">
+            <video ref={videoRef} playsInline muted className="mx-auto block max-h-[60vh] w-auto max-w-full" style={{ minHeight: scanning ? undefined : 0 }} />
+          </div>
+          <div className="flex items-center gap-2">
+            {!scanning
+              ? <Button onClick={startCamera}><Camera className="h-4 w-4" /> {t.start}</Button>
+              : <Button variant="ghost" onClick={stopCamera}><Square className="h-4 w-4" /> {t.stop}</Button>}
+            {scanning && <span className="text-sm text-muted-foreground">{t.scanning}</span>}
+          </div>
+        </div>
+      )}
+
+      {resultBlock}
+
+      {result && mode === 'camera' && !scanning && (
+        <Button variant="secondary" onClick={startCamera}>{t.again}</Button>
+      )}
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1593,6 +1593,23 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'Does it work offline?', a: 'Yes. GoodWebTools is a PWA, so once loaded the converter works with no internet connection.' },
     ],
   },
+  'barcode-scanner': {
+    title: 'Free Barcode Scanner — Scan EAN, UPC, Code 128, QR & More',
+    description: 'Scan and decode barcodes and QR codes online — EAN, UPC, Code 128/39, ITF, QR, Data Matrix, PDF417, Aztec — from your camera or an image. In your browser, nothing uploaded.',
+    intro: 'This free barcode scanner reads and decodes 1D barcodes (EAN-13, UPC-A, Code 128, Code 39, ITF and more) and 2D codes (QR, Data Matrix, PDF417, Aztec) from your camera or an uploaded image, showing the decoded value and the barcode format. Everything is decoded in your browser — nothing is uploaded.',
+    howTo: [
+      'Choose Camera to scan live, or Upload / paste to decode an image.',
+      'For camera, allow access and point a barcode at the lens — it decodes automatically.',
+      'For upload, drop or paste a photo or screenshot of the barcode.',
+      'Copy the decoded value; the detected format (e.g. EAN-13) is shown beside it.',
+    ],
+    faqs: [
+      { q: 'Which barcode formats are supported?', a: 'Common 1D formats (EAN-13/8, UPC-A/E, Code 128, Code 39, Code 93, ITF, Codabar, DataBar) and 2D formats (QR Code, Data Matrix, PDF417, Aztec).' },
+      { q: 'Is the image or camera uploaded?', a: 'No. Decoding runs entirely in your browser using an on-device engine; your camera frames and images never leave your device.' },
+      { q: 'Why can’t my camera scan on iPhone?', a: 'Some browsers lack the native BarcodeDetector; the scanner automatically falls back to an on-device wasm decoder, which is a little slower — hold the code steady and well-lit.' },
+      { q: 'Does it work offline?', a: 'Yes. As a PWA it keeps scanning with no connection once loaded (the decoder is cached on first use).' },
+    ],
+  },
   'barcode-generator': {
     title: 'Free Barcode Generator — Code 128, EAN, UPC & More (PNG/SVG)',
     description: 'Generate barcodes online — Code 128, EAN-13, EAN-8, UPC, Code 39, ITF and more — and download as PNG or SVG. Free and private; everything renders in your browser.',
@@ -4404,6 +4421,23 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Bisakah membuat berkas BRF untuk embosser?', a: 'Belum — keluarannya adalah teks braille Unicode untuk tampilan layar dan penyalinan, bukan berkas BRF siap embosser.' },
       { q: 'Apakah teks saya diunggah?', a: 'Tidak. Konversi berjalan sepenuhnya di browser Anda; teks Anda tidak pernah meninggalkan perangkat.' },
       { q: 'Apakah bekerja offline?', a: 'Ya. GoodWebTools adalah PWA, jadi setelah dimuat konverter bekerja tanpa koneksi internet.' },
+    ],
+  },
+  'barcode-scanner': {
+    title: 'Pemindai Barcode Gratis — Pindai EAN, UPC, Code 128, QR & Lainnya',
+    description: 'Pindai dan dekode barcode serta kode QR online — EAN, UPC, Code 128/39, ITF, QR, Data Matrix, PDF417, Aztec — dari kamera atau gambar. Di browser Anda, tanpa unggahan.',
+    intro: 'Tool pemindai barcode gratis ini membaca dan mendekode barcode 1D (EAN-13, UPC-A, Code 128, Code 39, ITF, dan lainnya) serta kode 2D (QR, Data Matrix, PDF417, Aztec) dari kamera atau gambar yang diunggah, menampilkan nilai hasil dekode dan format barcode-nya. Semuanya didekode di browser Anda — tidak ada yang diunggah.',
+    howTo: [
+      'Pilih Kamera untuk memindai langsung, atau Unggah / tempel untuk mendekode gambar.',
+      'Untuk kamera, izinkan akses dan arahkan barcode ke lensa — didekode otomatis.',
+      'Untuk unggah, letakkan atau tempel foto atau tangkapan layar barcode.',
+      'Salin nilai hasil dekode; format yang terdeteksi (mis. EAN-13) ditampilkan di sampingnya.',
+    ],
+    faqs: [
+      { q: 'Format barcode apa saja yang didukung?', a: 'Format 1D umum (EAN-13/8, UPC-A/E, Code 128, Code 39, Code 93, ITF, Codabar, DataBar) dan format 2D (QR Code, Data Matrix, PDF417, Aztec).' },
+      { q: 'Apakah gambar atau kamera diunggah?', a: 'Tidak. Pendekodean berjalan sepenuhnya di browser Anda memakai mesin di perangkat; frame kamera dan gambar Anda tidak pernah meninggalkan perangkat.' },
+      { q: 'Kenapa kamera saya tidak bisa memindai di iPhone?', a: 'Sebagian browser tidak punya BarcodeDetector bawaan; pemindai otomatis beralih ke dekoder wasm di perangkat, yang sedikit lebih lambat — tahan barcode agar stabil dan terang.' },
+      { q: 'Apakah bekerja offline?', a: 'Ya. Sebagai PWA tetap memindai tanpa koneksi setelah dimuat (dekoder di-cache saat pertama dipakai).' },
     ],
   },
   'barcode-generator': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan, Activity, Grid3x3, Bird, ServerCog, Pilcrow, MonitorSmartphone, Volume2, Monitor, MousePointerClick, ListChecks, Landmark, Hourglass, Globe, Smile, StickyNote, Waves, Music4 } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan, Activity, Grid3x3, Bird, ServerCog, Pilcrow, MonitorSmartphone, Volume2, Monitor, MousePointerClick, ListChecks, Landmark, Hourglass, Globe, Smile, StickyNote, Waves, Music4, ScanBarcode } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -981,6 +981,17 @@ export const tools: ToolDef[] = [
     summary: 'Decode a QR code from an image',
     load: () => import('@/islands/dev/QrRead'),
     status: 'stable'
+  },
+  {
+    id: 'barcode-scanner',
+    name: 'Barcode Scanner',
+    category: 'Dev',
+    route: '/tools/barcode-scanner',
+    keywords: ['barcode scanner', 'barcode reader', 'scan barcode', 'ean', 'upc', 'code 128', 'qr', 'data matrix', 'pdf417', 'decode barcode'],
+    icon: ScanBarcode,
+    summary: 'Scan & decode barcodes and QR codes from camera or image',
+    load: () => import('@/islands/dev/BarcodeScanner'),
+    status: 'beta'
   },
   {
     id: 'barcode-generator',

--- a/src/tools/dev/barcode.lib.test.ts
+++ b/src/tools/dev/barcode.lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFormat, formatKind, ZXING_FORMATS } from './barcode.lib';
+
+describe('barcode format helpers', () => {
+  it('normalises zxing format names', () => {
+    expect(normalizeFormat('EAN-13')).toBe('EAN-13');
+    expect(normalizeFormat('Code128')).toBe('Code 128');
+    expect(normalizeFormat('DataMatrix')).toBe('Data Matrix');
+    expect(normalizeFormat('QRCode')).toBe('QR Code');
+  });
+
+  it('normalises BarcodeDetector snake_case names', () => {
+    expect(normalizeFormat('ean_13')).toBe('EAN-13');
+    expect(normalizeFormat('code_128')).toBe('Code 128');
+    expect(normalizeFormat('data_matrix')).toBe('Data Matrix');
+    expect(normalizeFormat('qr_code')).toBe('QR Code');
+    expect(normalizeFormat('upc_a')).toBe('UPC-A');
+  });
+
+  it('falls back to the raw value for unknown formats', () => {
+    expect(normalizeFormat('SomethingNew')).toBe('SomethingNew');
+    expect(normalizeFormat('')).toBe('Unknown');
+  });
+
+  it('classifies 1D vs 2D', () => {
+    expect(formatKind('EAN-13')).toBe('1D');
+    expect(formatKind('Code 128')).toBe('1D');
+    expect(formatKind('QR Code')).toBe('2D');
+    expect(formatKind('PDF417')).toBe('2D');
+    expect(formatKind('Data Matrix')).toBe('2D');
+    expect(formatKind('Aztec')).toBe('2D');
+  });
+
+  it('requests a broad set of formats from zxing', () => {
+    expect(ZXING_FORMATS).toContain('EAN-13');
+    expect(ZXING_FORMATS).toContain('Code128');
+    expect(ZXING_FORMATS).toContain('QRCode');
+    expect(ZXING_FORMATS).toContain('PDF417');
+  });
+});

--- a/src/tools/dev/barcode.lib.ts
+++ b/src/tools/dev/barcode.lib.ts
@@ -1,0 +1,103 @@
+/**
+ * Multi-format barcode decoding from an image File or a live camera frame.
+ * Reuses the same pipeline as the QR reader — native BarcodeDetector first
+ * (fast, no download), then zxing-wasm (ZXing C++ → wasm, robust everywhere,
+ * served same-origin from /zxing_reader.wasm) — but for every 1D and 2D format.
+ *
+ * The decode functions are browser-only (they touch canvas / wasm); the format
+ * helpers are pure and unit-tested.
+ */
+
+export interface BarcodeResult {
+  text: string;
+  format: string; // friendly, normalised (e.g. 'EAN-13', 'Code 128', 'QR Code')
+}
+
+/** Formats requested from zxing-wasm (its BarcodeFormat spelling). */
+export const ZXING_FORMATS = [
+  'Aztec', 'Codabar', 'Code128', 'Code39', 'Code93', 'DataBar', 'DataBarExpanded',
+  'DataMatrix', 'EAN-13', 'EAN-8', 'ITF', 'MaxiCode', 'PDF417', 'QRCode',
+  'MicroQRCode', 'UPC-A', 'UPC-E',
+] as const;
+
+const FRIENDLY: Record<string, string> = {
+  ean13: 'EAN-13', ean8: 'EAN-8', upca: 'UPC-A', upce: 'UPC-E',
+  code128: 'Code 128', code39: 'Code 39', code93: 'Code 93',
+  itf: 'ITF', codabar: 'Codabar',
+  databar: 'DataBar', databarexpanded: 'DataBar Expanded',
+  datamatrix: 'Data Matrix', pdf417: 'PDF417', aztec: 'Aztec',
+  qrcode: 'QR Code', microqrcode: 'Micro QR', maxicode: 'MaxiCode',
+};
+
+const TWO_D = new Set(['QR Code', 'Micro QR', 'Data Matrix', 'PDF417', 'Aztec', 'MaxiCode']);
+
+/**
+ * Normalise a raw format name from either BarcodeDetector ('ean_13') or
+ * zxing-wasm ('EAN-13') into a single friendly label.
+ */
+export function normalizeFormat(raw: string): string {
+  if (!raw) return 'Unknown';
+  const key = raw.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return FRIENDLY[key] ?? raw;
+}
+
+/** Whether a friendly format is a 2D (matrix) code rather than a 1D barcode. */
+export function formatKind(friendly: string): '1D' | '2D' {
+  return TWO_D.has(friendly) ? '2D' : '1D';
+}
+
+/* ------------------------------------------------------------------ *
+ * Browser-only decoders (dynamic-import the wasm so the chunk stays small)
+ * ------------------------------------------------------------------ */
+
+interface DetectedBarcode { rawValue: string; format?: string }
+interface BarcodeDetectorLike { detect(source: CanvasImageSource): Promise<DetectedBarcode[]> }
+type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => BarcodeDetectorLike;
+
+/** Decode with the native BarcodeDetector (all supported formats), or null. */
+export async function decodeWithDetector(source: CanvasImageSource): Promise<BarcodeResult | null> {
+  const Ctor = (globalThis as { BarcodeDetector?: BarcodeDetectorCtor }).BarcodeDetector;
+  if (!Ctor) return null;
+  try {
+    const codes = await new Ctor().detect(source);
+    const hit = codes[0];
+    if (!hit?.rawValue) return null;
+    return { text: hit.rawValue, format: normalizeFormat(hit.format ?? '') };
+  } catch {
+    return null;
+  }
+}
+
+/** Decode with zxing-wasm (all formats, tryHarder), or null. */
+export async function decodeWithZxing(input: Blob): Promise<BarcodeResult | null> {
+  try {
+    const { readBarcodes, prepareZXingModule } = await import('zxing-wasm/reader');
+    prepareZXingModule({
+      overrides: {
+        locateFile: (path: string, prefix: string) =>
+          path.endsWith('.wasm') ? '/zxing_reader.wasm' : prefix + path,
+      },
+    });
+    const results = await readBarcodes(input, {
+      formats: [...ZXING_FORMATS],
+      tryHarder: true,
+      maxNumberOfSymbols: 1,
+    });
+    const hit = results[0];
+    if (!hit?.text) return null;
+    return { text: hit.text, format: normalizeFormat(hit.format ?? '') };
+  } catch {
+    return null;
+  }
+}
+
+/** Decode the first barcode found in an image File, or null. Browser-only. */
+export async function decodeBarcodeFromFile(file: File): Promise<BarcodeResult | null> {
+  let bitmap: ImageBitmap | null = null;
+  try {
+    bitmap = await createImageBitmap(file);
+    return (await decodeWithDetector(bitmap)) ?? (await decodeWithZxing(file));
+  } finally {
+    bitmap?.close?.();
+  }
+}


### PR DESCRIPTION
Adds a **Barcode Scanner** to the Dev category (`/tools/barcode-scanner`).

- **Camera mode** — live scan (rear camera), decodes automatically.
- **Upload / paste mode** — decode a photo or screenshot.
- Formats: EAN-13/8, UPC-A/E, Code 128/39/93, ITF, Codabar, DataBar (1D) and QR, Data Matrix, PDF417, Aztec (2D). Shows the decoded value + detected format.

Reuses the QR reader's pipeline — native `BarcodeDetector` first, then `zxing-wasm` (served same-origin from `/zxing_reader.wasm`) — generalised to all formats, with a per-frame zxing fallback for browsers without BarcodeDetector (e.g. iOS Safari). All client-side; camera frames and images never leave the device.

Pure format-normalisation lib is unit-tested (5 tests); thin island. EN + ID SEO.

- Tests: full suite **1532 passing**
- Lint: 0 errors
- Build: both `/tools/barcode-scanner/` pages built, no new precache warning (zxing already cached)