### PR TITLE
Promote to production: teleprompter TURN relay

### DIFF
--- a/src/hooks/useTeleprompterLink.ts
+++ b/src/hooks/useTeleprompterLink.ts
@@ -2,7 +2,25 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { connectSignal, type SignalClient } from '@/tools/webrtc/signal-client';
 import { createPeer, type PeerHandles } from '@/tools/webrtc/peer';
 import type { SignalMessage } from '@/tools/webrtc/signal.lib';
+import { DEFAULT_ICE_SERVERS } from '@/tools/webrtc/ice.lib';
 import { encodeMsg, decodeMsg, type RemoteMsg } from '@/tools/media/teleprompter-remote.lib';
+
+/**
+ * Fetch short-lived TURN credentials so pairing works across strict NATs (a
+ * phone on mobile data). Falls back to STUN-only if TURN isn't configured.
+ */
+async function fetchIceServers(): Promise<RTCIceServer[]> {
+  try {
+    const res = await fetch('/api/turn', { cache: 'no-store' });
+    if (!res.ok) return DEFAULT_ICE_SERVERS;
+    const data = (await res.json()) as { iceServers?: RTCIceServer | RTCIceServer[] };
+    const t = data.iceServers;
+    const turn = Array.isArray(t) ? t : t ? [t] : [];
+    return turn.length ? [...DEFAULT_ICE_SERVERS, ...turn] : DEFAULT_ICE_SERVERS;
+  } catch {
+    return DEFAULT_ICE_SERVERS;
+  }
+}
 
 export type LinkStatus = 'idle' | 'waiting' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -21,6 +39,7 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
   const peerRef = useRef<PeerHandles | null>(null);
   const channelRef = useRef<RTCDataChannel | null>(null);
   const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const iceRef = useRef<RTCIceServer[]>(DEFAULT_ICE_SERVERS);
   const onMsgRef = useRef(onMessage);
   onMsgRef.current = onMessage;
 
@@ -53,22 +72,28 @@ export function useTeleprompterLink(onMessage: (m: RemoteMsg) => void) {
         } else if (s === 'failed' || s === 'closed') { clearDisconnect(); setStatus('disconnected'); }
       },
       onChannel: wireChannel,
+      iceServers: iceRef.current,
     });
   }, [wireChannel, clearDisconnect]);
 
   const connect = useCallback((code: string, role: 'host' | 'guest') => {
     setStatus(role === 'host' ? 'waiting' : 'connecting');
-    signalRef.current = connectSignal(code, {
-      onMessage: (msg: SignalMessage) => {
-        switch (msg.type) {
-          case 'welcome': if (msg.role === 'guest') setupPeer(false); else setStatus('waiting'); break;
-          case 'peer-joined': setupPeer(true); break;
-          case 'peer-left': setStatus('disconnected'); break;
-          case 'full': setStatus('error'); break;
-          default: void peerRef.current?.applySignal(msg); // offer / answer / ice
-        }
-      },
-      onError: () => setStatus('error'),
+    // Get TURN credentials first so the peer (created on the next signaling
+    // message) can traverse strict NATs; then open the signaling channel.
+    void fetchIceServers().then((ice) => {
+      iceRef.current = ice;
+      signalRef.current = connectSignal(code, {
+        onMessage: (msg: SignalMessage) => {
+          switch (msg.type) {
+            case 'welcome': if (msg.role === 'guest') setupPeer(false); else setStatus('waiting'); break;
+            case 'peer-joined': setupPeer(true); break;
+            case 'peer-left': setStatus('disconnected'); break;
+            case 'full': setStatus('error'); break;
+            default: void peerRef.current?.applySignal(msg); // offer / answer / ice
+          }
+        },
+        onError: () => setStatus('error'),
+      });
     });
   }, [setupPeer]);
 

--- a/src/islands/media/Teleprompter.tsx
+++ b/src/islands/media/Teleprompter.tsx
@@ -34,7 +34,7 @@ const TR: Record<Lang, Record<string, string>> = {
     empty: 'Type or paste a script above, then press Start.',
     pair: 'Pair phone', pairing: 'Scan with your phone', code: 'Code',
     waiting: 'Waiting for phone…', phoneOn: 'Phone connected', phoneOff: 'Phone disconnected',
-    pairNote: 'Your phone pairs over a direct connection between your two devices — only the pairing code and connection details use our server, never the script.',
+    pairNote: 'Paired over a direct device-to-device connection. On strict networks (e.g. mobile data) it relays through Cloudflare’s TURN service, which then sees your devices’ IP addresses. The script is never stored.',
     remoteTitle: 'Remote control', connecting: 'Connecting to the teleprompter…', top: 'Top',
   },
   id: {
@@ -49,7 +49,7 @@ const TR: Record<Lang, Record<string, string>> = {
     empty: 'Ketik atau tempel naskah di atas, lalu tekan Mulai.',
     pair: 'Pair phone', pairing: 'Pindai dengan ponsel', code: 'Kode',
     waiting: 'Menunggu ponsel…', phoneOn: 'Ponsel terhubung', phoneOff: 'Ponsel terputus',
-    pairNote: 'Ponsel Anda dipasangkan lewat koneksi langsung antar dua perangkat — hanya kode pemasangan dan detail koneksi yang memakai server kami, bukan naskahnya.',
+    pairNote: 'Terhubung langsung antar dua perangkat. Di jaringan ketat (mis. data seluler) koneksi direlai lewat layanan TURN Cloudflare, yang lalu melihat alamat IP perangkat Anda. Naskah tidak pernah disimpan.',
     remoteTitle: 'Kendali jarak jauh', connecting: 'Menghubungkan ke teleprompter…', top: 'Atas',
   },
 };

--- a/src/registry/tool-seo.ts
+++ b/src/registry/tool-seo.ts
@@ -2701,7 +2701,7 @@ const en: Record<string, ToolSeoContent> = {
     ],
     faqs: [
       { q: 'Is my script uploaded?', a: 'No. The script is stored only in your browser and never sent anywhere. It is also saved locally so it survives a page reload.' },
-      { q: 'How does the phone remote work?', a: 'Your phone pairs over a direct connection between your two devices; the script and controls are sent device-to-device and only the pairing (a short code and connection details) uses our server. If the phone disconnects, the teleprompter keeps running.' },
+      { q: 'How does the phone remote work?', a: 'Your phone pairs over a direct connection between your two devices; the script and controls are sent device-to-device and only the pairing (a short code and connection details) uses our server. On strict networks (such as mobile data) the connection may relay through Cloudflare’s TURN service, which then sees your devices’ IP addresses. If the phone disconnects, the teleprompter keeps running.' },
       { q: 'How does voice-tracking work and is it private?', a: 'It uses your browser’s built-in speech recognition to advance the text as you read. In Chrome and Edge that sends microphone audio to the browser’s speech service (e.g. Google) to transcribe — so avoid it for sensitive material. Auto-scroll needs no microphone.' },
       { q: 'Which browsers support voice-tracking?', a: 'Chrome and Edge (desktop) support it. On Safari and Firefox the voice option is hidden, but adjustable auto-scroll still works.' },
       { q: 'Can I use it with a teleprompter (beam-splitter) rig?', a: 'Yes — turn on mirror mode to flip the text horizontally (and vertically if needed) so it reads correctly in the reflection.' },
@@ -5681,7 +5681,7 @@ const id: Record<string, ToolSeoContent> = {
     ],
     faqs: [
       { q: 'Apakah naskah saya diunggah?', a: 'Tidak. Naskah hanya disimpan di browser Anda dan tidak dikirim ke mana pun. Naskah juga tersimpan lokal sehingga bertahan saat halaman dimuat ulang.' },
-      { q: 'Bagaimana remote ponsel bekerja?', a: 'Ponsel Anda dipasangkan lewat koneksi langsung antar dua perangkat Anda; naskah dan kontrol dikirim antar-perangkat dan hanya proses pemasangan (kode singkat dan detail koneksi) yang memakai server kami. Jika ponsel terputus, teleprompter tetap berjalan.' },
+      { q: 'Bagaimana remote ponsel bekerja?', a: 'Ponsel Anda dipasangkan lewat koneksi langsung antar dua perangkat Anda; naskah dan kontrol dikirim antar-perangkat dan hanya proses pemasangan (kode singkat dan detail koneksi) yang memakai server kami. Di jaringan ketat (seperti data seluler) koneksi bisa direlai lewat layanan TURN Cloudflare, yang lalu melihat alamat IP perangkat Anda. Jika ponsel terputus, teleprompter tetap berjalan.' },
       { q: 'Bagaimana pelacakan suara bekerja dan apakah privat?', a: 'Ia memakai pengenalan suara bawaan browser untuk memajukan teks saat Anda membaca. Di Chrome dan Edge, audio mikrofon dikirim ke layanan suara browser (mis. Google) untuk ditranskripsi — jadi hindari untuk materi sensitif. Auto-scroll tidak butuh mikrofon.' },
       { q: 'Browser apa yang mendukung pelacakan suara?', a: 'Chrome dan Edge (desktop) mendukungnya. Di Safari dan Firefox opsi suara disembunyikan, tetapi auto-scroll yang bisa diatur tetap berfungsi.' },
       { q: 'Bisakah dipakai dengan rig teleprompter (beam-splitter)?', a: 'Bisa — nyalakan mode cermin untuk membalik teks secara horizontal (dan vertikal bila perlu) agar terbaca benar di pantulan.' },

--- a/worker/index.js
+++ b/worker/index.js
@@ -28,6 +28,34 @@ export default {
       return env.SIGNAL.getByName(roomId).fetch(request);
     }
 
+    // Short-lived TURN credentials from Cloudflare Realtime TURN, so the P2P
+    // tools can traverse strict NATs (e.g. a phone on mobile data). Returns
+    // `{ iceServers: [] }` when TURN isn't configured, so callers fall back to
+    // STUN-only cleanly. Requires the secrets TURN_KEY_ID and TURN_KEY_API_TOKEN.
+    if (url.pathname === '/api/turn') {
+      const empty = () => new Response(JSON.stringify({ iceServers: [] }), {
+        headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+      });
+      if (!env.TURN_KEY_ID || !env.TURN_KEY_API_TOKEN) return empty();
+      try {
+        const res = await fetch(
+          `https://rtc.live.cloudflare.com/v1/turn/keys/${env.TURN_KEY_ID}/credentials/generate-ice-servers`,
+          {
+            method: 'POST',
+            headers: { 'authorization': `Bearer ${env.TURN_KEY_API_TOKEN}`, 'content-type': 'application/json' },
+            body: JSON.stringify({ ttl: 86400 }),
+          },
+        );
+        if (!res.ok) return empty();
+        const data = await res.json();
+        return new Response(JSON.stringify(data), {
+          headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+        });
+      } catch {
+        return empty();
+      }
+    }
+
     // Same-origin proxy for Hugging Face model files. transformers.js fetches
     // Whisper weights from huggingface.co, which 302-redirects large files to a
     // CDN — the browser/Workbox can't reliably cache those redirected responses,


### PR DESCRIPTION
Promotes #324 — /api/turn (Cloudflare TURN) so the phone remote works across networks. Needs the TURN_KEY_ID / TURN_KEY_API_TOKEN Worker secrets to activate; STUN-only until then.