### PR TITLE
Fix SSR hydration mismatch (2048, Block Puzzle) + multi-frame DICOM

### DIFF
--- a/src/islands/documents/DicomViewer.tsx
+++ b/src/islands/documents/DicomViewer.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { Dropzone } from '@/components/ui/Dropzone';
 import { Alert } from '@/components/ui/Alert';
-import { applyWindowLevel, isUncompressed, rescale } from '@/tools/documents/dicom.lib';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { applyWindowLevel, isUncompressed, rescale, parseFrameCount, clampFrameCount } from '@/tools/documents/dicom.lib';
 import type { Lang } from '@/i18n/config';
 
 interface Loaded {
-  rows: number; cols: number; pixels: Int16Array | Uint16Array | Uint8Array; rgb: Uint8Array | null;
+  rows: number; cols: number; frames: number;
+  /** All frames, packed one after another (rows*cols per frame). */
+  pixels: Int16Array | Uint16Array | Uint8Array; rgb: Uint8Array | null;
   slope: number; intercept: number; invert: boolean; minC: number; maxW: number;
   meta: { label: string; value: string }[];
 }
@@ -17,6 +20,7 @@ const TR: Record<Lang, Record<string, string>> = {
     failed: 'Could not read this DICOM file.',
     compressed: 'This DICOM uses a compressed transfer syntax (e.g. JPEG/JPEG 2000/RLE), which this viewer does not decode yet. Uncompressed Little-Endian images are supported.',
     center: 'Brightness (window center)', width: 'Contrast (window width)', another: 'Another file',
+    frame: 'Frame', prevFrame: 'Previous frame', nextFrame: 'Next frame',
   },
   id: {
     intro: 'Buka citra medis DICOM (.dcm) dari CD atau USB rumah sakit dan lihat secara privat — dengan kontrol window/level (kecerahan/kontras). Pindaian Anda dibaca di browser dan tidak pernah diunggah.',
@@ -24,6 +28,7 @@ const TR: Record<Lang, Record<string, string>> = {
     failed: 'Tidak dapat membaca berkas DICOM ini.',
     compressed: 'DICOM ini memakai transfer syntax terkompresi (mis. JPEG/JPEG 2000/RLE) yang belum didekode penampil ini. Citra Little-Endian tanpa kompresi didukung.',
     center: 'Kecerahan (window center)', width: 'Kontras (window width)', another: 'Berkas lain',
+    frame: 'Frame', prevFrame: 'Frame sebelumnya', nextFrame: 'Frame berikutnya',
   },
 };
 
@@ -33,12 +38,13 @@ export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
   const [error, setError] = useState('');
   const [center, setCenter] = useState(128);
   const [width, setWidth] = useState(256);
+  const [frame, setFrame] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const onDrop = async (files: File[]) => {
     const f = files[0];
     if (!f) return;
-    setError(''); setLoaded(null);
+    setError(''); setLoaded(null); setFrame(0);
     try {
       const dicomParser = (await import('dicom-parser')).default;
       const byteArray = new Uint8Array(await f.arrayBuffer());
@@ -56,17 +62,23 @@ export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
       const intercept = parseFloat(ds.string('x00281052') || '0') || 0;
       const el = ds.elements.x7fe00010;
       const n = rows * cols;
+      // Multi-frame images (cine loops, volumes) pack every frame into the one
+      // pixel-data element; clamp to what the data can hold so a bad header can't
+      // read past the buffer.
+      const bytesPerFrame = n * samples * (bits > 8 ? 2 : 1);
+      const frames = clampFrameCount(parseFrameCount(ds.string('x00280008')), el.length, bytesPerFrame);
+      const total = n * frames;
 
       let pixels: Int16Array | Uint16Array | Uint8Array;
       let rgb: Uint8Array | null = null;
       if (samples === 3) {
-        rgb = new Uint8Array(byteArray.buffer, el.dataOffset, n * 3);
+        rgb = new Uint8Array(byteArray.buffer, el.dataOffset, total * 3);
         pixels = new Uint8Array(0);
       } else if (bits <= 8) {
-        pixels = new Uint8Array(byteArray.buffer, el.dataOffset, n);
+        pixels = new Uint8Array(byteArray.buffer, el.dataOffset, total);
       } else {
         // Copy the slice so the typed-array view is always correctly aligned.
-        const buf = byteArray.buffer.slice(el.dataOffset, el.dataOffset + n * 2);
+        const buf = byteArray.buffer.slice(el.dataOffset, el.dataOffset + total * 2);
         pixels = signed ? new Int16Array(buf) : new Uint16Array(buf);
       }
 
@@ -84,9 +96,10 @@ export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
         { label: 'Modality', value: ds.string('x00080060') || '—' },
         { label: 'Study', value: ds.string('x00081030') || '—' },
         { label: 'Size', value: `${cols} × ${rows}` },
+        ...(frames > 1 ? [{ label: 'Frames', value: String(frames) }] : []),
       ];
-      setLoaded({ rows, cols, pixels, rgb, slope, intercept, invert: photometric === 'MONOCHROME1', minC: wc, maxW: ww, meta });
-      setCenter(wc); setWidth(ww);
+      setLoaded({ rows, cols, frames, pixels, rgb, slope, intercept, invert: photometric === 'MONOCHROME1', minC: wc, maxW: ww, meta });
+      setCenter(wc); setWidth(ww); setFrame(0);
     } catch (e) {
       setError(e instanceof Error ? e.message : t.failed);
     }
@@ -101,22 +114,24 @@ export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
     canvas.width = loaded.cols; canvas.height = loaded.rows;
     const img = ctx.createImageData(loaded.cols, loaded.rows);
     const n = loaded.rows * loaded.cols;
+    const f = Math.min(Math.max(frame, 0), loaded.frames - 1);
+    const base = f * n; // start of this frame within the packed pixel data
     if (loaded.rgb) {
       for (let i = 0; i < n; i++) {
-        img.data[i * 4] = loaded.rgb[i * 3];
-        img.data[i * 4 + 1] = loaded.rgb[i * 3 + 1];
-        img.data[i * 4 + 2] = loaded.rgb[i * 3 + 2];
+        img.data[i * 4] = loaded.rgb[(base + i) * 3];
+        img.data[i * 4 + 1] = loaded.rgb[(base + i) * 3 + 1];
+        img.data[i * 4 + 2] = loaded.rgb[(base + i) * 3 + 2];
         img.data[i * 4 + 3] = 255;
       }
     } else {
       for (let i = 0; i < n; i++) {
-        const v = rescale(loaded.pixels[i], loaded.slope, loaded.intercept);
+        const v = rescale(loaded.pixels[base + i], loaded.slope, loaded.intercept);
         const g = applyWindowLevel(v, center, width, loaded.invert);
         img.data[i * 4] = g; img.data[i * 4 + 1] = g; img.data[i * 4 + 2] = g; img.data[i * 4 + 3] = 255;
       }
     }
     ctx.putImageData(img, 0, 0);
-  }, [loaded, center, width]);
+  }, [loaded, center, width, frame]);
 
   return (
     <div className="space-y-4">
@@ -141,6 +156,35 @@ export default function DicomViewer({ lang = 'en' }: { lang?: Lang }) {
           <div className="flex justify-center border-2 border-border bg-black p-2">
             <canvas ref={canvasRef} className="max-h-[70vh] w-auto max-w-full" style={{ imageRendering: 'pixelated' }} />
           </div>
+          {loaded.frames > 1 && (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setFrame(f => Math.max(0, f - 1))}
+                disabled={frame === 0}
+                aria-label={t.prevFrame}
+                className="flex h-9 w-9 shrink-0 items-center justify-center border-2 border-border disabled:opacity-40 hover:enabled:shadow-brutal"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              <input
+                type="range" min={0} max={loaded.frames - 1} value={frame}
+                onChange={e => setFrame(Number(e.target.value))}
+                aria-label={t.frame}
+                className="w-full accent-accent"
+              />
+              <button
+                type="button"
+                onClick={() => setFrame(f => Math.min(loaded.frames - 1, f + 1))}
+                disabled={frame >= loaded.frames - 1}
+                aria-label={t.nextFrame}
+                className="flex h-9 w-9 shrink-0 items-center justify-center border-2 border-border disabled:opacity-40 hover:enabled:shadow-brutal"
+              >
+                <ChevronRight className="h-5 w-5" />
+              </button>
+              <span className="shrink-0 text-sm font-bold tabular-nums">{frame + 1} / {loaded.frames}</span>
+            </div>
+          )}
           {!loaded.rgb && (
             <div className="grid gap-3 sm:grid-cols-2">
               <label className="space-y-1 text-sm"><span className="block font-semibold">{t.center}: {Math.round(center)}</span>

--- a/src/islands/games/BlockPuzzle.tsx
+++ b/src/islands/games/BlockPuzzle.tsx
@@ -41,7 +41,10 @@ export default function BlockPuzzle({ lang = 'en' }: { lang?: Lang }) {
   const t = TR[lang] ?? TR.en;
   const { ref: stageRef, expanded, enter, exit } = useExpand<HTMLDivElement>();
   const [board, setBoard] = useState<Board>(emptyBoard);
-  const [hand, setHand] = useState<(PieceShape | null)[]>(() => drawHand());
+  // Three empty slots on the server and first client render (deterministic);
+  // the random opening hand is dealt in a mount effect so hydration matches
+  // (avoids React #425).
+  const [hand, setHand] = useState<(PieceShape | null)[]>([null, null, null]);
   const [score, setScore] = useState(0);
   const [best, setBest] = useState(0);
   const [over, setOver] = useState(false);
@@ -55,6 +58,7 @@ export default function BlockPuzzle({ lang = 'en' }: { lang?: Lang }) {
   latest.current = { board, hand, score };
 
   useEffect(() => {
+    setHand(drawHand());
     try { setBest(Number(localStorage.getItem(BEST_KEY)) || 0); } catch { /* blocked */ }
     return () => { if (flashTimer.current) clearTimeout(flashTimer.current); };
   }, []);

--- a/src/islands/games/Game2048.tsx
+++ b/src/islands/games/Game2048.tsx
@@ -54,7 +54,10 @@ function fresh(): Tile[] { return spawn(spawn([])); }
 export default function Game2048({ lang = 'en' }: { lang?: Lang }) {
   const t = TR[lang] ?? TR.en;
   const { ref: stageRef, expanded, enter, exit } = useExpand<HTMLDivElement>();
-  const [tiles, setTiles] = useState<Tile[]>(fresh);
+  // Start empty so the server and first client render match; the opening tiles
+  // (which use Math.random) are dealt in a mount effect to avoid a hydration
+  // mismatch (React #425).
+  const [tiles, setTiles] = useState<Tile[]>([]);
   const [ghosts, setGhosts] = useState<Ghost[]>([]);
   const [score, setScore] = useState(0);
   const [won, setWon] = useState(false);
@@ -66,6 +69,7 @@ export default function Game2048({ lang = 'en' }: { lang?: Lang }) {
   const latest = useRef({ tiles, score, over });
   latest.current = { tiles, score, over };
 
+  useEffect(() => { setTiles(fresh()); }, []);
   useEffect(() => () => { if (ghostTimer.current) clearTimeout(ghostTimer.current); }, []);
 
   const doMove = useCallback((dir: Direction | null) => {

--- a/src/tools/documents/dicom.lib.test.ts
+++ b/src/tools/documents/dicom.lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyWindowLevel, isUncompressed, rescale } from './dicom.lib';
+import { applyWindowLevel, isUncompressed, rescale, parseFrameCount, clampFrameCount } from './dicom.lib';
 
 describe('rescale', () => {
   it('applies slope and intercept', () => {
@@ -39,5 +39,34 @@ describe('isUncompressed', () => {
     expect(isUncompressed('1.2.840.10008.1.2.4.90')).toBe(false); // JPEG 2000
     expect(isUncompressed('1.2.840.10008.1.2.5')).toBe(false); // RLE
     expect(isUncompressed('')).toBe(false);
+  });
+});
+
+describe('parseFrameCount', () => {
+  it('reads a valid multi-frame count', () => {
+    expect(parseFrameCount('96')).toBe(96);
+    expect(parseFrameCount(' 12 ')).toBe(12);
+  });
+  it('defaults to a single frame when absent or invalid', () => {
+    expect(parseFrameCount(undefined)).toBe(1);
+    expect(parseFrameCount(null)).toBe(1);
+    expect(parseFrameCount('')).toBe(1);
+    expect(parseFrameCount('0')).toBe(1);
+    expect(parseFrameCount('-4')).toBe(1);
+    expect(parseFrameCount('abc')).toBe(1);
+  });
+});
+
+describe('clampFrameCount', () => {
+  it('keeps the declared count when the pixel data is large enough', () => {
+    // 96 frames of a 128×128 16-bit image = 96 × 32768 bytes.
+    expect(clampFrameCount(96, 96 * 128 * 128 * 2, 128 * 128 * 2)).toBe(96);
+  });
+  it('caps a header that claims more frames than the data holds', () => {
+    expect(clampFrameCount(96, 3 * 128 * 128 * 2, 128 * 128 * 2)).toBe(3);
+  });
+  it('never returns less than one frame', () => {
+    expect(clampFrameCount(10, 0, 4096)).toBe(1);
+    expect(clampFrameCount(1, 4096, 0)).toBe(1);
   });
 });

--- a/src/tools/documents/dicom.lib.ts
+++ b/src/tools/documents/dicom.lib.ts
@@ -15,6 +15,27 @@ export function isUncompressed(transferSyntaxUID: string): boolean {
   return UNCOMPRESSED.has(transferSyntaxUID);
 }
 
+/**
+ * Number of frames from the DICOM `NumberOfFrames` (0028,0008) string.
+ * Multi-frame objects (cine loops, volumes) pack every frame into one pixel-data
+ * element; a missing or invalid value means a single-frame image.
+ */
+export function parseFrameCount(raw: string | undefined | null): number {
+  const n = parseInt((raw ?? '').trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+/**
+ * Clamp the declared frame count to what the pixel data can actually hold, so a
+ * wrong header never makes the viewer read past the buffer. `bytesPerFrame` is
+ * rows × cols × samples × (bits > 8 ? 2 : 1).
+ */
+export function clampFrameCount(declared: number, availableBytes: number, bytesPerFrame: number): number {
+  if (bytesPerFrame <= 0) return 1;
+  const fit = Math.floor(availableBytes / bytesPerFrame);
+  return Math.max(1, Math.min(declared, fit));
+}
+
 /** Modality rescale: stored value → real-world value. */
 export function rescale(stored: number, slope: number, intercept: number): number {
   return stored * slope + intercept;


### PR DESCRIPTION
Found by auditing the rest of the tools for the same bug classes we just fixed in Snake/iWork.

## 1 & 2 — SSR hydration mismatch (React #425) in 2048 and Block Puzzle
**Reproduced** in dev (astro dev logs full hydration warnings): loading `/tools/2048/` and `/tools/block-puzzle/` threw *"Text content does not match server-rendered HTML"* / *"Hydration failed"* — the opening board/hand is built with `Math.random()` in the `useState` initializer, so server HTML ≠ client first render.

**Fix** (mirrors the corrected OnetGame pattern):
- 2048: `useState<Tile[]>([])` + deal the two opening tiles in a mount `useEffect`.
- Block Puzzle: `useState([null, null, null])` (three empty slots — no layout shift) + `drawHand()` in the mount effect.

**Verified:** zero hydration warnings after the fix, and the games still deal correctly on mount (2048 → 2 tiles, Block Puzzle → 3 pieces).

## 3 — DICOM viewer showed only the first frame
Multi-frame DICOM (cine loops, volumes) packs every frame into one pixel-data element via `NumberOfFrames` (0028,0008). The viewer never read it and sliced a single `rows×cols` frame — the direct analog of the iWork "slide 1 only" bug.

**Fix:** read the frame count (clamped via `clampFrameCount` to what the data actually holds, so a bad header can't over-read), keep all frames, index the render by the current frame, and add a **frame slider + prev/next + counter**. Single-frame files are unchanged (count clamps to 1, nav hidden).

**Verified:** new `parseFrameCount`/`clampFrameCount` unit tests, plus an end-to-end check that builds a synthetic 3-frame DICOM, parses it with the real `dicom-parser`, and confirms each frame reads back its own pixels at the right offset (and a header claiming 99 frames clamps to the real 2).

## Verify loop
`vitest run` 1771 passing · lint 0 · `tsc --noEmit` clean · `npm run build` OK.

_Audit also checked Dino, Flappy, Wheel, and all doc/media viewers (Docx/Spreadsheet/Epub/Odt/Music/Video) — those are correct; no changes needed._