### PR TITLE
feat(games): fullscreen expand for 2048 and Flying Bird

### DIFF
--- a/src/hooks/useExpand.test.ts
+++ b/src/hooks/useExpand.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useExpand } from './useExpand';
+
+describe('useExpand', () => {
+  it('starts collapsed', () => {
+    const { result } = renderHook(() => useExpand());
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it('enter() expands (overlay fallback when Fullscreen API is unavailable)', () => {
+    const { result } = renderHook(() => useExpand());
+    act(() => result.current.enter());
+    expect(result.current.expanded).toBe(true);
+  });
+
+  it('exit() collapses', () => {
+    const { result } = renderHook(() => useExpand());
+    act(() => result.current.enter());
+    act(() => result.current.exit());
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it('Escape collapses while expanded', () => {
+    const { result } = renderHook(() => useExpand());
+    act(() => result.current.enter());
+    act(() => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it('Escape does nothing when already collapsed', () => {
+    const { result } = renderHook(() => useExpand());
+    act(() => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(result.current.expanded).toBe(false);
+  });
+});

--- a/src/hooks/useExpand.ts
+++ b/src/hooks/useExpand.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Expand a tool area to fill the screen (games, canvases). Tries the native
+ * Fullscreen API first — on Android that hides the browser chrome entirely —
+ * and falls back to a CSS fixed overlay driven by the returned `expanded`
+ * flag (iOS Safari has no element fullscreen). Esc and native fullscreen
+ * exit both collapse the state.
+ */
+export function useExpand<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const enter = useCallback(() => {
+    setExpanded(true);
+    ref.current?.requestFullscreen?.().catch(() => { /* overlay fallback */ });
+  }, []);
+
+  const exit = useCallback(() => {
+    setExpanded(false);
+    if (typeof document !== 'undefined' && document.fullscreenElement) {
+      document.exitFullscreen().catch(() => { /* already exited */ });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!expanded) return;
+    // Leaving native fullscreen (Esc, back gesture) must also collapse the UI.
+    const onFsChange = () => { if (!document.fullscreenElement) setExpanded(false); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') exit(); };
+    document.addEventListener('fullscreenchange', onFsChange);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('fullscreenchange', onFsChange);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [expanded, exit]);
+
+  return { ref, expanded, enter, exit };
+}

--- a/src/islands/games/FlappyBird.tsx
+++ b/src/islands/games/FlappyBird.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
+import { Maximize2, Minimize2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { useExpand } from '@/hooks/useExpand';
 import { stepBird, outOfBounds, hitsPipe, type Pipe } from '@/tools/games/flappy.lib';
 import type { Lang } from '@/i18n/config';
 
@@ -6,10 +9,12 @@ const TR: Record<Lang, Record<string, string>> = {
   en: {
     intro: 'A flappy-bird style game. Click, tap or press Space to flap and fly through the gaps. How far can you get?',
     ready: 'Tap / Space to start', dead: 'Game over', best: 'Best', restart: 'Tap to restart',
+    expand: 'Expand', exit: 'Exit',
   },
   id: {
     intro: 'Game bergaya flappy bird. Klik, ketuk, atau tekan Spasi untuk mengepak dan terbang melewati celah. Sejauh apa Anda bisa?',
     ready: 'Ketuk / Spasi untuk mulai', dead: 'Permainan selesai', best: 'Terbaik', restart: 'Ketuk untuk ulang',
+    expand: 'Perbesar', exit: 'Keluar',
   },
 };
 
@@ -24,6 +29,7 @@ function initial(): GameState { return { phase: 'ready', y: H / 2, v: 0, pipes: 
 
 export default function FlappyBird({ lang = 'en' }: { lang?: Lang }) {
   const t = TR[lang] ?? TR.en;
+  const { ref: stageRef, expanded, enter, exit } = useExpand<HTMLDivElement>();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const g = useRef<GameState>(initial());
   const [best, setBest] = useState(0);
@@ -123,23 +129,44 @@ export default function FlappyBird({ lang = 'en' }: { lang?: Lang }) {
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">{t.intro}</p>
 
-      <div className="relative mx-auto w-full max-w-[360px]">
-        <canvas
-          ref={canvasRef}
-          width={W}
-          height={H}
-          onPointerDown={e => { e.preventDefault(); flap(); }}
-          className="w-full cursor-pointer touch-none select-none border-2 border-border"
-          style={{ imageRendering: 'auto' }}
-        />
-        {phase !== 'playing' && (
-          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 text-center text-white">
-            <div className="rounded bg-black/60 px-4 py-2">
-              <div className="text-lg font-black">{phase === 'dead' ? t.dead : t.ready}</div>
-              {phase === 'dead' && <div className="text-sm">{t.best}: {best} · {t.restart}</div>}
+      {/* Stage: normal flow, or a fullscreen overlay (native fullscreen on
+          Android, CSS overlay fallback on iOS) for comfortable mobile play. */}
+      <div
+        ref={stageRef}
+        className={expanded
+          ? 'fixed inset-0 z-[60] flex flex-col items-center justify-center gap-3 overflow-hidden bg-background p-3'
+          : 'space-y-3'}
+      >
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <div className="border-2 border-border px-3 py-1 text-sm"><span className="text-muted-foreground">{t.best}:</span> <span className="font-black tabular-nums">{best}</span></div>
+          <Button
+            variant="secondary"
+            onClick={e => { e.currentTarget.blur(); if (expanded) exit(); else enter(); }}
+          >
+            {expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            {expanded ? t.exit : t.expand}
+          </Button>
+        </div>
+
+        {/* Expanded: height-driven sizing; 2:3 aspect keeps width ≤ ~92vw. */}
+        <div className={expanded ? 'relative aspect-[2/3] h-[min(85vh,138vw)]' : 'relative mx-auto w-full max-w-[360px]'}>
+          <canvas
+            ref={canvasRef}
+            width={W}
+            height={H}
+            onPointerDown={e => { e.preventDefault(); flap(); }}
+            className={`cursor-pointer touch-none select-none border-2 border-border ${expanded ? 'h-full w-full' : 'w-full'}`}
+            style={{ imageRendering: 'auto' }}
+          />
+          {phase !== 'playing' && (
+            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 text-center text-white">
+              <div className="rounded bg-black/60 px-4 py-2">
+                <div className="text-lg font-black">{phase === 'dead' ? t.dead : t.ready}</div>
+                {phase === 'dead' && <div className="text-sm">{t.best}: {best} · {t.restart}</div>}
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/islands/games/Game2048.tsx
+++ b/src/islands/games/Game2048.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Maximize2, Minimize2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
+import { useExpand } from '@/hooks/useExpand';
 import { move, emptyCells, emptyGrid, hasMoves, maxTile, bestMove, type Grid, type Direction } from '@/tools/games/game2048.lib';
 import type { Lang } from '@/i18n/config';
 
@@ -7,12 +9,12 @@ const TR: Record<Lang, Record<string, string>> = {
   en: {
     intro: 'Play 2048 — combine tiles to reach 2048. Use arrow keys or swipe. Includes cheats: Undo and an Auto-play that simulates the best moves for you.',
     score: 'Score', newGame: 'New game', undo: 'Undo', auto: 'Auto-play (cheat)', stop: 'Stop', won: 'You made 2048! 🎉', over: 'Game over', keepGoing: 'Keep going',
-    hint: 'Arrow keys or swipe to move.',
+    hint: 'Arrow keys or swipe to move.', expand: 'Expand', exit: 'Exit',
   },
   id: {
     intro: 'Main 2048 — gabungkan ubin untuk mencapai 2048. Pakai tombol panah atau geser. Termasuk cheat: Urungkan dan Auto-play yang mensimulasikan langkah terbaik untuk Anda.',
     score: 'Skor', newGame: 'Main baru', undo: 'Urungkan', auto: 'Auto-play (cheat)', stop: 'Berhenti', won: 'Anda mencapai 2048! 🎉', over: 'Permainan selesai', keepGoing: 'Lanjutkan',
-    hint: 'Tombol panah atau geser untuk bergerak.',
+    hint: 'Tombol panah atau geser untuk bergerak.', expand: 'Perbesar', exit: 'Keluar',
   },
 };
 
@@ -38,6 +40,7 @@ function fresh(): Grid { return spawn(spawn(emptyGrid())); }
 
 export default function Game2048({ lang = 'en' }: { lang?: Lang }) {
   const t = TR[lang] ?? TR.en;
+  const { ref: stageRef, expanded, enter, exit } = useExpand<HTMLDivElement>();
   const [grid, setGrid] = useState<Grid>(fresh);
   const [score, setScore] = useState(0);
   const [won, setWon] = useState(false);
@@ -107,14 +110,29 @@ export default function Game2048({ lang = 'en' }: { lang?: Lang }) {
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">{t.intro}</p>
 
-      <div className="flex flex-wrap items-center gap-3">
+      {/* Stage: normal flow, or a fullscreen overlay (native fullscreen on
+          Android, CSS overlay fallback on iOS) for comfortable mobile play. */}
+      <div
+        ref={stageRef}
+        className={expanded
+          ? 'fixed inset-0 z-[60] flex flex-col items-center justify-center gap-4 overflow-hidden bg-background p-4'
+          : 'space-y-4'}
+      >
+      <div className="flex flex-wrap items-center justify-center gap-3">
         <div className="border-2 border-border px-3 py-1 text-sm"><span className="text-muted-foreground">{t.score}:</span> <span className="font-black tabular-nums">{score}</span></div>
         <Button onClick={newGame}>{t.newGame}</Button>
         <Button variant="secondary" onClick={undo} disabled={!history.length}>{t.undo}</Button>
         <Button variant={auto ? 'ghost' : 'secondary'} onClick={() => setAuto(a => !a)}>{auto ? t.stop : t.auto}</Button>
+        <Button
+          variant="secondary"
+          onClick={e => { e.currentTarget.blur(); if (expanded) exit(); else enter(); }}
+        >
+          {expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          {expanded ? t.exit : t.expand}
+        </Button>
       </div>
 
-      <div className="relative mx-auto w-full max-w-sm">
+      <div className={expanded ? 'relative w-full max-w-[min(92vw,62vh)]' : 'relative mx-auto w-full max-w-sm'}>
         <div className="grid grid-cols-4 gap-2 border-2 border-border bg-muted p-2 touch-none select-none"
           onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
           {grid.flat().map((v, i) => (
@@ -133,6 +151,7 @@ export default function Game2048({ lang = 'en' }: { lang?: Lang }) {
       </div>
 
       <p className="text-center text-xs text-muted-foreground">{t.hint}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds an **Expand** button to both games for comfortable mobile play:

- New reusable `useExpand` hook (5 unit tests): tries the native Fullscreen API first (Android — hides browser chrome entirely), falls back to a `fixed inset-0` overlay on iOS Safari (no element fullscreen there). Esc and native fullscreen exit both collapse.
- **2048**: board scales to `min(92vw, 62vh)` when expanded; controls (score / new game / undo / auto-play) stay visible.
- **Flying Bird**: canvas fills the viewport at its 2:3 aspect (`h-[min(85vh,138vw)]`); Best-score chip + expand control added; button blurs after click so Space keeps flapping instead of re-toggling.

- Tests: full suite **1542 passing**
- Lint: 0 errors
- Build: both game pages built