### PR TITLE
Promote: agent tool-routing fixes (crop → GWT tool, no competitor tips)

### DIFF
--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -17,7 +17,12 @@ export interface ChatUiTurn {
   href?: string;
 }
 
-const CHAT_SYSTEM = "You are GoodWebTools' friendly assistant. Reply in ONE short, friendly sentence. You can run tools for tasks like compressing images, making QR codes, hashing or encoding text — offer to help if it fits.";
+const CHAT_SYSTEM = [
+  "You are GoodWebTools' assistant. GoodWebTools is a free site with 190+ privacy-first tools that run entirely in the browser (image/PDF/video/audio editing, converters, dev utilities, and more).",
+  'Reply in 1–2 short, friendly sentences.',
+  "NEVER recommend external or competitor websites, apps, or software (e.g. Photoshop, Canva, iLoveIMG, Photopea) — and don't give generic OS/phone instructions. If the user wants to DO something, assume GoodWebTools has a tool for it and offer to open it (tell them to just ask, e.g. \"want me to crop it?\").",
+  'If you are unsure whether a tool exists, say you can look for one rather than sending them elsewhere.',
+].join(' ');
 
 /**
  * Orchestrates one agent conversation over any `AgentProvider`:

--- a/src/tools/agent/executors.test.ts
+++ b/src/tools/agent/executors.test.ts
@@ -50,6 +50,12 @@ describe('executor registry', () => {
     expect(ids).toContain('video-to-audio');
     expect(ids).not.toContain('video-convert');
   });
+  it('does not scope media-trim for image cropping (only for audio/video)', () => {
+    expect(scopeExecutors('how to crop image').map(e => e.toolId)).not.toContain('media-trim');
+    expect(scopeExecutors('crop this image').map(e => e.toolId)).not.toContain('media-trim');
+    expect(scopeExecutors('crop this video').map(e => e.toolId)).toContain('media-trim');
+    expect(scopeExecutors('cut this mp3').map(e => e.toolId)).toContain('media-trim');
+  });
   it('does not scope any media compressor for small talk', () => {
     expect(scopeExecutors('hello how are you today')).toEqual([]);
   });

--- a/src/tools/agent/executors.ts
+++ b/src/tools/agent/executors.ts
@@ -464,7 +464,9 @@ export const AGENT_EXECUTORS: AgentExecutor[] = [
   },
   {
     toolId: 'media-trim', description: 'Trim/cut an audio or video file to a time range (start and end, e.g. 0:10 to 0:30)',
-    match: re(/\b(trim|crop|shorten)\b|\bcut\b.*(video|audio|clip|mp3|mp4|song|track|file|this|it)/i),
+    // Require a media noun near the verb so "crop/cut/trim IMAGE" doesn't grab the
+    // audio/video trimmer (image cropping is a different, interactive tool).
+    match: re(/\b(trim|cut|crop|shorten)\b.*(video|audio|clip|mp3|mp4|wav|m4a|song|track|movie|footage|recording|sound)|(video|audio|clip|mp3|mp4|wav|m4a|song|track|movie|footage|recording|sound).*\b(trim|cut|crop|shorten)\b|\b(trim|cut|shorten) (this|it|that)\b/i),
     files: [{ key: 'file', accept: 'audio/*,video/*', label: 'Audio or video' }],
     params: [
       { key: 'start', type: 'string', label: 'Start (e.g. 0:10)', default: '0' },

--- a/src/tools/agent/intent.test.ts
+++ b/src/tools/agent/intent.test.ts
@@ -19,6 +19,16 @@ describe('classifyIntent', () => {
     }
   });
 
+  it('chats about the agent itself instead of routing to a tool', () => {
+    expect(classifyIntent('what model are you').mode).toBe('chat');
+    expect(classifyIntent('who are you').mode).toBe('chat');
+    expect(classifyIntent('what can you do').mode).toBe('chat');
+  });
+  it('opens the image crop tool for "how to crop image" (not the media trimmer)', () => {
+    const i = classifyIntent('how to crop image');
+    expect(i.mode).toBe('open');
+    if (i.mode === 'open') expect(i.candidates[0].id).toBe('image-crop');
+  });
   it('continues the active executor on a param-only follow-up ("50kb")', () => {
     // No "image" word → would otherwise mis-route to pdf-compress. With an active
     // image-compress task, a size tweak stays on it.

--- a/src/tools/agent/intent.ts
+++ b/src/tools/agent/intent.ts
@@ -18,6 +18,10 @@ export type Intent =
 // smaller", "again", "to 300"). Used only when a tool is already active.
 const CONTINUATION = /\b\d+(\.\d+)?\s?(kb|mb|gb|%|px|k|m)\b|\b(make it|instead|again|smaller|bigger|larger|lower|higher|reduce|to \d)/i;
 
+// Questions about the agent itself — must chat, not route to a tool. Otherwise
+// "what model are you" matches the browser-info tool (it has a "model" keyword).
+const META = /\b(who are you|what are you|which model|what model are you|are you (an? )?(ai|llm|bot|gpt|model|human)|your name|what can you do|what do you do|how do you work|are you (chatgpt|claude|gpt|gemini))\b/i;
+
 /**
  * Decide how to handle a message. `activeToolId` (the tool from the previous
  * turn, if any) lets a bare parameter follow-up like "50kb" continue that tool
@@ -25,6 +29,8 @@ const CONTINUATION = /\b\d+(\.\d+)?\s?(kb|mb|gb|%|px|k|m)\b|\b(make it|instead|a
  * 50kb" to the wrong tool because the message no longer contains "image".
  */
 export function classifyIntent(query: string, activeToolId?: string | null): Intent {
+  if (META.test(query)) return { mode: 'chat' };
+
   const scoped = scopeExecutors(query);
   const isContinuation = !!activeToolId && CONTINUATION.test(query);
   const active = activeToolId ? executorFor(activeToolId) : undefined;


### PR DESCRIPTION
Promotes the agent routing fixes from #350 to production.