### PR TITLE
Fix CI: scope vitest to src/ (ignore Playwright e2e specs)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
+    // Vitest owns unit tests under src/; Playwright owns the e2e/ specs. Scoping
+    // the include here stops vitest from matching e2e/*.spec.ts (which use the
+    // Playwright runner and would fail as empty "0 test" suites).
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
The Test step failed because vitest matched e2e/*.spec.ts as empty suites. Scopes vitest include to src/**. Unit suite: 2121 pass; e2e run separately via Playwright.