### PR TITLE
Promote to production: Keynote slide images in iWork viewer

### DIFF
--- a/src/islands/documents/IWorkViewer.tsx
+++ b/src/islands/documents/IWorkViewer.tsx
@@ -16,7 +16,7 @@ const TR: Record<Lang, Record<string, string>> = {
     loading: 'Opening…', page: 'Page', another: 'Another file',
     slide: 'Slide', of: 'of', prev: 'Previous slide', next: 'Next slide',
     noText: 'This slide has no text.',
-    deckNote: 'Keynote stores a picture of the first slide only, so the remaining slides are shown as the text and tables they contain.',
+    deckNote: 'Keynote stores a picture of the first slide only, so the remaining slides are shown as the text, tables and images they contain.',
     singleNote: 'iWork saves a preview of the first page only. To see the whole document, export it to PDF from Pages, Numbers or Keynote and open that instead.',
     untitled: 'Untitled slide',
   },
@@ -28,7 +28,7 @@ const TR: Record<Lang, Record<string, string>> = {
     loading: 'Membuka…', page: 'Halaman', another: 'Berkas lain',
     slide: 'Slide', of: 'dari', prev: 'Slide sebelumnya', next: 'Slide berikutnya',
     noText: 'Slide ini tidak memuat teks.',
-    deckNote: 'Keynote hanya menyimpan gambar slide pertama, jadi slide selanjutnya ditampilkan sebagai teks dan tabel yang dikandungnya.',
+    deckNote: 'Keynote hanya menyimpan gambar slide pertama, jadi slide selanjutnya ditampilkan sebagai teks, tabel, dan gambar yang dikandungnya.',
     singleNote: 'iWork hanya menyimpan pratinjau halaman pertama. Untuk melihat seluruh dokumen, ekspor ke PDF dari Pages, Numbers, atau Keynote lalu buka berkas PDF-nya.',
     untitled: 'Slide tanpa judul',
   },
@@ -43,9 +43,11 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [opened, setOpened] = useState(false);
+  const [slideImgs, setSlideImgs] = useState<Record<string, string>>({});
   const rendererRef = useRef<PdfRenderer | null>(null);
   const urlsRef = useRef<string[]>([]);
   const imageRef = useRef('');
+  const slideImgRef = useRef<string[]>([]);
 
   const cleanup = useCallback(() => {
     rendererRef.current?.destroy();
@@ -54,6 +56,8 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
     urlsRef.current = [];
     if (imageRef.current) URL.revokeObjectURL(imageRef.current);
     imageRef.current = '';
+    slideImgRef.current.forEach(u => URL.revokeObjectURL(u));
+    slideImgRef.current = [];
   }, []);
 
   useEffect(() => () => cleanup(), [cleanup]);
@@ -82,7 +86,7 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
     const f = files.find(x => /\.(pages|numbers|key)$/i.test(x.name));
     if (!f) return;
     cleanup();
-    setError(''); setPages([]); setImageUrl(''); setSlides([]); setIndex(0);
+    setError(''); setPages([]); setImageUrl(''); setSlides([]); setSlideImgs({}); setIndex(0);
     setBusy(true); setOpened(true);
     try {
       const { unzipSync } = await import('fflate');
@@ -90,6 +94,18 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
 
       // Keynote decks: recover the text of every slide, in presentation order.
       const outline = readSlideOutline(entries as Record<string, Uint8Array>);
+
+      // Turn each slide's placed images into object URLs to render inline.
+      const imgMap: Record<string, string> = {};
+      for (const slide of outline) {
+        for (const path of slide.images) {
+          if (imgMap[path] || !entries[path]) continue;
+          const url = URL.createObjectURL(new Blob([entries[path]]));
+          imgMap[path] = url;
+          slideImgRef.current.push(url);
+        }
+      }
+      setSlideImgs(imgMap);
 
       const preview = findPreview(Object.keys(entries));
       if (!preview) {
@@ -124,7 +140,7 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
 
   const reset = () => {
     cleanup();
-    setPages([]); setImageUrl(''); setSlides([]); setIndex(0); setError(''); setOpened(false);
+    setPages([]); setImageUrl(''); setSlides([]); setSlideImgs({}); setIndex(0); setError(''); setOpened(false);
   };
 
   const current = slides[index];
@@ -199,7 +215,10 @@ export default function IWorkViewer({ lang = 'en' }: { lang?: Lang }) {
                     </table>
                   </div>
                 ))}
-                {!current.title && !current.body.length && !current.tables.length && (
+                {current.images.map((path, ii) => slideImgs[path] && (
+                  <img key={ii} src={slideImgs[path]} alt="" className="mx-auto max-h-[45vh] max-w-full border-2 border-border" />
+                ))}
+                {!current.title && !current.body.length && !current.tables.length && !current.images.length && (
                   <p className="text-sm text-muted-foreground">{t.noText}</p>
                 )}
               </div>

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -1121,7 +1121,7 @@ const en: Record<string, ToolSeoContent> = {
     howTo: [
       'Drop your .pages, .numbers or .key file.',
       'For a Keynote deck, move through the slides with the arrows, your keyboard’s arrow keys, or the strip of slide buttons below.',
-      'Slide one shows the picture Keynote saved; every other slide shows the text it contains.',
+      'Slide one shows the picture Keynote saved; every other slide shows the text, tables and images it contains.',
       'For Pages and Numbers, the built-in first-page preview is shown.',
       'Open another file any time.',
     ],
@@ -4081,7 +4081,7 @@ const id: Record<string, ToolSeoContent> = {
     howTo: [
       'Letakkan berkas .pages, .numbers, atau .key Anda.',
       'Untuk presentasi Keynote, berpindah slide dengan tombol panah di layar, tombol panah keyboard, atau deretan tombol slide di bawah.',
-      'Slide pertama menampilkan gambar yang disimpan Keynote; slide lainnya menampilkan teks yang dikandungnya.',
+      'Slide pertama menampilkan gambar yang disimpan Keynote; slide lainnya menampilkan teks, tabel, dan gambar yang dikandungnya.',
       'Untuk Pages dan Numbers, pratinjau bawaan halaman pertama yang ditampilkan.',
       'Buka berkas lain kapan saja.',
     ],

--- a/src/tools/documents/iwa.lib.test.ts
+++ b/src/tools/documents/iwa.lib.test.ts
@@ -4,6 +4,7 @@ import {
   slideTextRuns, slideOrder, slideEntryNames, readSlideOutline,
   readRefAt, storageTexts, shapeStorages, slidePlaceholders, slideContent,
   readStringTable, readTile, readTable, refsToType, slideTables,
+  readDataInfo, dataEntryPath, slideImages,
 } from './iwa.lib';
 
 /* ------------------------------------------------------------- test helpers */
@@ -364,6 +365,41 @@ describe('tables', () => {
     const payload = new Uint8Array([...pbVarint(1, 730), ...pbVarint(2, 700), ...pbVarint(3, 999)]);
     expect(refsToType(payload, index, 6000)).toEqual([730]);
     expect(refsToType(payload, index, 6005)).toEqual([700]);
+  });
+});
+
+describe('images', () => {
+  /** DataInfo registry (type 11006): each entry = { 1: dataId, 3: filename }. */
+  const dataInfo = (id: number, entries: [number, string][]) =>
+    archive(id, [{ type: 11006, payload: entries.flatMap(([did, fn]) => pbBytes(3, [...pbVarint(1, did), ...pbString(3, fn)])) }]);
+
+  it('reads the data id → filename registry, keeping only images', () => {
+    const bytes = iwaFile(new Uint8Array(dataInfo(2, [[9072, 'testimg.png'], [8945, 'clip.mov'], [40, 'photo.jpeg']])));
+    const map = readDataInfo({ 'Index/Metadata.iwa': bytes });
+    expect([...map]).toEqual([[9072, 'testimg.png'], [40, 'photo.jpeg']]); // .mov dropped
+  });
+
+  it('resolves the Data/ zip entry, which appends the data id', () => {
+    const names = ['Data/testimg-9072.png', 'Data/photo-40.jpeg', 'preview.jpg'];
+    expect(dataEntryPath(names, 9072, 'testimg.png')).toBe('Data/testimg-9072.png');
+    expect(dataEntryPath(names, 40, 'photo.jpeg')).toBe('Data/photo-40.jpeg');
+    expect(dataEntryPath(names, 1, 'missing.png')).toBeNull();
+  });
+
+  it('collects a slide’s images from reference-shaped ids only', () => {
+    const info = new Map<number, string>([[9072, 'testimg.png']]);
+    const names = ['Data/testimg-9072.png'];
+    // The id appears as field 1 of a nested message (a TSP.Reference).
+    const slide = readArchives(new Uint8Array(archive(200, [{ type: 5, payload: pbBytes(7, pbBytes(9, pbVarint(1, 9072))) }])));
+    expect(slideImages(slide, info, names)).toEqual(['Data/testimg-9072.png']);
+  });
+
+  it('ignores a bare number that merely equals a data id', () => {
+    const info = new Map<number, string>([[240, 'w.png']]); // 240 also a plausible width
+    const names = ['Data/w-240.png'];
+    // 240 here is a bare scalar (field 5), not field 1 of a sub-message → not a reference.
+    const slide = readArchives(new Uint8Array(archive(200, [{ type: 5, payload: pbVarint(5, 240) }])));
+    expect(slideImages(slide, info, names)).toEqual([]);
   });
 });
 

--- a/src/tools/documents/iwa.lib.ts
+++ b/src/tools/documents/iwa.lib.ts
@@ -40,6 +40,8 @@ export interface SlideOutline {
   body: string[];
   /** Tables on the slide, in the order the slide references them. */
   tables: SlideTable[];
+  /** Zip paths of images placed on the slide (Data/…), in reference order. */
+  images: string[];
 }
 
 /* ------------------------------------------------------------------ snappy */
@@ -625,6 +627,92 @@ export function readTable(model: Archive, index: ArchiveIndex): SlideTable | nul
   return { rows, cols, cells };
 }
 
+/* -------------------------------------------------------------------- images
+ *
+ * A placed image is a drawable that references a package data id; the id → file
+ * name mapping lives in the DataInfo registry (Index/Metadata.iwa, message type
+ * 11006). The actual zip entry appends the data id: "testimg.png" (registry) is
+ * stored as "Data/testimg-9072.png". Theme/background art is referenced only by
+ * the master slides we exclude, so a slide's own references yield just its
+ * user-placed images.
+ */
+
+const IMAGE_EXT = /\.(png|jpe?g|heic|heif|tiff?|gif|bmp|webp)$/i;
+
+/** data id → original file name, from the package DataInfo registry. */
+export function readDataInfo(entries: Record<string, Uint8Array>): Map<number, string> {
+  const out = new Map<number, string>();
+  const meta = entries['Index/Metadata.iwa'];
+  if (!meta) return out;
+  let archives: Archive[];
+  try { archives = readArchives(decodeIwa(meta)); } catch { return out; }
+  for (const a of archives) {
+    for (const m of a.messages) {
+      if (m.type !== 11006) continue; // TSP.PackageMetadata / DataInfo table
+      for (const f of readFields(m.payload)) {
+        if (f.wire !== 2 || !f.bytes) continue; // one DataInfo entry
+        let id = -1;
+        let file: string | null = null;
+        for (const g of readFields(f.bytes)) {
+          if (g.no === 1 && g.wire === 0) id = g.value;
+          else if (g.wire === 2 && g.bytes) {
+            const s = new TextDecoder().decode(g.bytes).trim();
+            if (IMAGE_EXT.test(s)) file = s;
+          }
+        }
+        if (id >= 0 && file) out.set(id, file);
+      }
+    }
+  }
+  return out;
+}
+
+/** Locate the zip entry for a data id whose registry name is `filename`. */
+export function dataEntryPath(names: string[], dataId: number, filename: string): string | null {
+  const dot = filename.lastIndexOf('.');
+  const base = dot >= 0 ? filename.slice(0, dot) : filename;
+  const ext = dot >= 0 ? filename.slice(dot) : '';
+  const guess = `Data/${base}-${dataId}${ext}`;
+  if (names.includes(guess)) return guess;
+  const alt = names.find(n => n.startsWith(`Data/${base}-`) && n.includes(`-${dataId}`));
+  if (alt) return alt;
+  return names.includes(`Data/${filename}`) ? `Data/${filename}` : null;
+}
+
+/**
+ * Zip paths of the images placed on a slide, in reference order.
+ *
+ * A data reference is the TSP.Reference shape `{ 1: id }`, so we only treat a
+ * value as an image reference when it is field 1 of a nested message — a bare
+ * number that happens to equal a small data id is not a reference.
+ */
+export function slideImages(slideArchives: Archive[], dataInfo: Map<number, string>, names: string[]): string[] {
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  const walk = (buf: Uint8Array, depth: number): void => {
+    if (depth > 8) return;
+    for (const f of readFields(buf)) {
+      if (f.wire !== 2 || !f.bytes || !f.bytes.length) continue;
+      for (const g of readFields(f.bytes)) {
+        if (g.no === 1 && g.wire === 0 && dataInfo.has(g.value) && !seen.has(g.value)) {
+          seen.add(g.value);
+          ids.push(g.value);
+        }
+        break; // only the first field decides the Reference shape
+      }
+      walk(f.bytes, depth + 1);
+    }
+  };
+  for (const a of slideArchives) for (const m of a.messages) walk(m.payload, 0);
+
+  const paths: string[] = [];
+  for (const id of ids) {
+    const path = dataEntryPath(names, id, dataInfo.get(id) as string);
+    if (path && !paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
 /** Every table on a slide, in the order the slide references them. */
 export function slideTables(slideArchives: Archive[], index: ArchiveIndex): SlideTable[] {
   const out: SlideTable[] = [];
@@ -661,6 +749,9 @@ export function readSlideOutline(entries: Record<string, Uint8Array>): SlideOutl
   // follow a slide's references into the table model.
   let index: ArchiveIndex;
   try { index = readArchiveIndex(entries); } catch { index = new Map(); }
+  let dataInfo: Map<number, string>;
+  try { dataInfo = readDataInfo(entries); } catch { dataInfo = new Map(); }
+  const allNames = Object.keys(entries);
 
   const slides = new Map<number, SlideOutline>();
   for (const name of names) {
@@ -673,7 +764,9 @@ export function readSlideOutline(entries: Record<string, Uint8Array>): SlideOutl
     if (!archives.length) continue;
     let tables: SlideTable[] = [];
     try { tables = slideTables(archives, index); } catch { tables = []; }
-    slides.set(archives[0].id, { id: archives[0].id, ...slideContent(archives), tables });
+    let images: string[] = [];
+    try { images = slideImages(archives, dataInfo, allNames); } catch { images = []; }
+    slides.set(archives[0].id, { id: archives[0].id, ...slideContent(archives), tables, images });
   }
   if (!slides.size) return [];
 


### PR DESCRIPTION
Promotes #314 — the iWork viewer now shows user-placed images on each slide (already verified live via the develop→prod deploy).