### PR TITLE
feat(media): Meditation Session Generator — layered binaural sessions

### DIFF
--- a/src/islands/media/MeditationSession.tsx
+++ b/src/islands/media/MeditationSession.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Play, Square, Download, Headphones } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { ProgressBar } from '@/components/ui/ProgressBar';
+import { downloadService } from '@/services/download';
+import { resolveSession, stereoToWav, type ResolvedSession, type Point } from '@/tools/media/session.lib';
+import { SESSION_PRESETS, presetById } from '@/tools/media/farfield-presets';
+import { makeNoise } from '@/tools/media/noise.lib';
+import { floatToPcm16 } from '@/tools/media/tts-audio.lib';
+import type { Lang } from '@/i18n/config';
+
+const RATE = 44100;
+const EXPORT_MAX_S = 2700; // offline renders above ~45 min exhaust mobile memory
+
+const TR: Record<Lang, {
+  intro: string; play: string; stop: string; exportWav: string; exportMp3: string; rendering: string;
+  tooLong: string; timeline: string; headphones: string; disclaimer: string; attribution: string;
+  fidelity: Record<'measured-tape' | 'patent' | 'original', string>;
+}> = {
+  en: {
+    intro: 'Generate layered binaural meditation sessions — timed sequences of gliding carrier pairs, crossfades and noise beds reconstructed from expired patents and tape measurements. Everything is synthesized on your device: play for the full session with zero bandwidth, or export to WAV/MP3.',
+    play: 'Play session', stop: 'Stop', exportWav: 'Export WAV', exportMp3: 'Export MP3', rendering: 'Rendering audio…',
+    tooLong: 'Export is available for sessions up to 45 minutes — play this one live instead.',
+    timeline: 'Beat-frequency timeline',
+    headphones: 'Use headphones — binaural beats need one carrier per ear.',
+    disclaimer: 'This is a sound generator, not a medical device. Evidence for effects of binaural beats is limited and mixed. Start at a low volume and don’t use while driving.',
+    attribution: 'Preset parameters ported from the open-source farfield project (Apache-2.0), reconstructing techniques from expired patents (US 3,884,218; US 5,213,562; US 5,356,368). No original audio is used.',
+    fidelity: { 'measured-tape': 'Measured from tape', patent: 'From expired patent', original: 'Original design' },
+  },
+  id: {
+    intro: 'Buat sesi meditasi binaural berlapis — sekuens berjadwal dari pasangan carrier yang meluncur, crossfade, dan lapisan noise yang direkonstruksi dari paten kedaluwarsa dan pengukuran kaset. Semuanya disintesis di perangkat Anda: putar sesi penuh tanpa bandwidth, atau ekspor ke WAV/MP3.',
+    play: 'Putar sesi', stop: 'Berhenti', exportWav: 'Ekspor WAV', exportMp3: 'Ekspor MP3', rendering: 'Merender audio…',
+    tooLong: 'Ekspor tersedia untuk sesi hingga 45 menit — putar yang ini secara langsung saja.',
+    timeline: 'Linimasa frekuensi beat',
+    headphones: 'Gunakan headphone — binaural beat butuh satu carrier per telinga.',
+    disclaimer: 'Ini generator suara, bukan perangkat medis. Bukti efek binaural beat terbatas dan beragam. Mulai dari volume rendah dan jangan gunakan saat menyetir.',
+    attribution: 'Parameter preset diporting dari proyek open-source farfield (Apache-2.0), merekonstruksi teknik dari paten kedaluwarsa (US 3,884,218; US 5,213,562; US 5,356,368). Tidak ada audio asli yang digunakan.',
+    fidelity: { 'measured-tape': 'Diukur dari kaset', patent: 'Dari paten kedaluwarsa', original: 'Desain orisinal' },
+  },
+};
+
+const fmtTime = (s: number) => {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${String(sec).padStart(2, '0')}`;
+};
+
+/** Apply automation points to an AudioParam relative to t0. */
+function applyPoints(param: AudioParam, points: Point[], t0: number) {
+  if (!points.length) return;
+  param.setValueAtTime(points[0].v, t0 + points[0].t);
+  for (let i = 1; i < points.length; i++) param.linearRampToValueAtTime(points[i].v, t0 + points[i].t);
+}
+
+/** Build the full session graph into `dest`. Works on both live and offline contexts. */
+function buildGraph(ctx: BaseAudioContext, resolved: ResolvedSession, dest: AudioNode, t0: number) {
+  const master = ctx.createGain();
+  master.gain.value = 1;
+  const comp = ctx.createDynamicsCompressor();
+  comp.threshold.value = -18; comp.knee.value = 12; comp.ratio.value = 4; comp.attack.value = 0.02; comp.release.value = 0.3;
+  const limiter = ctx.createDynamicsCompressor();
+  limiter.threshold.value = -3; limiter.knee.value = 0; limiter.ratio.value = 20; limiter.attack.value = 0.001; limiter.release.value = 0.05;
+  master.connect(comp); comp.connect(limiter); limiter.connect(dest);
+
+  for (const v of resolved.voices) {
+    const oscL = ctx.createOscillator();
+    const oscR = ctx.createOscillator();
+    oscL.type = oscR.type = 'sine';
+    applyPoints(oscL.frequency, v.freqL, t0);
+    applyPoints(oscR.frequency, v.freqR, t0);
+    const merger = ctx.createChannelMerger(2);
+    oscL.connect(merger, 0, 0);
+    oscR.connect(merger, 0, 1);
+
+    const gain = ctx.createGain();
+    gain.gain.value = 0;
+    applyPoints(gain.gain, v.gain, t0);
+
+    let tail: AudioNode = gain;
+    if (v.tremolo) {
+      // Amplitude modulation: gain oscillates between 1-depth and 1.
+      const trem = ctx.createGain();
+      trem.gain.value = 1 - v.tremolo.depth / 2;
+      const lfo = ctx.createOscillator();
+      lfo.type = 'sine';
+      applyPoints(lfo.frequency, v.tremolo.rate, t0);
+      const depth = ctx.createGain();
+      depth.gain.value = v.tremolo.depth / 2;
+      lfo.connect(depth).connect(trem.gain);
+      lfo.start(t0 + v.gain[0].t);
+      lfo.stop(t0 + v.gain[v.gain.length - 1].t + 0.1);
+      gain.connect(trem);
+      tail = trem;
+    }
+    merger.connect(gain);
+    tail.connect(master);
+
+    const start = t0 + v.gain[0].t;
+    const stop = t0 + v.gain[v.gain.length - 1].t + 0.1;
+    oscL.start(start); oscL.stop(stop);
+    oscR.start(start); oscR.stop(stop);
+  }
+
+  if (resolved.bed) {
+    const buffer = ctx.createBuffer(1, ctx.sampleRate * 10, ctx.sampleRate);
+    buffer.getChannelData(0).set(makeNoise(buffer.length, resolved.bed.color));
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.loop = true;
+    const gain = ctx.createGain();
+    gain.gain.value = 0;
+    applyPoints(gain.gain, resolved.bed.gain, t0);
+    src.connect(gain).connect(master);
+    src.start(t0);
+    src.stop(t0 + resolved.duration + 0.1);
+  }
+}
+
+export default function MeditationSession({ lang = 'en' }: { lang?: Lang }) {
+  const t = TR[lang] ?? TR.en;
+  const [presetId, setPresetId] = useState('relaxation');
+  const [playing, setPlaying] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const [rendering, setRendering] = useState(false);
+
+  const ctxRef = useRef<AudioContext | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startAtRef = useRef(0);
+
+  const preset = presetById(presetId);
+  const resolved = useMemo(() => resolveSession(preset), [preset]);
+
+  const stop = () => {
+    if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+    if (audioRef.current) { audioRef.current.pause(); audioRef.current.srcObject = null; }
+    ctxRef.current?.close().catch(() => {});
+    ctxRef.current = null;
+    setPlaying(false);
+    setElapsed(0);
+  };
+  useEffect(() => stop, []);
+  // Switching preset stops playback.
+  useEffect(() => { stop(); }, [presetId]);
+
+  const play = async () => {
+    stop();
+    const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    const ctx = new AudioCtx({ latencyHint: 'playback' });
+    ctxRef.current = ctx;
+    if (ctx.state === 'suspended') await ctx.resume();
+    const dest = ctx.createMediaStreamDestination();
+    if (audioRef.current) { audioRef.current.srcObject = dest.stream; audioRef.current.play().catch(() => {}); }
+    const t0 = ctx.currentTime + 0.1;
+    startAtRef.current = t0;
+    buildGraph(ctx, resolved, dest, t0);
+    setPlaying(true);
+    if ('mediaSession' in navigator) {
+      try {
+        navigator.mediaSession.metadata = new MediaMetadata({ title: preset.title, artist: 'GoodWebTools' });
+        navigator.mediaSession.setActionHandler('pause', () => stop());
+      } catch { /* unsupported */ }
+    }
+    timerRef.current = setInterval(() => {
+      const c = ctxRef.current;
+      if (!c) return;
+      const e = Math.max(0, c.currentTime - startAtRef.current);
+      setElapsed(e);
+      if (e >= resolved.duration) stop();
+    }, 500);
+  };
+
+  const render = async (): Promise<{ left: Float32Array; right: Float32Array } | null> => {
+    const off = new OfflineAudioContext(2, Math.ceil(resolved.duration * RATE), RATE);
+    buildGraph(off, resolved, off.destination, 0);
+    const buf = await off.startRendering();
+    return { left: buf.getChannelData(0), right: buf.getChannelData(1) };
+  };
+
+  const exportWav = async () => {
+    setRendering(true);
+    try {
+      const r = await render();
+      if (r) await downloadService.download(new Blob([stereoToWav(r.left, r.right, RATE)], { type: 'audio/wav' }), `${preset.id}.wav`);
+    } finally { setRendering(false); }
+  };
+
+  const exportMp3 = async () => {
+    setRendering(true);
+    try {
+      const r = await render();
+      if (!r) return;
+      const lamejs = await import('@breezystack/lamejs');
+      const enc = new lamejs.Mp3Encoder(2, RATE, 128);
+      const l = floatToPcm16(r.left);
+      const rr = floatToPcm16(r.right);
+      const chunks: Uint8Array[] = [];
+      for (let i = 0; i < l.length; i += 1152) {
+        const out = enc.encodeBuffer(l.subarray(i, i + 1152), rr.subarray(i, i + 1152));
+        if (out.length) chunks.push(new Uint8Array(out));
+      }
+      const end = enc.flush();
+      if (end.length) chunks.push(new Uint8Array(end));
+      await downloadService.download(new Blob(chunks as BlobPart[], { type: 'audio/mpeg' }), `${preset.id}.mp3`);
+    } finally { setRendering(false); }
+  };
+
+  // Timeline: beat frequency per voice on a log scale.
+  const timeline = useMemo(() => {
+    const W = 600, H = 110;
+    const y = (beat: number) => H - (Math.log2(Math.max(0.5, beat) / 0.5) / Math.log2(256)) * H;
+    const x = (time: number) => (time / resolved.duration) * W;
+    const lines = resolved.voices.map((v) => {
+      const pts: string[] = [];
+      const n = Math.min(v.freqL.length, v.freqR.length);
+      for (let i = 0; i < n; i++) {
+        const beat = Math.abs(v.freqR[i].v - v.freqL[i].v);
+        pts.push(`${x(v.freqL[i].t).toFixed(1)},${y(beat).toFixed(1)}`);
+      }
+      return pts.join(' ');
+    });
+    return { W, H, lines };
+  }, [resolved]);
+
+  const canExport = resolved.duration <= EXPORT_MAX_S;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t.intro}</p>
+      <audio ref={audioRef} loop className="hidden" />
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {SESSION_PRESETS.map((p) => {
+          const dur = resolveSession(p).duration;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setPresetId(p.id)}
+              className={`rounded-lg border-2 p-3 text-left transition-colors ${presetId === p.id ? 'border-accent bg-accent/10' : 'border-border bg-muted/40 hover:border-accent/50'}`}
+            >
+              <span className="flex items-center justify-between gap-2">
+                <span className="font-semibold">{p.title}</span>
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">{fmtTime(dur)}</span>
+              </span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">{t.fidelity[p.fidelity]}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="text-sm text-muted-foreground">{preset.description[lang === 'id' ? 'id' : 'en']}</p>
+
+      <div className="space-y-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t.timeline}</span>
+        <svg viewBox={`0 0 ${timeline.W} ${timeline.H}`} className="h-28 w-full rounded-lg border border-border bg-muted/40">
+          {timeline.lines.map((pts, i) => (
+            <polyline key={i} points={pts} fill="none" stroke="currentColor" strokeWidth="1.5" className="text-accent" opacity={0.35 + 0.5 * ((i % 3) / 2)} />
+          ))}
+          {playing && <line x1={(elapsed / resolved.duration) * timeline.W} x2={(elapsed / resolved.duration) * timeline.W} y1="0" y2={timeline.H} stroke="currentColor" className="text-red-500" strokeWidth="1.5" />}
+        </svg>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {!playing
+          ? <Button onClick={play}><Play className="h-4 w-4" /> {t.play}</Button>
+          : <Button variant="ghost" onClick={stop}><Square className="h-4 w-4" /> {t.stop}</Button>}
+        {playing && <span className="font-mono text-sm tabular-nums">{fmtTime(elapsed)} / {fmtTime(resolved.duration)}</span>}
+        {canExport ? (
+          <>
+            <Button variant="secondary" onClick={exportWav} disabled={rendering}><Download className="h-4 w-4" /> {t.exportWav}</Button>
+            <Button variant="secondary" onClick={exportMp3} disabled={rendering}><Download className="h-4 w-4" /> {t.exportMp3}</Button>
+          </>
+        ) : (
+          <span className="text-xs text-muted-foreground">{t.tooLong}</span>
+        )}
+        {rendering && <span className="text-sm text-muted-foreground">{t.rendering}</span>}
+      </div>
+
+      {playing && <ProgressBar percent={Math.min(100, Math.round((elapsed / resolved.duration) * 100))} />}
+
+      <p className="flex items-start gap-2 text-xs text-muted-foreground"><Headphones className="mt-0.5 h-4 w-4 shrink-0" /> {t.headphones}</p>
+      <p className="rounded-lg border border-border bg-muted/40 p-3 text-xs text-muted-foreground">{t.disclaimer}</p>
+      <p className="text-xs text-muted-foreground">{t.attribution}</p>
+    </div>
+  );
+}

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -196,6 +196,24 @@ const en: Record<string, ToolSeoContent> = {
       { q: 'What do delta, theta and alpha mean?', a: 'They are frequency ranges for the beat: delta is slowest (0.5–4 Hz), through theta and alpha, up to beta and gamma. Pick one as a starting point and adjust to taste.' },
     ],
   },
+  'meditation-session': {
+    title: 'Meditation Session Generator — Layered Binaural Sessions',
+    description: 'Generate full layered binaural meditation sessions — timed sequences with gliding beats, crossfades and noise beds from expired patents. Play or export WAV/MP3. Free, on your device.',
+    intro: 'This free meditation session generator synthesizes complete, timed binaural sessions — layered carrier pairs whose beat frequencies glide on a schedule, with crossfades and a noise bed — reconstructed from expired patents and tape measurements via the open-source farfield project. Everything is generated on your device: play a session live with zero bandwidth, or export it as a WAV/MP3 file. It is a sound generator, not a medical device.',
+    howTo: [
+      'Pick a session preset — from a 5-minute wake sequence to a 90-minute sleep cycle.',
+      'Put on headphones (binaural beats need one carrier per ear).',
+      'Press Play — the timeline shows the beat frequencies as the session progresses.',
+      'Optionally export the session as a WAV or MP3 file (up to 45 minutes).',
+    ],
+    faqs: [
+      { q: 'How is this different from the Ambient & Binaural Generator?', a: 'That tool plays a constant tone you tune by hand. This one plays complete timed sessions: multiple layered carrier pairs whose beats glide and crossfade over 20–90 minutes, following published session designs.' },
+      { q: 'Where do the presets come from?', a: 'The numeric parameters are ported from the open-source farfield project (Apache-2.0), which reconstructs techniques from expired patents (US 3,884,218; US 5,213,562; US 5,356,368) and spectral measurements of original tapes. No original audio is used.' },
+      { q: 'Do binaural beats actually work?', a: 'The evidence for effects on relaxation, focus or sleep is limited and mixed. This is a sound generator, not a medical device — enjoy the sessions as ambient sound and set your own expectations.' },
+      { q: 'Does it stream or use data?', a: 'No. Sessions are synthesized on your device with the Web Audio API — a 90-minute session uses zero bandwidth and works offline.' },
+      { q: 'Can I download a session?', a: 'Yes. Sessions up to 45 minutes can be rendered (faster than real time) and downloaded as WAV or MP3; longer ones are best played live.' },
+    ],
+  },
   'metronome': {
     title: 'Free Online Metronome — Tap Tempo & Time Signatures',
     description: 'A precise, sample-accurate metronome with tap tempo and time signatures that stays on beat even in a background tab. Free and in your browser.',
@@ -3024,6 +3042,24 @@ const id: Record<string, ToolSeoContent> = {
       { q: 'Apakah binaural beat benar-benar bekerja?', a: 'Bukti efek pada fokus, relaksasi, atau tidur terbatas dan beragam. Tool ini generator suara, bukan perangkat medis — nikmati sebagai suara ambient dan atur ekspektasi Anda sendiri.' },
       { q: 'Apakah nge-stream atau pakai data?', a: 'Tidak. Nada dibuat di perangkat Anda dengan Web Audio API, jadi sesi berjam-jam memakai nol bandwidth dan bekerja offline.' },
       { q: 'Apa arti delta, theta, dan alpha?', a: 'Itu rentang frekuensi untuk beat: delta paling lambat (0,5–4 Hz), lalu theta dan alpha, hingga beta dan gamma. Pilih satu sebagai titik awal dan sesuaikan selera.' },
+    ],
+  },
+  'meditation-session': {
+    title: 'Generator Sesi Meditasi — Sesi Binaural Berlapis',
+    description: 'Buat sesi meditasi binaural berlapis lengkap — sekuens berjadwal dengan beat meluncur, crossfade, dan lapisan noise dari paten kedaluwarsa. Putar atau ekspor WAV/MP3. Gratis, di perangkat Anda.',
+    intro: 'Tool generator sesi meditasi gratis ini mensintesis sesi binaural lengkap yang berjadwal — pasangan carrier berlapis dengan frekuensi beat yang meluncur, crossfade, dan lapisan noise — direkonstruksi dari paten kedaluwarsa dan pengukuran kaset lewat proyek open-source farfield. Semuanya dibuat di perangkat Anda: putar sesi langsung tanpa bandwidth, atau ekspor sebagai file WAV/MP3. Ini generator suara, bukan perangkat medis.',
+    howTo: [
+      'Pilih preset sesi — dari sekuens bangun 5 menit hingga siklus tidur 90 menit.',
+      'Pakai headphone (binaural beat butuh satu carrier per telinga).',
+      'Tekan Putar — linimasa menampilkan frekuensi beat selama sesi berjalan.',
+      'Opsional ekspor sesi sebagai file WAV atau MP3 (hingga 45 menit).',
+    ],
+    faqs: [
+      { q: 'Apa bedanya dengan Generator Ambient & Binaural?', a: 'Tool itu memutar nada konstan yang Anda atur manual. Tool ini memutar sesi lengkap berjadwal: beberapa pasangan carrier berlapis yang beat-nya meluncur dan ber-crossfade selama 20–90 menit, mengikuti desain sesi yang dipublikasikan.' },
+      { q: 'Dari mana preset-nya berasal?', a: 'Parameter numeriknya diporting dari proyek open-source farfield (Apache-2.0), yang merekonstruksi teknik dari paten kedaluwarsa (US 3,884,218; US 5,213,562; US 5,356,368) dan pengukuran spektral kaset asli. Tidak ada audio asli yang dipakai.' },
+      { q: 'Apakah binaural beat benar-benar bekerja?', a: 'Bukti efek pada relaksasi, fokus, atau tidur terbatas dan beragam. Ini generator suara, bukan perangkat medis — nikmati sesinya sebagai suara ambient dan atur ekspektasi Anda sendiri.' },
+      { q: 'Apakah nge-stream atau pakai data?', a: 'Tidak. Sesi disintesis di perangkat Anda dengan Web Audio API — sesi 90 menit memakai nol bandwidth dan bekerja offline.' },
+      { q: 'Bisakah mengunduh sesi?', a: 'Ya. Sesi hingga 45 menit bisa dirender (lebih cepat dari waktu nyata) dan diunduh sebagai WAV atau MP3; yang lebih panjang paling baik diputar langsung.' },
     ],
   },
   'metronome': {

--- a/src/registry/tools.ts
+++ b/src/registry/tools.ts
@@ -1,4 +1,4 @@
-import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan, Activity, Grid3x3, Bird, ServerCog, Pilcrow, MonitorSmartphone, Volume2, Monitor, MousePointerClick, ListChecks, Landmark, Hourglass, Globe, Smile, StickyNote, Waves, Music4, ScanBarcode } from 'lucide-react';
+import { Hash, Braces, Binary, Link, KeyRound, Fingerprint, KeySquare, FileDiff, Table, FileText, QrCode, ScanLine, Clock, Calculator, Palette, FilePlus2, Scissors, RotateCw, FileImage, FileX, Stamp, Image, Replace, Minimize2, Maximize2, Eraser, Archive, Lock, Unlock, Crop, Droplet, PenTool, Combine, ShieldCheck, FileCode, FileCode2, FileCog, FileArchive, FolderArchive, Sparkles, ScanFace, Scaling, Aperture, Wand2, PenLine, Shapes, Film, FileVideo, Music, AudioLines, MonitorPlay, Camera, Code2, Database, Keyboard, Contrast, Eye, ScanText, Receipt, Webcam, Mic, Send, Video, Wrench, Compass, Map, Waypoints, ImageDown, ScrollText, Ghost, FileSpreadsheet, BookOpen, FileType2, FileDown, GitCompare, FileOutput, CalendarClock, ClipboardPaste, PlugZap, Regex, Contact, Wallet, Network, Subtitles, Presentation, SquareUser, WholeWord, Percent, Baseline, CaseSensitive, Brush, AppWindow, ListOrdered, FileSignature, Shrink, Cake, Ruler, Timer, Highlighter, Gauge, Speech, Accessibility, Tags, Link2Off, Home, HeartHandshake, Gift, Barcode, Disc3, Sticker, Glasses, HeartPulse, BookCopy, Users, Grip, MailOpen, Scan, Activity, Grid3x3, Bird, ServerCog, Pilcrow, MonitorSmartphone, Volume2, Monitor, MousePointerClick, ListChecks, Landmark, Hourglass, Globe, Smile, StickyNote, Waves, Music4, ScanBarcode, Brain } from 'lucide-react';
 import type { ToolDef } from '@/types/tool';
 
 export const tools: ToolDef[] = [
@@ -287,6 +287,17 @@ export const tools: ToolDef[] = [
     icon: AudioLines,
     summary: 'Generate binaural & isochronic tones with a noise bed',
     load: () => import('@/islands/media/AmbientGenerator'),
+    status: 'beta'
+  },
+  {
+    id: 'meditation-session',
+    name: 'Meditation Session Generator',
+    category: 'Media',
+    route: '/tools/meditation-session',
+    keywords: ['meditation session', 'binaural beats session', 'layered binaural', 'sleep sounds', 'deep relaxation audio', 'brainwave session', 'focus session generator'],
+    icon: Brain,
+    summary: 'Layered binaural meditation sessions — play or export WAV/MP3',
+    load: () => import('@/islands/media/MeditationSession'),
     status: 'beta'
   },
   {

--- a/src/tools/media/farfield-presets.test.ts
+++ b/src/tools/media/farfield-presets.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { SESSION_PRESETS, presetById } from './farfield-presets';
+import { resolveSession } from './session.lib';
+
+describe('farfield presets', () => {
+  it.each(SESSION_PRESETS.map((p) => [p.id] as const))('%s resolves without error', (id) => {
+    const r = resolveSession(presetById(id));
+    expect(r.duration).toBeGreaterThan(60);
+    expect(r.voices.length).toBeGreaterThan(0);
+    // Every automation point lies within the session.
+    for (const v of r.voices) {
+      for (const pt of [...v.freqL, ...v.freqR, ...v.gain]) {
+        expect(pt.t).toBeGreaterThanOrEqual(0);
+        expect(pt.t).toBeLessThanOrEqual(r.duration + 1e-6);
+      }
+      // Gains normalised (≤ -6 dBFS reference = ~0.501).
+      for (const pt of v.gain) expect(pt.v).toBeLessThanOrEqual(0.502);
+      // Frequencies stay positive and audible-ish.
+      for (const pt of [...v.freqL, ...v.freqR]) expect(pt.v).toBeGreaterThan(10);
+    }
+  });
+
+  it('resolved totals match the source material', () => {
+    expect(resolveSession(presetById('relaxation')).duration).toBe(1200 + 180);
+    expect(resolveSession(presetById('sleep-90')).duration).toBe(5400);
+    expect(resolveSession(presetById('focus-10')).duration).toBe(1800);
+    expect(resolveSession(presetById('wake')).duration).toBe(300);
+  });
+
+  it('sleep-90 has no emerge by design', () => {
+    expect(presetById('sleep-90').emerge).toBeNull();
+  });
+
+  it('focus-10 keeps the reversed pair C (left carries the higher frequency)', () => {
+    const r = resolveSession(presetById('focus-10'));
+    const c = r.voices.find((v) => v.name === 'C')!;
+    expect(c.freqL[0].v).toBeGreaterThan(c.freqR[0].v);
+  });
+
+  it('focus-12 puts the high member on the left ear throughout', () => {
+    const r = resolveSession(presetById('focus-12'));
+    const delta = r.voices.find((v) => v.name === 'delta')!;
+    expect(delta.freqL[0].v).toBeGreaterThan(delta.freqR[0].v);
+  });
+});

--- a/src/tools/media/farfield-presets.ts
+++ b/src/tools/media/farfield-presets.ts
@@ -1,0 +1,255 @@
+/**
+ * Session presets ported from the open-source farfield project
+ * (https://github.com/txus/farfield, Apache-2.0). Only numeric parameters
+ * are ported — no audio. Fidelity labels follow farfield:
+ *  - 'patent'        parameters published in expired patents
+ *                    (US 3,884,218; US 5,213,562; US 5,356,368)
+ *  - 'measured-tape' transcribed from spectral analysis of original tapes
+ *  - 'original'      farfield's own designs inside the patents' band rules
+ */
+import type { SessionPreset } from './session.lib';
+
+const MOOD_DEFAULTS = { carrierBase: 200, nPairs: 3, harmonics: [1, 0.35, 0.15] };
+
+export const SESSION_PRESETS: SessionPreset[] = [
+  {
+    id: 'relaxation',
+    title: 'Relaxation — alpha (10 Hz)',
+    fidelity: 'original',
+    description: {
+      en: 'A gentle 20-minute glide from 14 Hz down to a steady 10 Hz alpha, with a soft pink-noise bed. Ends with a 3-minute emerge ramp back to 15 Hz.',
+      id: 'Luncuran lembut 20 menit dari 14 Hz turun ke alpha 10 Hz yang stabil, dengan lapisan pink noise halus. Diakhiri ramp keluar 3 menit kembali ke 15 Hz.',
+    },
+    defaultTotal: 1200,
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 180, overlap: 20, groups: [{ name: 'entry', beat: { from: 14, to: 10 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+      { duration: 'hold', groups: [{ name: 'hold', beat: 10, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    ],
+    emerge: { duration: 180, targetBeat: 15 },
+  },
+  {
+    id: 'concentration',
+    title: 'Concentration — low beta (14 Hz)',
+    fidelity: 'original',
+    description: {
+      en: 'A 20-minute session rising from 10 Hz to a steady 14 Hz low-beta hold — one of the four modes named in US 5,356,368.',
+      id: 'Sesi 20 menit naik dari 10 Hz ke low-beta 14 Hz yang stabil — salah satu dari empat mode yang disebut dalam paten US 5,356,368.',
+    },
+    defaultTotal: 1200,
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 180, overlap: 20, groups: [{ name: 'entry', beat: { from: 10, to: 14 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+      { duration: 'hold', groups: [{ name: 'hold', beat: 14, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    ],
+    emerge: { duration: 180, targetBeat: 15 },
+  },
+  {
+    id: 'attention',
+    title: 'Attention — beta (16 Hz)',
+    fidelity: 'original',
+    description: {
+      en: 'A 20-minute session rising from 10 Hz to a steady 16 Hz beta hold.',
+      id: 'Sesi 20 menit naik dari 10 Hz ke beta 16 Hz yang stabil.',
+    },
+    defaultTotal: 1200,
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 180, overlap: 20, groups: [{ name: 'entry', beat: { from: 10, to: 16 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+      { duration: 'hold', groups: [{ name: 'hold', beat: 16, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    ],
+    emerge: { duration: 180, targetBeat: 15 },
+  },
+  {
+    id: 'alert',
+    title: 'Awake & alert — beta (20 Hz)',
+    fidelity: 'original',
+    description: {
+      en: 'A 20-minute session rising from 12 Hz to a brisk 20 Hz beta hold.',
+      id: 'Sesi 20 menit naik dari 12 Hz ke beta 20 Hz yang cepat.',
+    },
+    defaultTotal: 1200,
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 180, overlap: 20, groups: [{ name: 'entry', beat: { from: 12, to: 20 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+      { duration: 'hold', groups: [{ name: 'hold', beat: 20, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    ],
+    emerge: { duration: 180, targetBeat: 15 },
+  },
+  {
+    id: 'focus-3',
+    title: 'Focus 3 — settling on 7 Hz',
+    fidelity: 'original',
+    description: {
+      en: 'A 20-minute settle from 12 Hz onto a single steady 7 Hz signal at the alpha/theta border — farfield’s own design for coherent, alert relaxation.',
+      id: 'Penurunan 20 menit dari 12 Hz ke satu sinyal stabil 7 Hz di batas alpha/theta — desain farfield sendiri untuk relaksasi koheren dan terjaga.',
+    },
+    defaultTotal: 1200,
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 240, overlap: 30, groups: [{ name: 'coherence', beat: { from: 12, to: 7 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+      { duration: 'hold', groups: [{ name: 'coherence', beat: 7, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    ],
+    emerge: { duration: 180, targetBeat: 15 },
+  },
+  {
+    id: 'wake',
+    title: 'Wake sequence — beta (16 Hz)',
+    fidelity: 'patent',
+    description: {
+      en: 'The 5-minute wake sequence from US 5,356,368 — the one place the patent gives explicit carriers: a pure 400/416 Hz pair producing a 16 Hz beat.',
+      id: 'Sekuens bangun 5 menit dari US 5,356,368 — satu-satunya tempat paten memberi carrier eksplisit: pasangan murni 400/416 Hz menghasilkan beat 16 Hz.',
+    },
+    segments: [
+      { duration: 300, groups: [{ name: 'wake', beat: 16, carrierBase: 400, nPairs: 1, harmonics: [1], levelDb: 0 }] },
+    ],
+    emerge: null,
+  },
+  {
+    id: 'sleep-90',
+    title: 'Sleep processor — 90-minute cycle',
+    fidelity: 'patent',
+    description: {
+      en: 'The 90-minute sleep sequence from US 5,356,368: alpha → theta → delta → deep delta, then back toward REM. Deliberately has no emerge — it is designed to end in light sleep.',
+      id: 'Sekuens tidur 90 menit dari US 5,356,368: alpha → theta → delta → delta dalam, lalu kembali menuju REM. Sengaja tanpa ramp keluar — dirancang berakhir dalam tidur ringan.',
+    },
+    defaults: MOOD_DEFAULTS,
+    segments: [
+      { duration: 320, overlap: 20, groups: [{ name: 'A', beat: 10, levelDb: 0 }, { name: 'B', beat: 7, levelDb: -15 }], bed: { levelDb: -20, color: 'pink' } },
+      { duration: 920, overlap: 20, groups: [{ name: 'B', beat: 7, levelDb: 0 }, { name: 'C', beat: 2.5, levelDb: -20 }], bed: { levelDb: -15, color: 'pink' } },
+      { duration: 1220, overlap: 20, groups: [{ name: 'C', beat: 2.5, levelDb: 0 }, { name: 'D', beat: 1, levelDb: -10 }], bed: { levelDb: -10, color: 'pink' } },
+      { duration: 1520, overlap: 20, groups: [{ name: 'D', beat: 1, levelDb: 0 }], bed: { levelDb: -10, color: 'pink' } },
+      { duration: 920, overlap: 20, groups: [{ name: 'C', beat: 2.5, levelDb: 0 }, { name: 'D', beat: 1, levelDb: -10 }], bed: { levelDb: -10, color: 'pink' } },
+      { duration: 600, groups: [{ name: 'B', beat: 7, levelDb: 0 }, { name: 'C', beat: 2.5, levelDb: -10 }], bed: { levelDb: -15, color: 'pink' } },
+    ],
+    emerge: null,
+  },
+  {
+    id: 'focus-10',
+    title: 'Focus 10 — measured free flow (30 min)',
+    fidelity: 'measured-tape',
+    description: {
+      en: 'Transcribed by farfield from spectral analysis of an original “free flow 10” tape: three carrier groups with continuously gliding ~4 Hz beats, a reversed high pair, a slow tremolo, and an unusually loud brown-noise bed.',
+      id: 'Ditranskrip farfield dari analisis spektral kaset asli “free flow 10”: tiga grup carrier dengan beat ~4 Hz yang terus meluncur, satu pasangan tinggi terbalik, tremolo lambat, dan lapisan brown noise yang luar biasa keras.',
+    },
+    defaults: { nPairs: 1, harmonics: [1] },
+    segments: [
+      {
+        duration: 265, overlap: 15,
+        groups: [{ name: 'A', levelDb: 0, pairs: [{ center: 102, beat: { from: 4.115, to: 4.07 } }] }],
+        bed: { levelDb: -4.1, color: 'brown' },
+      },
+      {
+        duration: 85, overlap: 15,
+        groups: [
+          { name: 'A', levelDb: 0, pairs: [{ center: 102, beat: { from: 4.07, to: 4.057 } }] },
+          { name: 'B', levelDb: -0.5, pairs: [{ center: 300.5, beat: { from: 3.867, to: 3.859 } }], tremolo: { rateHz: { from: 0.58, to: 0.575 }, depth: 0.22 } },
+        ],
+        bed: { levelDb: -4.1, color: 'brown' },
+      },
+      {
+        duration: 965, overlap: 15,
+        groups: [
+          { name: 'A', levelDb: 0, pairs: [{ center: 102, beat: { from: 4.057, to: 3.886 } }] },
+          { name: 'B', levelDb: -0.5, pairs: [{ center: 300.5, beat: { from: 3.859, to: 3.751 } }], tremolo: { rateHz: { from: 0.575, to: 0.514 }, depth: 0.22 } },
+          { name: 'C', levelDb: -6, pairs: [{ left: 497, right: 493.3 }] },
+        ],
+        bed: { levelDb: -4.1, color: 'brown' },
+      },
+      {
+        duration: 215, overlap: 15,
+        groups: [
+          { name: 'B', levelDb: -0.5, pairs: [{ center: 300.5, beat: { from: 3.751, to: 3.728 } }], tremolo: { rateHz: { from: 0.514, to: 0.501 }, depth: 0.22 } },
+          { name: 'C', levelDb: -6, pairs: [{ left: 497, right: 493.3 }] },
+        ],
+        bed: { levelDb: -4.1, color: 'brown' },
+      },
+      {
+        duration: 330,
+        groups: [
+          { name: 'B', levelDb: -0.5, pairs: [{ center: 300.5, beat: { from: 3.728, to: 3.691 } }], tremolo: { rateHz: { from: 0.501, to: 0.48 }, depth: 0.22 } },
+        ],
+        bed: { levelDb: -4.1, color: 'brown' },
+      },
+    ],
+    emerge: null,
+  },
+  {
+    id: 'focus-12',
+    title: 'Focus 12 — measured free flow (35 min)',
+    fidelity: 'measured-tape',
+    description: {
+      en: 'Transcribed by farfield from an original “free flow 12” tape: a layered stack (50 Hz ground with a mono anchor, delta, theta and alpha layers, left ear high throughout) over a dominant brown bed, ending in a bright 16/64 Hz wake block.',
+      id: 'Ditranskrip farfield dari kaset asli “free flow 12”: tumpukan berlapis (ground 50 Hz dengan jangkar mono, lapisan delta, theta, dan alpha, telinga kiri lebih tinggi) di atas lapisan brown dominan, diakhiri blok bangun 16/64 Hz yang terang.',
+    },
+    defaults: { nPairs: 1, harmonics: [1] },
+    segments: [
+      {
+        duration: 370, overlap: 15,
+        groups: [
+          { name: 'ground', highEar: 'left', levelDb: -1, pairs: [{ mono: 50 }, { center: 50.125, beat: 0.75 }] },
+          { name: 'delta', highEar: 'left', levelDb: 0, pairs: [{ center: 100, beat: 1.5 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+      {
+        duration: 255, overlap: 15,
+        groups: [
+          { name: 'ground', highEar: 'left', levelDb: -1, pairs: [{ mono: 50 }, { center: 50.125, beat: 0.75 }] },
+          { name: 'delta', highEar: 'left', levelDb: 0, pairs: [{ center: 100, beat: 1.5 }] },
+          { name: 'th200', highEar: 'left', levelDb: -7, pairs: [{ center: 200, beat: 4 }] },
+          { name: 'th250', highEar: 'left', levelDb: -14, pairs: [{ center: 250, beat: 4 }] },
+          { name: 'th300', highEar: 'left', levelDb: -16, pairs: [{ center: 300, beat: 4 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+      {
+        duration: 1165, overlap: 15,
+        groups: [
+          { name: 'ground', highEar: 'left', levelDb: -1, pairs: [{ mono: 50 }, { center: 50.125, beat: 0.75 }] },
+          { name: 'delta', highEar: 'left', levelDb: 0, pairs: [{ center: 100, beat: 1.5 }] },
+          { name: 'th200', highEar: 'left', levelDb: -7, pairs: [{ center: 200, beat: 4 }] },
+          { name: 'th250', highEar: 'left', levelDb: -14, pairs: [{ center: 250, beat: 4 }] },
+          { name: 'th300', highEar: 'left', levelDb: -16, pairs: [{ center: 300, beat: 4 }] },
+          { name: 'al400', highEar: 'left', levelDb: -20, pairs: [{ center: 400, beat: 10 }] },
+          { name: 'al500', highEar: 'left', levelDb: -18.5, pairs: [{ center: 500, beat: 10 }] },
+          { name: 'al600', highEar: 'left', levelDb: -24, pairs: [{ center: 600, beat: 10 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+      {
+        duration: 195, overlap: 15,
+        groups: [
+          { name: 'ground', highEar: 'left', levelDb: -1, pairs: [{ mono: 50 }, { center: 50.125, beat: 0.75 }] },
+          { name: 'delta', highEar: 'left', levelDb: 0, pairs: [{ center: 100, beat: 1.5 }] },
+          { name: 'th200', highEar: 'left', levelDb: -7, pairs: [{ center: 200, beat: 4 }] },
+          { name: 'th250', highEar: 'left', levelDb: -14, pairs: [{ center: 250, beat: 4 }] },
+          { name: 'th300', highEar: 'left', levelDb: -16, pairs: [{ center: 300, beat: 4 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+      {
+        duration: 40, overlap: 15,
+        groups: [
+          { name: 'ground', highEar: 'left', levelDb: -1, pairs: [{ mono: 50 }, { center: 50.125, beat: 0.75 }] },
+          { name: 'delta', highEar: 'left', levelDb: 0, pairs: [{ center: 100, beat: 1.5 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+      {
+        duration: 160,
+        groups: [
+          { name: 'x475', highEar: 'left', levelDb: 12, pairs: [{ center: 475, beat: 16 }] },
+          { name: 'x600', highEar: 'left', levelDb: 4, pairs: [{ center: 600, beat: 16 }] },
+          { name: 'x64', highEar: 'left', levelDb: 3, pairs: [{ center: 600, beat: 64 }] },
+        ],
+        bed: { levelDb: 4.9, color: 'brown' },
+      },
+    ],
+    emerge: null,
+  },
+];
+
+export function presetById(id: string): SessionPreset {
+  return SESSION_PRESETS.find((p) => p.id === id) ?? SESSION_PRESETS[0];
+}

--- a/src/tools/media/session.lib.test.ts
+++ b/src/tools/media/session.lib.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { parseDur, dbToGain, resolveSegments, resolveSession, stereoToWav, type SessionPreset } from './session.lib';
+
+const TINY: SessionPreset = {
+  id: 'tiny',
+  title: 'Tiny',
+  fidelity: 'original',
+  description: { en: 'test', id: 'tes' },
+  defaultTotal: 600,
+  defaults: { carrierBase: 200, nPairs: 2, harmonics: [1, 0.5] },
+  segments: [
+    { duration: 180, overlap: 20, groups: [{ name: 'entry', beat: { from: 14, to: 10 }, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+    { duration: 'hold', groups: [{ name: 'hold', beat: 10, levelDb: 0 }], bed: { levelDb: -18, color: 'pink' } },
+  ],
+  emerge: { duration: 60, targetBeat: 15 },
+};
+
+describe('parseDur', () => {
+  it.each([
+    ['3:00', 180], ['0:20', 20], ['20:00', 1200], ['1:05:00', 3900],
+  ])('%s → %i s', (s, n) => expect(parseDur(s)).toBe(n));
+});
+
+describe('resolveSegments', () => {
+  it('lays segments out with the crossfade overlap subtracted', () => {
+    const segs = resolveSegments(TINY);
+    expect(segs[0]).toMatchObject({ start: 0, dur: 180, ovOut: 20 });
+    // Next starts where the crossfade begins: 180 - 20 = 160.
+    expect(segs[1].start).toBe(160);
+  });
+
+  it("expands 'hold' to fill defaultTotal", () => {
+    const segs = resolveSegments(TINY);
+    expect(segs[1].dur).toBe(600 - 160);
+    expect(segs[1].start + segs[1].dur).toBe(600);
+  });
+});
+
+describe('resolveSession', () => {
+  const r = resolveSession(TINY);
+
+  it('total duration includes the emerge ramp', () => {
+    expect(r.duration).toBe(660);
+  });
+
+  it('expands default harmonic stacks into one voice per pair', () => {
+    // 2 segments × 1 group × 2 pairs = 4 voices.
+    expect(r.voices).toHaveLength(4);
+  });
+
+  it('splits the beat symmetrically around the carrier (right ear higher)', () => {
+    const v = r.voices[0]; // entry, pair 1: carrier 200, beat 14→10
+    expect(v.freqL[0].v).toBeCloseTo(200 - 7, 5);
+    expect(v.freqR[0].v).toBeCloseTo(200 + 7, 5);
+    expect(v.freqR[1].v - v.freqL[1].v).toBeCloseTo(10, 5);
+  });
+
+  it('crossfades: first segment fades out over its overlap window', () => {
+    const v = r.voices[0];
+    const fadeStart = v.gain[2];
+    const end = v.gain[3];
+    expect(end.t).toBe(180);
+    expect(fadeStart.t).toBe(160);
+    expect(end.v).toBe(0);
+  });
+
+  it('second harmonic is quieter than the first', () => {
+    const [v1, v2] = r.voices;
+    expect(v2.gain[1].v).toBeCloseTo(v1.gain[1].v * 0.5, 6);
+  });
+
+  it('normalises the loudest layer to -6 dBFS', () => {
+    expect(r.voices[0].gain[1].v).toBeCloseTo(dbToGain(-6), 6);
+  });
+
+  it('emerge ramps the final beat to the target', () => {
+    const holdVoice = r.voices[2]; // hold group, pair 1
+    const lastL = holdVoice.freqL[holdVoice.freqL.length - 1];
+    const lastR = holdVoice.freqR[holdVoice.freqR.length - 1];
+    expect(lastR.t).toBe(660);
+    expect(lastR.v - lastL.v).toBeCloseTo(15, 5);
+  });
+
+  it('builds a continuous bed with a fade-out at the end', () => {
+    expect(r.bed?.color).toBe('pink');
+    const g = r.bed!.gain;
+    expect(g[0]).toEqual({ t: 0, v: 0 });
+    expect(g[g.length - 1]).toEqual({ t: 660, v: 0 });
+  });
+
+  it('handles explicit left/right and mono pairs', () => {
+    const p: SessionPreset = {
+      ...TINY,
+      defaultTotal: undefined,
+      emerge: null,
+      segments: [{
+        duration: 100,
+        groups: [{ name: 'x', levelDb: 0, pairs: [{ left: 497, right: 493.3 }, { mono: 50 }] }],
+      }],
+    };
+    const res = resolveSession(p);
+    expect(res.voices[0].freqL[0].v).toBe(497);
+    expect(res.voices[0].freqR[0].v).toBe(493.3);
+    expect(res.voices[1].freqL[0].v).toBe(50);
+    expect(res.voices[1].freqR[0].v).toBe(50);
+  });
+
+  it('high_ear left puts the higher carrier on the left', () => {
+    const p: SessionPreset = {
+      ...TINY,
+      defaultTotal: undefined,
+      emerge: null,
+      segments: [{
+        duration: 100,
+        groups: [{ name: 'x', levelDb: 0, highEar: 'left', pairs: [{ center: 100, beat: 1.5 }] }],
+      }],
+    };
+    const res = resolveSession(p);
+    expect(res.voices[0].freqL[0].v).toBeGreaterThan(res.voices[0].freqR[0].v);
+  });
+});
+
+describe('stereoToWav', () => {
+  it('writes a valid 16-bit stereo RIFF header and interleaves samples', () => {
+    const l = Float32Array.from([0, 1]);
+    const rr = Float32Array.from([-1, 0]);
+    const wav = stereoToWav(l, rr, 44100);
+    expect(wav.length).toBe(44 + 2 * 4);
+    expect(String.fromCharCode(...wav.slice(0, 4))).toBe('RIFF');
+    const view = new DataView(wav.buffer);
+    expect(view.getUint16(22, true)).toBe(2);       // stereo
+    expect(view.getUint32(24, true)).toBe(44100);
+    expect(view.getInt16(44, true)).toBe(0);        // L0
+    expect(view.getInt16(46, true)).toBe(-0x8000);  // R0
+    expect(view.getInt16(48, true)).toBe(0x7fff);   // L1
+  });
+});

--- a/src/tools/media/session.lib.ts
+++ b/src/tools/media/session.lib.ts
@@ -1,0 +1,269 @@
+/**
+ * Binaural meditation-session model: a preset (segments of layered carrier
+ * pairs with gliding beats, crossfades, a noise bed and an optional emerge
+ * ramp) is resolved into absolute automation timelines the island feeds to
+ * Web Audio. Pure and framework-free.
+ *
+ * The schema and the bundled preset parameters are ported from the
+ * open-source farfield project (Apache-2.0), which reconstructs techniques
+ * from expired patents (US 3,884,218; US 5,213,562; US 5,356,368) and from
+ * spectral measurements. No audio is copied — only numeric parameters.
+ */
+
+export interface Ramp { from: number; to: number }
+export type Val = number | Ramp;
+
+export interface PairDef {
+  /** Carrier centre + beat split across ears (usual case). */
+  center?: number;
+  beat?: Val;
+  /** Explicit per-ear carriers. */
+  left?: number;
+  right?: number;
+  /** Same frequency in both ears (a monaural anchor tone). */
+  mono?: number;
+}
+
+export interface GroupDef {
+  name: string;
+  levelDb: number;
+  /** Shorthand: beat on the session's default harmonic carrier stack. */
+  beat?: Val;
+  carrierBase?: number;
+  nPairs?: number;
+  harmonics?: number[];
+  /** Explicit carrier pairs (overrides the shorthand). */
+  pairs?: PairDef[];
+  /** Which ear carries the higher frequency (default right). */
+  highEar?: 'left' | 'right';
+  tremolo?: { rateHz: Val; depth: number };
+}
+
+export interface BedDef { levelDb: number; color: 'pink' | 'brown' }
+
+export interface SegmentDef {
+  /** Seconds, or 'hold' to fill the session to defaultTotal. */
+  duration: number | 'hold';
+  /** Crossfade (s) into the NEXT segment. */
+  overlap?: number;
+  groups: GroupDef[];
+  bed?: BedDef;
+}
+
+export interface SessionPreset {
+  id: string;
+  title: string;
+  fidelity: 'measured-tape' | 'patent' | 'original';
+  description: { en: string; id: string };
+  defaultTotal?: number;
+  defaults?: { carrierBase?: number; nPairs?: number; harmonics?: number[] };
+  segments: SegmentDef[];
+  emerge?: { duration: number; targetBeat: number } | null;
+}
+
+/* ------------------------------------------------------------------ */
+
+export interface Point { t: number; v: number }
+
+export interface Voice {
+  name: string;
+  /** Per-ear frequency automation (equal for a mono anchor). */
+  freqL: Point[];
+  freqR: Point[];
+  /** Linear gain automation, already normalised. */
+  gain: Point[];
+  tremolo?: { rate: Point[]; depth: number };
+}
+
+export interface ResolvedSession {
+  duration: number;
+  voices: Voice[];
+  bed: { color: 'pink' | 'brown'; gain: Point[] } | null;
+}
+
+/** "M:SS" or "H:MM:SS" → seconds. */
+export function parseDur(s: string): number {
+  const parts = s.split(':').map(Number);
+  if (parts.some(isNaN)) throw new Error(`Bad duration: ${s}`);
+  return parts.reduce((acc, p) => acc * 60 + p, 0);
+}
+
+export const dbToGain = (db: number): number => Math.pow(10, db / 20);
+
+const valAt = (v: Val, frac: number): number =>
+  typeof v === 'number' ? v : v.from + (v.to - v.from) * frac;
+const valFrom = (v: Val): number => (typeof v === 'number' ? v : v.from);
+const valTo = (v: Val): number => (typeof v === 'number' ? v : v.to);
+
+/** Fade-in used when a segment has no incoming crossfade (avoids clicks). */
+const EDGE_FADE = 1;
+
+interface ResolvedSeg { start: number; dur: number; ovIn: number; ovOut: number; def: SegmentDef }
+
+/** Compute each segment's absolute start/duration, expanding 'hold'. */
+export function resolveSegments(preset: SessionPreset): ResolvedSeg[] {
+  const segs: ResolvedSeg[] = [];
+  let start = 0;
+  preset.segments.forEach((def, i) => {
+    const ovIn = i === 0 ? 0 : preset.segments[i - 1].overlap ?? 0;
+    const ovOut = def.overlap ?? 0;
+    let dur: number;
+    if (def.duration === 'hold') {
+      if (!preset.defaultTotal) throw new Error('hold segment needs defaultTotal');
+      dur = preset.defaultTotal - start;
+      if (dur <= 0) throw new Error('hold segment has no room');
+    } else {
+      dur = def.duration;
+    }
+    segs.push({ start, dur, ovIn, ovOut, def });
+    start += dur - ovOut;
+  });
+  return segs;
+}
+
+/** Expand a group into its concrete pairs (defaults → harmonic stack). */
+function pairsOf(group: GroupDef, preset: SessionPreset): { pair: PairDef; amp: number }[] {
+  if (group.pairs) return group.pairs.map((pair) => ({ pair, amp: 1 }));
+  const base = group.carrierBase ?? preset.defaults?.carrierBase ?? 200;
+  const n = group.nPairs ?? preset.defaults?.nPairs ?? 1;
+  const harmonics = group.harmonics ?? preset.defaults?.harmonics ?? [1];
+  const out: { pair: PairDef; amp: number }[] = [];
+  for (let k = 0; k < n; k++) {
+    out.push({ pair: { center: base * (k + 1), beat: group.beat ?? 0 }, amp: harmonics[k] ?? 0 });
+  }
+  return out;
+}
+
+/**
+ * Resolve a preset into absolute per-voice automation. Gains are normalised
+ * so the loudest layer sits at -6 dBFS before the master chain.
+ */
+export function resolveSession(preset: SessionPreset): ResolvedSession {
+  const segs = resolveSegments(preset);
+  const last = segs[segs.length - 1];
+  const bodyEnd = last.start + last.dur;
+  const emerge = preset.emerge ?? null;
+  const duration = bodyEnd + (emerge ? emerge.duration : 0);
+
+  // Normalisation reference: the loudest declared layer (groups or bed).
+  let maxDb = -Infinity;
+  for (const s of segs) {
+    for (const g of s.def.groups) maxDb = Math.max(maxDb, g.levelDb);
+    if (s.def.bed) maxDb = Math.max(maxDb, s.def.bed.levelDb);
+  }
+  if (!isFinite(maxDb)) maxDb = 0;
+  const norm = (db: number) => dbToGain(db - maxDb - 6);
+
+  const voices: Voice[] = [];
+  segs.forEach((seg, i) => {
+    const isLast = i === segs.length - 1;
+    const t0 = seg.start;
+    const t1 = seg.start + seg.dur;
+    const fadeIn = seg.ovIn > 0 ? seg.ovIn : EDGE_FADE;
+    // The last segment either extends through the emerge ramp or gets a
+    // short edge fade; other segments fade out across their own overlap.
+    const fadeOut = isLast ? EDGE_FADE : seg.ovOut > 0 ? seg.ovOut : EDGE_FADE;
+    const end = isLast && emerge ? duration : t1;
+
+    for (const g of seg.def.groups) {
+      const high = g.highEar ?? 'right';
+      for (const { pair, amp } of pairsOf(g, preset)) {
+        const level = norm(g.levelDb) * amp;
+        const gain: Point[] = [
+          { t: t0, v: 0 },
+          { t: Math.min(t0 + fadeIn, end), v: level },
+          { t: Math.max(t0, end - fadeOut), v: level },
+          { t: end, v: 0 },
+        ];
+
+        const freqL: Point[] = [];
+        const freqR: Point[] = [];
+        const pushFreq = (t: number, frac: number, emergeBeat?: number) => {
+          if (pair.mono !== undefined) {
+            freqL.push({ t, v: pair.mono });
+            freqR.push({ t, v: pair.mono });
+            return;
+          }
+          if (pair.left !== undefined && pair.right !== undefined) {
+            freqL.push({ t, v: pair.left });
+            freqR.push({ t, v: pair.right });
+            return;
+          }
+          const center = pair.center ?? 200;
+          const b = emergeBeat ?? valAt(pair.beat ?? 0, frac);
+          const lo = center - b / 2;
+          const hi = center + b / 2;
+          freqL.push({ t, v: high === 'left' ? hi : lo });
+          freqR.push({ t, v: high === 'left' ? lo : hi });
+        };
+        pushFreq(t0, 0);
+        pushFreq(t1, 1);
+        // Emerge: the final segment's beats glide to the target frequency.
+        if (isLast && emerge && pair.mono === undefined && !(pair.left !== undefined)) {
+          pushFreq(duration, 1, emerge.targetBeat);
+        }
+
+        const voice: Voice = { name: g.name, freqL, freqR, gain };
+        if (g.tremolo) {
+          voice.tremolo = {
+            depth: g.tremolo.depth,
+            rate: [
+              { t: t0, v: valFrom(g.tremolo.rateHz) },
+              { t: t1, v: valTo(g.tremolo.rateHz) },
+            ],
+          };
+        }
+        voices.push(voice);
+      }
+    }
+  });
+
+  // Bed: one continuous source whose gain ramps across segment boundaries.
+  let bed: ResolvedSession['bed'] = null;
+  const bedSegs = segs.filter((s) => s.def.bed);
+  if (bedSegs.length) {
+    const color = bedSegs[0].def.bed!.color;
+    const gain: Point[] = [{ t: 0, v: 0 }];
+    segs.forEach((seg, i) => {
+      const level = seg.def.bed ? norm(seg.def.bed.levelDb) : 0;
+      const at = seg.start + (i === 0 ? EDGE_FADE : seg.ovIn);
+      gain.push({ t: at, v: level });
+      // Hold until the next boundary begins.
+      const holdUntil = i === segs.length - 1 ? null : seg.start + seg.dur - seg.ovOut;
+      if (holdUntil !== null) gain.push({ t: holdUntil, v: level });
+    });
+    gain.push({ t: Math.max(0, duration - EDGE_FADE), v: gain[gain.length - 1].v });
+    gain.push({ t: duration, v: 0 });
+    bed = { color, gain };
+  }
+
+  return { duration, voices, bed };
+}
+
+/* ------------------------------------------------------------------ */
+
+/** Interleave two Float32 channels into a 16-bit stereo WAV file. */
+export function stereoToWav(left: Float32Array, right: Float32Array, sampleRate: number): Uint8Array {
+  const n = Math.min(left.length, right.length);
+  const dataLen = n * 4; // 2 channels × 2 bytes
+  const buf = new ArrayBuffer(44 + dataLen);
+  const view = new DataView(buf);
+  const str = (off: number, s: string) => { for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i)); };
+  str(0, 'RIFF'); view.setUint32(4, 36 + dataLen, true); str(8, 'WAVE');
+  str(12, 'fmt '); view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);            // PCM
+  view.setUint16(22, 2, true);            // stereo
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 4, true); // byte rate
+  view.setUint16(32, 4, true);            // block align
+  view.setUint16(34, 16, true);           // bits
+  str(36, 'data'); view.setUint32(40, dataLen, true);
+  let off = 44;
+  for (let i = 0; i < n; i++) {
+    const l = Math.max(-1, Math.min(1, left[i]));
+    const r = Math.max(-1, Math.min(1, right[i]));
+    view.setInt16(off, l < 0 ? l * 0x8000 : l * 0x7fff, true); off += 2;
+    view.setInt16(off, r < 0 ? r * 0x8000 : r * 0x7fff, true); off += 2;
+  }
+  return new Uint8Array(buf);
+}


### PR DESCRIPTION
Port of the open-source **farfield** engine (Apache-2.0) to the browser — complete timed binaural meditation sessions, fully client-side (`/tools/meditation-session`):

- **Session model + resolver** (`session.lib.ts`, pure, 17 tests): segments → absolute automation timelines — layered carrier pairs with gliding beats, crossfade overlaps, tremolo, harmonic stacks, mono anchors, high-ear convention, noise beds, emerge ramps, loudness normalisation. Plus a tested 16-bit **stereo WAV** encoder.
- **9 ported presets** (13 tests): the four patent 'Mood Minder' modes (relaxation/concentration/attention/alert), the patent wake sequence and 90-minute sleep cycle (US 5,356,368), farfield's Focus 3 design, and the two **tape-measured** free-flow sessions (Focus 10 / Focus 12 — incl. the reversed pair, mono 50 Hz anchor and tremolo). Parameters only — no audio copied; attribution in UI + code.
- **Island**: preset cards with fidelity badges, SVG beat-frequency timeline with live playhead, real-time playback (master bus + limiter, MediaStream→audio for mobile background, MediaSession), faster-than-realtime **WAV/MP3 export** via OfflineAudioContext (capped at 45 min — memory), headphones note + non-medical disclaimer.

Advantage over the Python original: it renders offline files only; this plays live with **zero bandwidth** and also exports.

- Tests: 30 new, full suite **1573 passing**
- Lint: 0 errors
- Build: both pages built (EN+ID SEO)