### PR TITLE
fix(agent): AI-identity detection for plurals + 'u'/'r' shorthand

### DIFF
--- a/src/tools/agent/intent.test.ts
+++ b/src/tools/agent/intent.test.ts
@@ -20,9 +20,13 @@ describe('classifyIntent', () => {
   });
 
   it('chats about the agent itself instead of routing to a tool', () => {
-    expect(classifyIntent('what model are you').mode).toBe('chat');
-    expect(classifyIntent('who are you').mode).toBe('chat');
-    expect(classifyIntent('what can you do').mode).toBe('chat');
+    for (const q of [
+      'what model are you', 'what models are u?', 'which model r you',
+      'who are you', 'who r u', 'what can you do', 'what can u do',
+      'are you an ai', 'are u chatgpt', 'whats your name',
+    ]) {
+      expect(classifyIntent(q).mode, q).toBe('chat');
+    }
   });
   it('opens the image crop tool for "how to crop image" (not the media trimmer)', () => {
     const i = classifyIntent('how to crop image');

--- a/src/tools/agent/intent.ts
+++ b/src/tools/agent/intent.ts
@@ -19,8 +19,9 @@ export type Intent =
 const CONTINUATION = /\b\d+(\.\d+)?\s?(kb|mb|gb|%|px|k|m)\b|\b(make it|instead|again|smaller|bigger|larger|lower|higher|reduce|to \d)/i;
 
 // Questions about the agent itself — must chat, not route to a tool. Otherwise
-// "what model are you" matches the browser-info tool (it has a "model" keyword).
-const META = /\b(who are you|what are you|which model|what model are you|are you (an? )?(ai|llm|bot|gpt|model|human)|your name|what can you do|what do you do|how do you work|are you (chatgpt|claude|gpt|gemini))\b/i;
+// "what model(s) are you/u" matches the browser-info tool (it has a "model"
+// keyword). Handles plurals and "u"/"ya" for "you".
+const META = /\b(what|which)\s+(models?|llms?|ai)\b|\b(who|what)\s+(are|r)\s+(you|u|ya)\b|\bare\s+(you|u|ya)\s+(an?\s+)?(ai|a\.?i\.?|llm|bot|gpt|model|robot|human|chatgpt|claude|gemini|deepseek)\b|\byour\s+name\b|\bwhat\s+(can|do)\s+(you|u|ya)\s+do\b|\bhow\s+do\s+(you|u)\s+work\b/i;
 
 /**
  * Decide how to handle a message. `activeToolId` (the tool from the previous


### PR DESCRIPTION
'What models are u?' still routed to browser-info (META only matched singular 'model'+'you'). Broaden to plurals, llm/ai, and u/r/ya shorthand; 'what is my browser' still routes correctly.