### PR TITLE
Fix teleprompter phone link dropping on transient ICE disconnect

### DIFF
--- a/src/hooks/useTeleprompterLink.ts
+++ b/src/hooks/useTeleprompterLink.ts
@@ -6,6 +6,9 @@ import { encodeMsg, decodeMsg, type RemoteMsg } from '@/tools/media/teleprompter
 
 export type LinkStatus = 'idle' | 'waiting' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
+/** Let a transient ICE 'disconnected' self-heal before we report a drop. */
+const DISCONNECT_GRACE_MS = 5000;
+
 /**
  * Pair two devices for the teleprompter over the shared WebRTC stack and carry
  * RemoteMsg control traffic on the data channel. The host waits for the guest;
@@ -17,19 +20,24 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
   const signalRef = useRef<SignalClient | null>(null);
   const peerRef = useRef<PeerHandles | null>(null);
   const channelRef = useRef<RTCDataChannel | null>(null);
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onMsgRef = useRef(onMessage);
   onMsgRef.current = onMessage;
 
+  const clearDisconnect = useCallback(() => {
+    if (disconnectTimerRef.current) { clearTimeout(disconnectTimerRef.current); disconnectTimerRef.current = null; }
+  }, []);
+
   const wireChannel = useCallback((ch: RTCDataChannel) => {
     channelRef.current = ch;
-    ch.onopen = () => setStatus('connected');
+    ch.onopen = () => { clearDisconnect(); setStatus('connected'); };
     ch.onclose = () => setStatus('disconnected');
     ch.onmessage = (e) => {
       if (typeof e.data !== 'string') return;
       const m = decodeMsg(e.data);
       if (m) onMsgRef.current(m);
     };
-  }, []);
+  }, [clearDisconnect]);
 
   const setupPeer = useCallback((initiator: boolean) => {
     peerRef.current?.close();
@@ -37,12 +45,16 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
       initiator,
       sendSignal: (msg) => signalRef.current?.send(msg),
       onState: (s) => {
-        if (s === 'connected') setStatus('connected');
-        else if (s === 'failed' || s === 'disconnected' || s === 'closed') setStatus('disconnected');
+        if (s === 'connected') { clearDisconnect(); setStatus('connected'); }
+        // A bare ICE 'disconnected' is often transient — wait before reporting it.
+        else if (s === 'disconnected') {
+          clearDisconnect();
+          disconnectTimerRef.current = setTimeout(() => setStatus('disconnected'), DISCONNECT_GRACE_MS);
+        } else if (s === 'failed' || s === 'closed') { clearDisconnect(); setStatus('disconnected'); }
       },
       onChannel: wireChannel,
     });
-  }, [wireChannel]);
+  }, [wireChannel, clearDisconnect]);
 
   const connect = useCallback((code: string, role: 'host' | 'guest') => {
     setStatus(role === 'host' ? 'waiting' : 'connecting');
@@ -66,13 +78,15 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
   }, []);
 
   const close = useCallback(() => {
+    clearDisconnect();
     channelRef.current = null;
     peerRef.current?.close(); peerRef.current = null;
     signalRef.current?.close(); signalRef.current = null;
     setStatus('idle');
-  }, []);
+  }, [clearDisconnect]);
 
   useEffect(() => () => {
+    if (disconnectTimerRef.current) clearTimeout(disconnectTimerRef.current);
     channelRef.current = null;
     peerRef.current?.close();
     signalRef.current?.close();


### PR DESCRIPTION
Follow-up to #320. A production two-context E2E showed the pairing genuinely works (the guest received the full script over the P2P channel), but the host then flashed **Phone disconnected** and a reverse command didn't land.

Root cause: the link hook treated a bare `connectionState === 'disconnected'` as terminal, but that's usually a momentary ICE blip that self-heals. File Transfer already handles this with a 5s grace period.

Fix: wait `DISCONNECT_GRACE_MS` (5s) before reporting a drop, clear the timer when the channel reopens, and rely on the data channel's `onopen`/`onclose` as the real connected/disconnected signal. `failed`/`closed` still report immediately.

tsc clean · lint 0 · build OK. Will re-run the two-device E2E on production after deploy.