### PR TITLE
Promote to production: teleprompter link grace fix

### DIFF
--- a/src/hooks/useTeleprompterLink.ts
+++ b/src/hooks/useTeleprompterLink.ts
@@ -6,6 +6,9 @@ import { encodeMsg, decodeMsg, type RemoteMsg } from '@/tools/media/teleprompter
 
 export type LinkStatus = 'idle' | 'waiting' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
+/** Let a transient ICE 'disconnected' self-heal before we report a drop. */
+const DISCONNECT_GRACE_MS = 5000;
+
 /**
  * Pair two devices for the teleprompter over the shared WebRTC stack and carry
  * RemoteMsg control traffic on the data channel. The host waits for the guest;
@@ -17,19 +20,24 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
   const signalRef = useRef<SignalClient | null>(null);
   const peerRef = useRef<PeerHandles | null>(null);
   const channelRef = useRef<RTCDataChannel | null>(null);
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onMsgRef = useRef(onMessage);
   onMsgRef.current = onMessage;
 
+  const clearDisconnect = useCallback(() => {
+    if (disconnectTimerRef.current) { clearTimeout(disconnectTimerRef.current); disconnectTimerRef.current = null; }
+  }, []);
+
   const wireChannel = useCallback((ch: RTCDataChannel) => {
     channelRef.current = ch;
-    ch.onopen = () => setStatus('connected');
+    ch.onopen = () => { clearDisconnect(); setStatus('connected'); };
     ch.onclose = () => setStatus('disconnected');
     ch.onmessage = (e) => {
       if (typeof e.data !== 'string') return;
       const m = decodeMsg(e.data);
       if (m) onMsgRef.current(m);
     };
-  }, []);
+  }, [clearDisconnect]);
 
   const setupPeer = useCallback((initiator: boolean) => {
     peerRef.current?.close();
@@ -37,12 +45,16 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
       initiator,
       sendSignal: (msg) => signalRef.current?.send(msg),
       onState: (s) => {
-        if (s === 'connected') setStatus('connected');
-        else if (s === 'failed' || s === 'disconnected' || s === 'closed') setStatus('disconnected');
+        if (s === 'connected') { clearDisconnect(); setStatus('connected'); }
+        // A bare ICE 'disconnected' is often transient — wait before reporting it.
+        else if (s === 'disconnected') {
+          clearDisconnect();
+          disconnectTimerRef.current = setTimeout(() => setStatus('disconnected'), DISCONNECT_GRACE_MS);
+        } else if (s === 'failed' || s === 'closed') { clearDisconnect(); setStatus('disconnected'); }
       },
       onChannel: wireChannel,
     });
-  }, [wireChannel]);
+  }, [wireChannel, clearDisconnect]);
 
   const connect = useCallback((code: string, role: 'host' | 'guest') => {
     setStatus(role === 'host' ? 'waiting' : 'connecting');
@@ -66,13 +78,15 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
   }, []);
 
   const close = useCallback(() => {
+    clearDisconnect();
     channelRef.current = null;
     peerRef.current?.close(); peerRef.current = null;
     signalRef.current?.close(); signalRef.current = null;
     setStatus('idle');
-  }, []);
+  }, [clearDisconnect]);
 
   useEffect(() => () => {
+    if (disconnectTimerRef.current) clearTimeout(disconnectTimerRef.current);
     channelRef.current = null;
     peerRef.current?.close();
     signalRef.current?.close();


### PR DESCRIPTION
Promotes #322 — keep the phone link alive through a transient ICE disconnect.