### PR TITLE
Use provided TURN in File Transfer and Video Call

### DIFF
--- a/src/hooks/useTeleprompterLink.ts
+++ b/src/hooks/useTeleprompterLink.ts
@@ -3,23 +3,13 @@ import { connectSignal, type SignalClient } from '@/tools/webrtc/signal-client';
 import { createPeer, type PeerHandles } from '@/tools/webrtc/peer';
 import type { SignalMessage } from '@/tools/webrtc/signal.lib';
 import { DEFAULT_ICE_SERVERS } from '@/tools/webrtc/ice.lib';
+import { fetchTurnServers } from '@/tools/webrtc/turn';
 import { encodeMsg, decodeMsg, type RemoteMsg } from '@/tools/media/teleprompter-remote.lib';
 
-/**
- * Fetch short-lived TURN credentials so pairing works across strict NATs (a
- * phone on mobile data). Falls back to STUN-only if TURN isn't configured.
- */
+/** Default STUN plus any TURN servers, so pairing works across strict NATs. */
 async function fetchIceServers(): Promise<RTCIceServer[]> {
-  try {
-    const res = await fetch('/api/turn', { cache: 'no-store' });
-    if (!res.ok) return DEFAULT_ICE_SERVERS;
-    const data = (await res.json()) as { iceServers?: RTCIceServer | RTCIceServer[] };
-    const t = data.iceServers;
-    const turn = Array.isArray(t) ? t : t ? [t] : [];
-    return turn.length ? [...DEFAULT_ICE_SERVERS, ...turn] : DEFAULT_ICE_SERVERS;
-  } catch {
-    return DEFAULT_ICE_SERVERS;
-  }
+  const turn = await fetchTurnServers();
+  return turn.length ? [...DEFAULT_ICE_SERVERS, ...turn] : DEFAULT_ICE_SERVERS;
 }
 
 export type LinkStatus = 'idle' | 'waiting' | 'connecting' | 'connected' | 'disconnected' | 'error';

--- a/src/islands/files/FileTransfer.tsx
+++ b/src/islands/files/FileTransfer.tsx
@@ -10,6 +10,7 @@ import { useFileTransfer } from '@/hooks/useFileTransfer';
 import { makeRoomId, roomLink, roomIdFromHash } from '@/tools/webrtc/signal.lib';
 import { formatBytes } from '@/tools/webrtc/file-transfer.lib';
 import { effectiveIceServers } from '@/tools/webrtc/ice.lib';
+import { fetchTurnServers } from '@/tools/webrtc/turn';
 import type { Lang } from '@/i18n/config';
 
 type Signaling = 'auto' | 'manual';
@@ -156,6 +157,9 @@ export default function FileTransfer({ lang = 'en' }: { lang?: Lang }) {
   const [acked, setAcked] = useState(false);
   const [signaling, setSignaling] = useState<Signaling>('auto');
   const [iceText, setIceText] = useState('');
+  // Provided TURN servers (from /api/turn) so transfers work across strict NATs.
+  const [turn, setTurn] = useState<RTCIceServer[]>([]);
+  useEffect(() => { fetchTurnServers().then(setTurn); }, []);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   // Auto mode
@@ -204,7 +208,7 @@ export default function FileTransfer({ lang = 'en' }: { lang?: Lang }) {
     try { localStorage.setItem(SIGNALING_KEY, s); } catch { /* ignore */ }
   };
 
-  const ice = () => effectiveIceServers(iceText);
+  const ice = () => [...turn, ...effectiveIceServers(iceText)];
 
   const start = () => {
     setAcked(true);

--- a/src/islands/network/VideoCall.tsx
+++ b/src/islands/network/VideoCall.tsx
@@ -8,6 +8,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { useVideoCall } from '@/hooks/useVideoCall';
 import { makeRoomId, roomLink, roomIdFromHash } from '@/tools/webrtc/signal.lib';
 import { effectiveIceServers } from '@/tools/webrtc/ice.lib';
+import { fetchTurnServers } from '@/tools/webrtc/turn';
 import type { Lang } from '@/i18n/config';
 
 type Signaling = 'auto' | 'manual';
@@ -170,6 +171,9 @@ export default function VideoCall({ lang = 'en' }: { lang?: Lang }) {
   const [acked, setAcked] = useState(false);
   const [signaling, setSignaling] = useState<Signaling>('auto');
   const [iceText, setIceText] = useState('');
+  // Provided TURN servers (from /api/turn) so calls work across strict NATs.
+  const [turn, setTurn] = useState<RTCIceServer[]>([]);
+  useEffect(() => { fetchTurnServers().then(setTurn); }, []);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [joining, setJoining] = useState(false);
@@ -200,7 +204,7 @@ export default function VideoCall({ lang = 'en' }: { lang?: Lang }) {
 
   const persistIce = (t: string) => { setIceText(t); try { localStorage.setItem(ICE_KEY, t); } catch { /* */ } };
   const persistSignaling = (s: Signaling) => { setSignaling(s); try { localStorage.setItem(SIGNALING_KEY, s); } catch { /* */ } };
-  const ice = () => effectiveIceServers(iceText);
+  const ice = () => [...turn, ...effectiveIceServers(iceText)];
 
   const start = async () => {
     setAcked(true);

--- a/src/tools/webrtc/turn.ts
+++ b/src/tools/webrtc/turn.ts
@@ -1,0 +1,23 @@
+/**
+ * Fetch short-lived TURN credentials from our `/api/turn` Worker route (backed by
+ * Cloudflare Realtime TURN) so the P2P tools can traverse strict NATs — e.g. a
+ * phone on mobile data connecting to a laptop on Wi-Fi.
+ *
+ * Returns the TURN server entries only (callers merge them with their own
+ * STUN/default and any user-supplied servers). Returns an empty array when TURN
+ * isn't configured or on any error, so callers degrade to STUN-only cleanly.
+ *
+ * TURN is a fallback: ICE always prefers a direct host/reflexive path, so pairing
+ * stays device-to-device on the same network and only relays when it must.
+ */
+export async function fetchTurnServers(): Promise<RTCIceServer[]> {
+  try {
+    const res = await fetch('/api/turn', { cache: 'no-store' });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { iceServers?: RTCIceServer | RTCIceServer[] };
+    const t = data.iceServers;
+    return Array.isArray(t) ? t : t ? [t] : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Now that `/api/turn` exists (from #324), extend it to the other two P2P tools so they work across networks out of the box — not just the teleprompter.

- New shared `src/tools/webrtc/turn.ts` → `fetchTurnServers()` (returns the TURN entries, or [] when unconfigured). The teleprompter hook now uses it too (DRY).
- **File Transfer** and **Video Call** fetch `/api/turn` on mount and **prepend** the servers to their ICE list. The existing 'bring your own STUN/TURN' box still works and is merged in. TURN is a fallback (ICE prefers a direct path), so same-network transfers/calls stay device-to-device.
- Degrades to STUN-only cleanly when TURN isn't configured — no behaviour change until the `TURN_KEY_ID`/`TURN_KEY_API_TOKEN` secrets are set.

tsc clean (the pre-existing `turndown` type warnings are unrelated) · lint 0 · full suite **1803** · build OK.