### PR TITLE
Promote to production: Keynote tables in iWork viewer

### DIFF
--- a/src/islands/documents/IWorkViewer.tsx
+++ b/src/islands/documents/IWorkViewer.tsx
@@ -16,7 +16,7 @@ const TR: Record<Lang, Record<string, string>> = {
     loading: 'Opening…', page: 'Page', another: 'Another file',
     slide: 'Slide', of: 'of', prev: 'Previous slide', next: 'Next slide',
     noText: 'This slide has no text.',
-    deckNote: 'Keynote stores a picture of the first slide only, so the remaining slides are shown as the text they contain.',
+    deckNote: 'Keynote stores a picture of the first slide only, so the remaining slides are shown as the text and tables they contain.',
     singleNote: 'iWork saves a preview of the first page only. To see the whole document, export it to PDF from Pages, Numbers or Keynote and open that instead.',
     untitled: 'Untitled slide',
   },
@@ -28,7 +28,7 @@ const TR: Record<Lang, Record<string, string>> = {
     loading: 'Membuka…', page: 'Halaman', another: 'Berkas lain',
     slide: 'Slide', of: 'dari', prev: 'Slide sebelumnya', next: 'Slide berikutnya',
     noText: 'Slide ini tidak memuat teks.',
-    deckNote: 'Keynote hanya menyimpan gambar slide pertama, jadi slide selanjutnya ditampilkan sebagai teks yang dikandungnya.',
+    deckNote: 'Keynote hanya menyimpan gambar slide pertama, jadi slide selanjutnya ditampilkan sebagai teks dan tabel yang dikandungnya.',
     singleNote: 'iWork hanya menyimpan pratinjau halaman pertama. Untuk melihat seluruh dokumen, ekspor ke PDF dari Pages, Numbers, atau Keynote lalu buka berkas PDF-nya.',
     untitled: 'Slide tanpa judul',
   },
@@ -182,7 +182,24 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
                 {current.body.map((line, i) => (
                   <p key={i} className="text-sm text-muted-foreground sm:text-lg">{line}</p>
                 ))}
-                {!current.title && !current.body.length && (
+                {current.tables.map((tbl, ti) => (
+                  <div key={ti} className="overflow-x-auto">
+                    <table className="mx-auto border-collapse text-sm">
+                      <tbody>
+                        {tbl.cells.map((row, r) => (
+                          <tr key={r}>
+                            {row.map((cell, c) => (
+                              <td key={c} className="min-w-[3rem] border border-border px-3 py-1.5 text-left align-top">
+                                {cell}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ))}
+                {!current.title && !current.body.length && !current.tables.length && (
                   <p className="text-sm text-muted-foreground">{t.noText}</p>
                 )}
               </div>

--- a/src/tools/documents/iwa.lib.test.ts
+++ b/src/tools/documents/iwa.lib.test.ts
@@ -3,6 +3,7 @@ import {
   snappyDecompress, decodeIwa, readFields, readArchives, cleanRun,
   slideTextRuns, slideOrder, slideEntryNames, readSlideOutline,
   readRefAt, storageTexts, shapeStorages, slidePlaceholders, slideContent,
+  readStringTable, readTile, readTable, refsToType, slideTables,
 } from './iwa.lib';
 
 /* ------------------------------------------------------------- test helpers */
@@ -82,6 +83,61 @@ const slideArchive = (id: number, title: number | null, body: number | null, dra
       ...drawables.flatMap(d => pbBytes(7, pbVarint(1, d))),
     ],
   }]);
+
+/* --- table builders (TST model) --- */
+
+/** A string DataList (type 6005, list type 1): key → text. */
+const stringList = (id: number, entries: [number, string][]) =>
+  archive(id, [{
+    type: 6005,
+    payload: [
+      ...pbVarint(1, 1), // list type 1 = strings
+      ...entries.flatMap(([k, s]) => pbBytes(3, [...pbVarint(1, k), ...pbString(3, s)])),
+    ],
+  }]);
+
+/** int16 LE per column; -1 marks an empty column. */
+const offsetBytes = (cols: number[]) =>
+  cols.flatMap(v => { const u = v < 0 ? v + 0x10000 : v; return [u & 0xff, (u >> 8) & 0xff]; });
+
+/** A 24-byte cell record carrying `key` as a uint32 at offset 12. */
+const cellRecord = (key: number) => {
+  const b = new Array(24).fill(0);
+  b[0] = 5;
+  b[12] = key & 0xff; b[13] = (key >> 8) & 0xff; b[14] = (key >> 16) & 0xff; b[15] = (key >> 24) & 0xff;
+  return b;
+};
+
+/** A tile (type 6002); each row = [rowIndex, [col→cell] map]. */
+const tile = (id: number, rows: { r: number; cells: Record<number, number> }[]) =>
+  archive(id, [{
+    type: 6002,
+    payload: rows.flatMap(({ r, cells }) => {
+      const colIdxs = Object.keys(cells).map(Number).sort((a, b) => a - b);
+      const maxCol = colIdxs.length ? Math.max(...colIdxs) : 0;
+      const storage: number[] = [];
+      const offsets: number[] = [];
+      for (let c = 0; c <= maxCol; c++) {
+        if (c in cells) { offsets.push(storage.length); storage.push(...cellRecord(cells[c])); }
+        else offsets.push(-1);
+      }
+      return pbBytes(5, [...pbVarint(1, r), ...pbBytes(6, storage), ...pbBytes(7, offsetBytes(offsets))]);
+    }),
+  }]);
+
+/** TableModelArchive (type 6001): rows (f6), cols (f7), refs to tile + string list. */
+const tableModel = (id: number, rows: number, cols: number, tileId: number, stringsId: number) =>
+  archive(id, [{ type: 6001, payload: [...pbVarint(6, rows), ...pbVarint(7, cols), ...pbVarint(10, tileId), ...pbVarint(11, stringsId)] }]);
+
+/** TableInfoArchive (type 6000) referencing its model. */
+const tableInfo = (id: number, modelId: number) =>
+  archive(id, [{ type: 6000, payload: pbVarint(2, modelId) }]);
+
+const indexOf = (...archs: number[][]) => {
+  const index = new Map<number, ReturnType<typeof readArchives>[number]>();
+  for (const bytes of archs) for (const a of readArchives(new Uint8Array(bytes))) index.set(a.id, a);
+  return index;
+};
 
 /* -------------------------------------------------------------------- tests */
 
@@ -240,6 +296,74 @@ describe('slide structure', () => {
   it('returns empty content for a slide with no text at all', () => {
     const ars = readArchives(new Uint8Array(slideArchive(200, null, null, [])));
     expect(slideContent(ars)).toEqual({ title: '', body: [] });
+  });
+});
+
+describe('tables', () => {
+  it('reads a string DataList and ignores non-string lists', () => {
+    const strings = readArchives(new Uint8Array(stringList(700, [[1, 'A'], [2, 'C'], [3, 'D']])));
+    expect([...readStringTable(strings[0])]).toEqual([[1, 'A'], [2, 'C'], [3, 'D']]);
+    // A numbers list (list type 2) yields nothing.
+    const numbers = readArchives(new Uint8Array(archive(701, [{ type: 6005, payload: [...pbVarint(1, 2), ...pbBytes(3, [...pbVarint(1, 1), ...pbString(3, '9')])] }])));
+    expect(readStringTable(numbers[0]).size).toBe(0);
+  });
+
+  it('reads cell placements (row, col, key) from a tile', () => {
+    const t = readArchives(new Uint8Array(tile(710, [
+      { r: 0, cells: { 0: 1 } },
+      { r: 3, cells: { 2: 2 } },
+      { r: 4, cells: { 3: 3 } },
+    ])));
+    expect(readTile(t[0])).toEqual([
+      { r: 0, c: 0, key: 1 }, { r: 3, c: 2, key: 2 }, { r: 4, c: 3, key: 3 },
+    ]);
+  });
+
+  it('builds a table grid with cells in their exact positions', () => {
+    const index = indexOf(
+      stringList(700, [[1, 'A'], [2, 'C'], [3, 'D']]),
+      tile(710, [{ r: 0, cells: { 0: 1 } }, { r: 3, cells: { 2: 2 } }, { r: 4, cells: { 3: 3 } }]),
+    );
+    const model = readArchives(new Uint8Array(tableModel(720, 5, 4, 710, 700)))[0];
+    const table = readTable(model, index)!;
+    expect(table).toMatchObject({ rows: 5, cols: 4 });
+    expect(table.cells[0][0]).toBe('A');
+    expect(table.cells[3][2]).toBe('C');
+    expect(table.cells[4][3]).toBe('D');
+    expect(table.cells[1][1]).toBe(''); // empty cell
+  });
+
+  it('leaves a cell blank when its key is not a string (e.g. a number cell)', () => {
+    const index = indexOf(stringList(700, [[1, 'A']]), tile(710, [{ r: 0, cells: { 0: 99 } }]));
+    const model = readArchives(new Uint8Array(tableModel(720, 1, 1, 710, 700)))[0];
+    expect(readTable(model, index)!.cells[0][0]).toBe('');
+  });
+
+  it('rejects an implausible table size', () => {
+    const index = indexOf(stringList(700, []), tile(710, []));
+    expect(readTable(readArchives(new Uint8Array(tableModel(720, 0, 4, 710, 700)))[0], index)).toBeNull();
+    expect(readTable(readArchives(new Uint8Array(tableModel(721, 5, 9999, 710, 700)))[0], index)).toBeNull();
+  });
+
+  it('finds a slide’s tables by following its references', () => {
+    const index = indexOf(
+      stringList(700, [[1, 'A'], [2, 'C'], [3, 'D']]),
+      tile(710, [{ r: 0, cells: { 0: 1 } }, { r: 3, cells: { 2: 2 } }, { r: 4, cells: { 3: 3 } }]),
+      tableModel(720, 5, 4, 710, 700),
+      tableInfo(730, 720),
+    );
+    const slide = readArchives(new Uint8Array(archive(200, [{ type: 5, payload: pbBytes(7, pbVarint(1, 730)) }])));
+    const tables = slideTables(slide, index);
+    expect(tables).toHaveLength(1);
+    expect(tables[0].cells[0][0]).toBe('A');
+    expect(tables[0].cells[4][3]).toBe('D');
+  });
+
+  it('refsToType only returns ids whose archive has the wanted message type', () => {
+    const index = indexOf(tableInfo(730, 720), stringList(700, [[1, 'X']]));
+    const payload = new Uint8Array([...pbVarint(1, 730), ...pbVarint(2, 700), ...pbVarint(3, 999)]);
+    expect(refsToType(payload, index, 6000)).toEqual([730]);
+    expect(refsToType(payload, index, 6005)).toEqual([700]);
   });
 });
 

--- a/src/tools/documents/iwa.lib.ts
+++ b/src/tools/documents/iwa.lib.ts
@@ -24,6 +24,13 @@
 /** Object-replacement character Keynote uses as a placeholder for inline items. */
 const OBJECT_REPLACEMENT = /￼/g;
 
+/** A table recovered from a slide: cells[row][col], '' for empty cells. */
+export interface SlideTable {
+  rows: number;
+  cols: number;
+  cells: string[][];
+}
+
 export interface SlideOutline {
   /** Object id of the slide inside the document. */
   id: number;
@@ -31,6 +38,8 @@ export interface SlideOutline {
   title: string;
   /** Remaining text runs, in the order they appear. */
   body: string[];
+  /** Tables on the slide, in the order the slide references them. */
+  tables: SlideTable[];
 }
 
 /* ------------------------------------------------------------------ snappy */
@@ -454,6 +463,191 @@ export function slideEntryNames(names: string[]): string[] {
   return names.filter(n => /^Index\/Slide[-.]/.test(n) && n.endsWith('.iwa'));
 }
 
+/* -------------------------------------------------------------------- tables
+ *
+ * Keynote tables live in the spreadsheet ("TST") model, spread across several
+ * archives, so a slide's table text is invisible to the plain outline above.
+ * The chain, all recovered here:
+ *
+ *   slide → TableInfoArchive (type 6000) → TableModelArchive (type 6001)
+ *   model → rows (field 6) + cols (field 7)
+ *   model → Tile (type 6002): each TileRowInfo gives a row index (field 1), a
+ *           per-column int16 offset table (field 7) and a cell-storage buffer
+ *           (field 6); a non-negative offset means that column has a cell, whose
+ *           record holds a key into the string store.
+ *   model → string DataList (type 6005 with list type 1): key → cell text.
+ */
+
+export type ArchiveIndex = Map<number, Archive>;
+
+/** Decode every Index/ .iwa archive into an id → archive lookup. */
+export function readArchiveIndex(entries: Record<string, Uint8Array>): ArchiveIndex {
+  const index: ArchiveIndex = new Map();
+  for (const name of Object.keys(entries)) {
+    if (!/^Index\/.*\.iwa$/.test(name) || /TemplateSlide/.test(name)) continue;
+    let archives: Archive[];
+    try { archives = readArchives(decodeIwa(entries[name])); } catch { continue; }
+    for (const a of archives) if (!index.has(a.id)) index.set(a.id, a);
+  }
+  return index;
+}
+
+/**
+ * Referenced object ids inside a payload whose archive carries a message of the
+ * given type. Object ids are large, so a bare varint that matches one is a real
+ * reference, not a coincidence.
+ */
+export function refsToType(payload: Uint8Array, index: ArchiveIndex, type: number): number[] {
+  const out: number[] = [];
+  const seen = new Set<number>();
+  const walk = (buf: Uint8Array, depth: number): void => {
+    if (depth > 8) return;
+    for (const f of readFields(buf)) {
+      if (f.wire === 0) {
+        const arch = index.get(f.value);
+        if (arch && !seen.has(f.value) && arch.messages.some(m => m.type === type)) {
+          seen.add(f.value);
+          out.push(f.value);
+        }
+      } else if (f.wire === 2 && f.bytes && f.bytes.length) {
+        walk(f.bytes, depth + 1);
+      }
+    }
+  };
+  walk(payload, 0);
+  return out;
+}
+
+/** key → text for a TST string DataList (message type 6005, list type 1). */
+export function readStringTable(archive: Archive): Map<number, string> {
+  const out = new Map<number, string>();
+  const msg = archive.messages.find(m => m.type === 6005);
+  if (!msg) return out;
+  let listType = 0;
+  for (const f of readFields(msg.payload)) { if (f.no === 1 && f.wire === 0) { listType = f.value; break; } }
+  if (listType !== 1) return out; // 1 = string list; others hold numbers, styles, etc.
+  for (const f of readFields(msg.payload)) {
+    if (f.no !== 3 || f.wire !== 2 || !f.bytes) continue; // TableDataList.ListEntry
+    let key = -1;
+    let text: string | null = null;
+    for (const g of readFields(f.bytes)) {
+      if (g.no === 1 && g.wire === 0) key = g.value;
+      else if (g.no === 3 && g.wire === 2 && g.bytes) text = cleanRun(new TextDecoder().decode(g.bytes));
+    }
+    if (key >= 0 && text !== null) out.set(key, text);
+  }
+  return out;
+}
+
+/** Signed 16-bit little-endian read. */
+function int16(buf: Uint8Array, i: number): number {
+  const v = buf[i] | (buf[i + 1] << 8);
+  return v >= 0x8000 ? v - 0x10000 : v;
+}
+
+/** A cell's string-store key, read from its record in the cell-storage buffer. */
+function cellKeyAt(storage: Uint8Array, start: number): number {
+  const o = start + 12; // record: version + flags + bitmasks, then the string id
+  if (o < 0 || o + 4 > storage.length) return -1;
+  return (storage[o] | (storage[o + 1] << 8) | (storage[o + 2] << 16)) + storage[o + 3] * 0x1000000;
+}
+
+interface CellPlacement { r: number; c: number; key: number }
+
+/** Cell placements (row, col, string key) from one Tile archive. */
+export function readTile(archive: Archive): CellPlacement[] {
+  const out: CellPlacement[] = [];
+  const msg = archive.messages.find(m => m.type === 6002);
+  if (!msg) return out;
+
+  const decodeRow = (r: number, offsets?: Uint8Array, storage?: Uint8Array): CellPlacement[] => {
+    if (!offsets || !storage) return [];
+    const cells: CellPlacement[] = [];
+    for (let i = 0; i + 2 <= offsets.length; i += 2) {
+      const off = int16(offsets, i);
+      if (off < 0 || off >= storage.length) continue;
+      const key = cellKeyAt(storage, off);
+      if (key >= 0) cells.push({ r, c: i / 2, key });
+    }
+    return cells;
+  };
+
+  for (const f of readFields(msg.payload)) {
+    if (f.no !== 5 || f.wire !== 2 || !f.bytes) continue; // TileRowInfo
+    let rowIndex = -1;
+    let offsets: Uint8Array | undefined;
+    let storage: Uint8Array | undefined;
+    let offsetsOld: Uint8Array | undefined;
+    let storageOld: Uint8Array | undefined;
+    for (const g of readFields(f.bytes)) {
+      if (g.no === 1 && g.wire === 0) rowIndex = g.value;
+      else if (g.no === 7 && g.wire === 2) offsets = g.bytes;
+      else if (g.no === 6 && g.wire === 2) storage = g.bytes;
+      else if (g.no === 4 && g.wire === 2) offsetsOld = g.bytes;
+      else if (g.no === 3 && g.wire === 2) storageOld = g.bytes;
+    }
+    if (rowIndex < 0) continue;
+    const current = decodeRow(rowIndex, offsets, storage);
+    out.push(...(current.length ? current : decodeRow(rowIndex, offsetsOld, storageOld)));
+  }
+  return out;
+}
+
+/** Build one table from its TableModelArchive (type 6001). */
+export function readTable(model: Archive, index: ArchiveIndex): SlideTable | null {
+  const msg = model.messages.find(m => m.type === 6001);
+  if (!msg) return null;
+  let rows = 0;
+  let cols = 0;
+  for (const f of readFields(msg.payload)) {
+    if (f.no === 6 && f.wire === 0) rows = f.value;
+    else if (f.no === 7 && f.wire === 0) cols = f.value;
+  }
+  if (rows <= 0 || cols <= 0 || rows > 1000 || cols > 256) return null;
+
+  const strings = new Map<number, string>();
+  for (const id of refsToType(msg.payload, index, 6005)) {
+    const arch = index.get(id);
+    if (arch) for (const [k, v] of readStringTable(arch)) strings.set(k, v);
+  }
+
+  const cells: string[][] = Array.from({ length: rows }, () => Array<string>(cols).fill(''));
+  for (const id of refsToType(msg.payload, index, 6002)) {
+    const arch = index.get(id);
+    if (!arch) continue;
+    for (const p of readTile(arch)) {
+      if (p.r < rows && p.c < cols) {
+        const text = strings.get(p.key);
+        if (text !== undefined) cells[p.r][p.c] = text;
+      }
+    }
+  }
+  return { rows, cols, cells };
+}
+
+/** Every table on a slide, in the order the slide references them. */
+export function slideTables(slideArchives: Archive[], index: ArchiveIndex): SlideTable[] {
+  const out: SlideTable[] = [];
+  const seen = new Set<number>();
+  for (const sa of slideArchives) {
+    for (const m of sa.messages) {
+      for (const infoId of refsToType(m.payload, index, 6000)) { // TableInfoArchive
+        const info = index.get(infoId);
+        const infoMsg = info?.messages.find(mm => mm.type === 6000);
+        if (!info || !infoMsg) continue;
+        for (const modelId of refsToType(infoMsg.payload, index, 6001)) {
+          if (seen.has(modelId)) continue;
+          seen.add(modelId);
+          const model = index.get(modelId);
+          const table = model && readTable(model, index);
+          if (table) out.push(table);
+        }
+      }
+    }
+  }
+  return out;
+}
+
 /**
  * Read the outline of every slide, in presentation order.
  * Returns an empty array for documents we can't parse (older iWork formats,
@@ -462,6 +656,11 @@ export function slideEntryNames(names: string[]): string[] {
 export function readSlideOutline(entries: Record<string, Uint8Array>): SlideOutline[] {
   const names = slideEntryNames(Object.keys(entries));
   if (!names.length) return [];
+
+  // Tables live outside the slide files; a document-wide archive index lets us
+  // follow a slide's references into the table model.
+  let index: ArchiveIndex;
+  try { index = readArchiveIndex(entries); } catch { index = new Map(); }
 
   const slides = new Map<number, SlideOutline>();
   for (const name of names) {
@@ -472,7 +671,9 @@ export function readSlideOutline(entries: Record<string, Uint8Array>): SlideOutl
       continue;
     }
     if (!archives.length) continue;
-    slides.set(archives[0].id, { id: archives[0].id, ...slideContent(archives) });
+    let tables: SlideTable[] = [];
+    try { tables = slideTables(archives, index); } catch { tables = []; }
+    slides.set(archives[0].id, { id: archives[0].id, ...slideContent(archives), tables });
   }
   if (!slides.size) return [];
 


### PR DESCRIPTION
Promotes #312 — the iWork viewer now renders Keynote tables as a faithful grid with cells in their exact positions.