### PR TITLE
Fix mobile video download + large-file error

### DIFF
--- a/src/islands/media/VideoCompress.tsx
+++ b/src/islands/media/VideoCompress.tsx
@@ -28,7 +28,7 @@ const TR: Record<Lang, {
   dropTitle: string; dropSubtitle: string;
   target: string; custom: string; keepAudio: string; maxWidth: string; widthKeep: string; widthHelp: string;
   privacy: string; compress: string; compressing: string; clear: string; working: string; loadEngine: string; encoding: string;
-  duration: string; estimate: string; overBudget: string; result: string; smaller: (p: number) => string; download: string; error: string;
+  duration: string; estimate: string; overBudget: string; result: string; smaller: (p: number) => string; download: string; error: string; largeFile: string;
 }> = {
   en: {
     dropTitle: 'Drop a video or click to browse',
@@ -53,6 +53,7 @@ const TR: Record<Lang, {
     smaller: (p) => `${p}% smaller`,
     download: 'Download MP4',
     error: 'Could not compress this video.',
+    largeFile: 'Large video — mobile browsers can run out of memory on big files. If compressing fails, try a shorter clip, a smaller max width, or the desktop app.',
   },
   id: {
     dropTitle: 'Letakkan video atau klik untuk memilih',
@@ -77,6 +78,7 @@ const TR: Record<Lang, {
     smaller: (p) => `${p}% lebih kecil`,
     download: 'Unduh MP4',
     error: 'Tidak dapat mengompres video ini.',
+    largeFile: 'Video besar — browser mobile bisa kehabisan memori pada file besar. Jika kompresi gagal, coba klip lebih pendek, lebar maksimum lebih kecil, atau pakai desktop app.',
   },
 };
 
@@ -104,6 +106,8 @@ export default function VideoCompress({ lang = 'en' }: { lang?: Lang }) {
   const plan = duration > 0 && targetBytes > 0
     ? computeTargetBitrate({ targetBytes, durationSec: duration, audioKbps: keepAudio ? 128 : 0 })
     : null;
+  // ffmpeg.wasm holds the whole file (~2×) in memory; phones OOM on big videos.
+  const largeVideo = !!file && file.size > 300 * 1024 * 1024;
 
   const onDrop = async (files: File[]) => {
     const video = files.find(f => f.type.startsWith('video/'));
@@ -216,6 +220,7 @@ export default function VideoCompress({ lang = 'en' }: { lang?: Lang }) {
         </p>
       )}
       {plan?.overBudget && <Alert variant="error">{t.overBudget}</Alert>}
+      {largeVideo && !busy && !result && <p className="text-xs text-amber-600 dark:text-amber-400">{t.largeFile}</p>}
 
       <p className="text-xs text-muted-foreground">{t.privacy}</p>
 

--- a/src/services/download.service.test.ts
+++ b/src/services/download.service.test.ts
@@ -28,6 +28,15 @@ describe('DownloadService', () => {
     expect(mockLink.click).toHaveBeenCalled();
   });
 
+  it('appends the link to the document before clicking (mobile/Firefox need it in the DOM)', async () => {
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const blob = new Blob(['test content'], { type: 'text/plain' });
+    await downloadService.download(blob, 'test.txt');
+
+    expect(appendSpy).toHaveBeenCalledWith(mockLink);
+    expect(mockLink.click).toHaveBeenCalled();
+  });
+
   it('should clean up blob URL after download', async () => {
     // Revocation is deferred via setTimeout — advance timers to trigger it.
     vi.useFakeTimers();

--- a/src/services/download.service.ts
+++ b/src/services/download.service.ts
@@ -23,15 +23,32 @@ export class DownloadService {
       }
     }
 
-    // Fallback to blob URL download
+    // Fallback to blob URL download.
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
     link.download = filename;
+    link.rel = 'noopener';
+    link.style.display = 'none';
+    // The anchor MUST be in the document for a synthetic click to trigger a
+    // download on mobile browsers and Firefox — a detached <a>.click() is ignored.
+    document.body.appendChild(link);
     link.click();
 
-    // Clean up
-    setTimeout(() => URL.revokeObjectURL(url), 100);
+    // Keep the object URL alive well past the click. Mobile browsers and large
+    // blobs (e.g. a compressed video) hand off to the download manager
+    // asynchronously; revoking too soon aborts the transfer and the file never
+    // saves. Clean up on a long delay, and on page hide as a backstop.
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      URL.revokeObjectURL(url);
+      link.remove();
+      window.removeEventListener('pagehide', cleanup);
+    };
+    window.addEventListener('pagehide', cleanup);
+    setTimeout(cleanup, 60_000);
   }
 
   async downloadZip(files: BlobFile[], zipName: string): Promise<void> {

--- a/src/tools/media/encode.lib.ts
+++ b/src/tools/media/encode.lib.ts
@@ -35,7 +35,14 @@ async function withFFmpeg<T>(file: Blob, onProgress: EncodeProgress | undefined,
   const cb = ({ progress }: { progress: number }) => onProgress?.(Math.min(1, progress));
   ffmpeg.on('progress', cb);
   try {
-    await ffmpeg.writeFile('in', await fileToU8(file));
+    try {
+      // Reads the whole file into memory then copies it into the WASM heap
+      // (~2× the file size). On phones this overruns the tab's memory budget for
+      // large videos and throws a cryptic NotReadableError — surface a clear one.
+      await ffmpeg.writeFile('in', await fileToU8(file));
+    } catch {
+      throw new Error('This file is too large to load in your browser — it ran out of memory. Try a shorter/smaller clip, or use the desktop app.');
+    }
     return await work(ffmpeg);
   } finally {
     ffmpeg.off('progress', cb);


### PR DESCRIPTION
download.service: append <a> to DOM before click + stop the 100ms premature blob-URL revoke (fixes processed-but-won't-download on mobile/large files, all tools). encode.lib: clear out-of-memory message for oversized files. VideoCompress: upfront large-file warning.