### PR TITLE
Promote to production: SEO indexing fix + ID schema/labels

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,9 +22,13 @@ if (process.env.WORKERS_CI === '1') {
   if (process.env.PUBLIC_GA_ID === undefined) {
     process.env.PUBLIC_GA_ID = isProductionBranch ? PROD_GA_ID : '';
   }
-  if (process.env.PUBLIC_NOINDEX === undefined) {
-    process.env.PUBLIC_NOINDEX = isProductionBranch ? '' : '1';
-  }
+  // Indexing is OPT-OUT, not auto-gated by branch: the WORKERS_CI_BRANCH check
+  // proved unreliable in the production build (it silently noindex'd the whole
+  // live site — the same failure that once blanked Google Analytics, which we
+  // fixed by not trusting the branch env). So pages are index,follow by default
+  // and only noindex when PUBLIC_NOINDEX is explicitly set to "1"/"true".
+  // Non-production Workers (e.g. goodwebtools-staging) set PUBLIC_NOINDEX=1 as a
+  // build var so preview deploys stay out of the index.
 }
 
 export default defineConfig({

--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from 'lucide-react';
 import { tools } from '@/registry/tools';
-import { categories, categoryColors, categoryNotes, categorySlug } from '@/registry/categories';
+import { categories, categoryColors, categoryNotes, categorySlug, categoryName } from '@/registry/categories';
 import { localizedTool } from '@/registry/tool-i18n';
 import { localizePath, DEFAULT_LOCALE, type Lang } from '@/i18n/config';
 
@@ -27,7 +27,7 @@ export function ToolGrid({ lang = DEFAULT_LOCALE }: { lang?: Lang }) {
               <span
                 className={`inline-block h-4 w-4 border-2 border-border ${categoryColors[category]}`}
               />
-              <h2 className="text-xl font-bold uppercase tracking-tight group-hover:underline">{category}</h2>
+              <h2 className="text-xl font-bold uppercase tracking-tight group-hover:underline">{categoryName(category, lang)}</h2>
               <span className="text-sm font-bold text-muted-foreground">
                 ({categoryTools.filter(tool => !tool.desktopOnly).length})
               </span>

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Command } from 'cmdk';
 import { searchTools } from '@/registry/tools';
 import { localizedTool } from '@/registry/tool-i18n';
-import { categories } from '@/registry/categories';
+import { categories, categoryName } from '@/registry/categories';
 import { isTauri } from '@/services/platform';
 import { localizePath } from '@/i18n/config';
 import { useLang } from '@/i18n/shared';
@@ -72,7 +72,7 @@ export function CommandPalette() {
               return (
                 <Command.Group
                   key={category}
-                  heading={category}
+                  heading={categoryName(category, lang)}
                   className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-bold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-muted-foreground"
                 >
                   {categoryTools.map(tool => {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -50,6 +50,11 @@ const alternates = localized
   ? LOCALES.map(l => ({ hreflang: l, href: new URL(localizePath(basePath, l), SITE_URL).href }))
   : [];
 const ogLocale = lang === 'id' ? 'id_ID' : 'en_US';
+const ogLocaleAlt = lang === 'id' ? 'en_US' : 'id_ID';
+const siteDescription =
+  lang === 'id'
+    ? 'Utilitas sisi-klien yang mengutamakan privasi dan berjalan sepenuhnya di browser Anda — tanpa unggahan, tanpa server.'
+    : SITE_TAGLINE;
 
 // Site-wide structured data + any page-specific graph.
 const siteJsonLd = {
@@ -57,7 +62,8 @@ const siteJsonLd = {
   '@type': 'WebSite',
   name: SITE_NAME,
   url: SITE_URL,
-  description: SITE_TAGLINE,
+  description: siteDescription,
+  inLanguage: lang === 'id' ? 'id' : 'en',
 };
 const jsonLdBlocks = [siteJsonLd, ...(Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : [])];
 ---
@@ -79,6 +85,7 @@ const jsonLdBlocks = [siteJsonLd, ...(Array.isArray(jsonLd) ? jsonLd : jsonLd ? 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:locale" content={ogLocale} />
+    {localized && <meta property="og:locale:alternate" content={ogLocaleAlt} />}
     <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />

--- a/src/pages/[...locale]/category/[category].astro
+++ b/src/pages/[...locale]/category/[category].astro
@@ -3,7 +3,7 @@ import { ChevronRight } from 'lucide-react';
 import Base from '@/layouts/Base.astro';
 import { tools } from '@/registry/tools';
 import { localizedTool } from '@/registry/tool-i18n';
-import { categories, categoryColors, catDescription, categorySlug, categoryFaqs, categoryNotes } from '@/registry/categories';
+import { categories, categoryColors, catDescription, categorySlug, categoryFaqs, categoryNotes, categoryName } from '@/registry/categories';
 import { SITE_URL, SITE_NAME } from '@/config';
 import type { Category } from '@/types/tool';
 import { LOCALES, localeParam, localizePath, type Lang } from '@/i18n/config';
@@ -19,7 +19,8 @@ export function getStaticPaths() {
 
 const { category, lang } = Astro.props as { category: Category; lang: Lang };
 const categoryTools = tools.filter(t2 => t2.category === category && !t2.desktopOnly);
-const pageTitle = t(lang, 'category.heading', { category });
+const catName = categoryName(category, lang);
+const pageTitle = t(lang, 'category.heading', { category: catName });
 const description = catDescription(category, lang);
 const homePath = localizePath('/', lang);
 const pageUrl = new URL(localizePath(`/category/${categorySlug(category)}`, lang), SITE_URL).href;
@@ -35,7 +36,7 @@ const breadcrumbJsonLd = {
 const itemListJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'ItemList',
-  name: `${category} tools on ${SITE_NAME}`,
+  name: lang === 'id' ? `Tool ${catName} di ${SITE_NAME}` : `${category} tools on ${SITE_NAME}`,
   numberOfItems: categoryTools.length,
   itemListElement: categoryTools.map((t2, i) => ({
     '@type': 'ListItem',
@@ -49,6 +50,7 @@ const faqs = categoryFaqs(category, lang);
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
+  inLanguage: lang === 'id' ? 'id' : 'en',
   mainEntity: faqs.map(f => ({
     '@type': 'Question',
     name: f.q,
@@ -72,7 +74,7 @@ const keywords = [
 ---
 
 <Base
-  title={t(lang, 'category.freePrivate', { category })}
+  title={t(lang, 'category.freePrivate', { category: catName })}
   description={description}
   keywords={keywords}
   jsonLd={[breadcrumbJsonLd, itemListJsonLd, faqJsonLd]}
@@ -143,7 +145,7 @@ const keywords = [
             <a href={localizePath(`/category/${categorySlug(c)}`, lang)}
               class="inline-flex items-center gap-1.5 border-2 border-border bg-muted px-3 py-1.5 text-sm font-bold shadow-brutal-sm press-brutal">
               <span class={`inline-block h-3 w-3 border border-border ${categoryColors[c]}`} />
-              {t(lang, 'category.heading', { category: c })}
+              {t(lang, 'category.heading', { category: categoryName(c, lang) })}
             </a>
           </li>
         ))}

--- a/src/pages/[...locale]/index.astro
+++ b/src/pages/[...locale]/index.astro
@@ -26,7 +26,7 @@ const homeKeywords = [
 const toolList = {
   '@context': 'https://schema.org',
   '@type': 'ItemList',
-  name: 'GoodWebTools catalog',
+  name: lang === 'id' ? 'Katalog GoodWebTools' : 'GoodWebTools catalog',
   numberOfItems: tools.length,
   itemListElement: tools.map((tool, i) => {
     const label = localizedTool(tool, lang);

--- a/src/pages/[...locale]/tools/[tool].astro
+++ b/src/pages/[...locale]/tools/[tool].astro
@@ -6,7 +6,7 @@ import ShareButton from '@/islands/share/ShareButton';
 import { tools, getToolById } from '@/registry/tools';
 import { localizedTool } from '@/registry/tool-i18n';
 import { getToolSeo } from '@/registry/tool-seo';
-import { categoryColors, categorySlug } from '@/registry/categories';
+import { categoryColors, categorySlug, categoryName } from '@/registry/categories';
 import { SITE_URL, SITE_NAME } from '@/config';
 import { LOCALES, localeParam, localizePath, type Lang } from '@/i18n/config';
 import { t } from '@/i18n/ui';
@@ -35,7 +35,8 @@ const metaDescription =
 // Localized links.
 const homePath = localizePath('/', lang);
 const catPath = localizePath(`/category/${categorySlug(tool.category)}`, lang);
-const catLabel = t(lang, 'category.heading', { category: tool.category });
+const catName = categoryName(tool.category, lang);
+const catLabel = t(lang, 'category.heading', { category: catName });
 const relatedTools = tools
   .filter(t2 => t2.category === tool.category && t2.id !== tool.id && !t2.desktopOnly)
   .slice(0, 6);
@@ -52,6 +53,7 @@ const softwareJsonLd = {
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   browserRequirements: 'Requires a modern web browser with JavaScript.',
   publisher: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL },
+  inLanguage: lang === 'id' ? 'id' : 'en',
 };
 const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
@@ -62,19 +64,14 @@ const breadcrumbJsonLd = {
     { '@type': 'ListItem', position: 3, name: label.name, item: toolUrl },
   ],
 };
+// NOTE: no HowTo JSON-LD — Google deprecated the HowTo rich result (Sept 2023),
+// so it earns no SERP feature; the on-page how-to steps below are the real value.
 const jsonLd: Record<string, unknown>[] = [softwareJsonLd, breadcrumbJsonLd];
-if (seo?.howTo && seo.howTo.length > 0) {
-  jsonLd.push({
-    '@context': 'https://schema.org',
-    '@type': 'HowTo',
-    name: t(lang, 'tool.howTo', { name: label.name }),
-    step: seo.howTo.map((text, i) => ({ '@type': 'HowToStep', position: i + 1, text })),
-  });
-}
 if (seo?.faqs && seo.faqs.length > 0) {
   jsonLd.push({
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
+    inLanguage: lang === 'id' ? 'id' : 'en',
     mainEntity: seo.faqs.map(f => ({
       '@type': 'Question',
       name: f.q,
@@ -101,7 +98,7 @@ if (seo?.faqs && seo.faqs.length > 0) {
         </li>
         <li aria-hidden="true"><ChevronRight className="h-3.5 w-3.5" /></li>
         <li>
-          <a href={catPath} class="border-2 border-border bg-muted px-2 py-1 text-foreground shadow-brutal-sm press-brutal">{tool.category}</a>
+          <a href={catPath} class="border-2 border-border bg-muted px-2 py-1 text-foreground shadow-brutal-sm press-brutal">{catName}</a>
         </li>
         <li aria-hidden="true"><ChevronRight className="h-3.5 w-3.5" /></li>
         <li aria-current="page" class="text-foreground">{label.name}</li>
@@ -157,18 +154,19 @@ if (seo?.faqs && seo.faqs.length > 0) {
 
         {relatedTools.length > 0 && (
           <section aria-labelledby="related-heading">
-            <h2 id="related-heading" class="mb-4 text-xl font-bold uppercase tracking-tight">{t(lang, 'tool.related', { category: tool.category })}</h2>
+            <h2 id="related-heading" class="mb-4 text-xl font-bold uppercase tracking-tight">{t(lang, 'tool.related', { category: catName })}</h2>
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {relatedTools.map(rt => {
                 const Icon = rt.icon;
+                const rtLabel = localizedTool(rt, lang);
                 return (
                   <a href={localizePath(rt.route, lang)} class="group flex items-start gap-3 border-2 border-border bg-muted p-4 shadow-brutal-sm press-brutal">
                     <span class={`mt-0.5 border-2 border-border p-2 text-black ${categoryColors[rt.category]}`}>
                       <Icon className="h-4 w-4" />
                     </span>
                     <span class="min-w-0">
-                      <span class="block font-bold">{rt.name}</span>
-                      <span class="block text-sm text-muted-foreground">{rt.summary}</span>
+                      <span class="block font-bold">{rtLabel.name}</span>
+                      <span class="block text-sm text-muted-foreground">{rtLabel.summary}</span>
                     </span>
                   </a>
                 );

--- a/src/registry/categories.ts
+++ b/src/registry/categories.ts
@@ -53,6 +53,25 @@ export function categorySlug(category: Category): string {
   return category.toLowerCase();
 }
 
+/**
+ * Localized category display name. Bahasa keeps established loanwords for the
+ * tech-native categories (PDF, Dev, Media, Network, Maps, Playground) and
+ * translates the everyday nouns, so ID pages don't show "Tool Image" etc.
+ * Anything without a mapping falls back to the English name.
+ */
+export const categoryNamesId: Partial<Record<Category, string>> = {
+  Image: 'Gambar',
+  Documents: 'Dokumen',
+  Files: 'Berkas',
+  Calculators: 'Kalkulator',
+  Games: 'Game',
+  Testers: 'Penguji',
+  Draw: 'Menggambar',
+};
+export function categoryName(category: Category, lang: Lang): string {
+  return lang === 'id' ? categoryNamesId[category] ?? category : category;
+}
+
 /** Category lead copy in the given language (English fallback). */
 export function catDescription(category: Category, lang: Lang): string {
   return lang === 'id' ? categoryDescriptionsId[category] : categoryDescriptions[category];


### PR DESCRIPTION
Promotes #330 to production.

**Critical:** production was serving site-wide `noindex, nofollow` due to unreliable branch detection in the build. Now indexing is opt-out (only noindex when `PUBLIC_NOINDEX=1`).

Also: ID JSON-LD `inLanguage`, localized WebSite.description / ItemList.name / category names (Image→Gambar etc.), removed deprecated HowTo schema, `og:locale:alternate`, localized related-tools cards.

CI green on #330 (Test·Build·Lint + Workers Builds).