### PR TITLE
Fix the real mobile download path + more OOM messages

### DIFF
--- a/src/islands/dev/BrailleConverter.tsx
+++ b/src/islands/dev/BrailleConverter.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { toBraille } from '@/tools/dev/braille.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -24,12 +25,7 @@ export default function BrailleConverter({ lang = 'en' }: { lang?: Lang }) {
 
   const download = () => {
     const blob = new Blob([braille], { type: 'text/plain;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'braille.txt';
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(blob, 'braille.txt');
   };
 
   return (

--- a/src/islands/documents/DocViewer.tsx
+++ b/src/islands/documents/DocViewer.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { Alert } from '@/components/ui/Alert';
 import { CopyButton } from '@/components/ui/CopyButton';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -48,10 +49,7 @@ export default function DocViewer({ lang = 'en' }: { lang?: Lang }) {
   const download = () => {
     if (text == null) return;
     const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url; a.download = `${name}.txt`; a.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(blob, `${name}.txt`);
   };
 
   const wordCount = text ? text.split(/\s+/).filter(Boolean).length : 0;

--- a/src/islands/documents/EmlViewer.tsx
+++ b/src/islands/documents/EmlViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Dropzone } from '@/components/ui/Dropzone';
 import { Alert } from '@/components/ui/Alert';
 import { formatAddress, formatAddressList } from '@/tools/documents/eml.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 interface ParsedEmail {
@@ -56,12 +57,7 @@ export default function EmlViewer({ lang = 'en' }: { lang?: Lang }) {
   const downloadAttachment = (a: ParsedEmail['attachments'][number]) => {
     const part = typeof a.content === 'string' ? new TextEncoder().encode(a.content) : new Uint8Array(a.content as ArrayBuffer);
     const blob = new Blob([part], { type: a.mimeType || 'application/octet-stream' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = a.filename || 'attachment';
-    link.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(blob, a.filename || 'attachment');
   };
 
   const row = (label: string, value: string) => value ? (

--- a/src/islands/image/BarcodeGenerator.tsx
+++ b/src/islands/image/BarcodeGenerator.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Alert } from '@/components/ui/Alert';
 import { BARCODE_FORMATS, validateValue } from '@/tools/image/barcode.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -60,12 +61,7 @@ export default function BarcodeGenerator({ lang = 'en' }: { lang?: Lang }) {
   const downloadPng = () => {
     canvasRef.current?.toBlob(blob => {
       if (!blob) return;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `barcode-${format}.png`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadService.download(blob, `barcode-${format}.png`);
     });
   };
 
@@ -79,12 +75,7 @@ export default function BarcodeGenerator({ lang = 'en' }: { lang?: Lang }) {
     }
     const xml = new XMLSerializer().serializeToString(svg);
     const blob = new Blob([xml], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `barcode-${format}.svg`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(blob, `barcode-${format}.svg`);
   };
 
   const input = 'w-full border-2 border-border bg-muted p-2 text-sm';

--- a/src/islands/image/ColorBlindSim.tsx
+++ b/src/islands/image/ColorBlindSim.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { usePasteImage } from '@/hooks/usePasteImage';
 import { CVD_TYPES, simulateImageData } from '@/tools/image/colorblind.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -57,12 +58,7 @@ export default function ColorBlindSim({ lang = 'en' }: { lang?: Lang }) {
   const download = () => {
     simRef.current?.toBlob(blob => {
       if (!blob) return;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `colorblind-${type}.png`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadService.download(blob, `colorblind-${type}.png`);
     }, 'image/png');
   };
 

--- a/src/islands/image/DeskewTool.tsx
+++ b/src/islands/image/DeskewTool.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { usePasteImage } from '@/hooks/usePasteImage';
 import { computeHomography, applyHomography, type Point } from '@/tools/image/perspective.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -130,9 +131,8 @@ export default function DeskewTool({ lang = 'en' }: { lang?: Lang }) {
   };
 
   const download = () => {
-    if (!resultUrl) return;
-    const a = document.createElement('a');
-    a.href = resultUrl; a.download = 'deskewed.png'; a.click();
+    if (!result) return;
+    downloadService.download(result, 'deskewed.png');
   };
 
   const backToEdit = () => { setResult(null); setResultUrl(''); };

--- a/src/islands/image/MemeGenerator.tsx
+++ b/src/islands/image/MemeGenerator.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { usePasteImage } from '@/hooks/usePasteImage';
 import { wrapText } from '@/tools/image/meme.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -81,12 +82,7 @@ export default function MemeGenerator({ lang = 'en' }: { lang?: Lang }) {
   const download = () => {
     canvasRef.current?.toBlob(blob => {
       if (!blob) return;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'meme.png';
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadService.download(blob, 'meme.png');
     }, 'image/png');
   };
 

--- a/src/islands/media/TextToSpeech.tsx
+++ b/src/islands/media/TextToSpeech.tsx
@@ -4,6 +4,7 @@ import { Alert } from '@/components/ui/Alert';
 import { splitIntoChunks } from '@/tools/media/tts.lib';
 import { floatToWav } from '@/tools/media/tts-audio.lib';
 import { NEURAL_VOICES } from '@/tools/media/neural-tts.engine';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, {
@@ -91,10 +92,7 @@ export default function TextToSpeech({ lang = 'en' }: { lang?: Lang }) {
   };
 
   const saveBlob = (bytes: Uint8Array, type: string, name: string) => {
-    const url = URL.createObjectURL(new Blob([bytes], { type }));
-    const a = document.createElement('a');
-    a.href = url; a.download = name; a.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(new Blob([bytes], { type }), name);
   };
 
   const downloadWav = () => { if (wavBytesRef.current) saveBlob(wavBytesRef.current, 'audio/wav', 'speech.wav'); };

--- a/src/islands/pdf/PdfToExcel.tsx
+++ b/src/islands/pdf/PdfToExcel.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@/components/ui/Dropzone';
 import { Button } from '@/components/ui/Button';
 import { Alert } from '@/components/ui/Alert';
 import { groupRows, toCsv, type TextItem } from '@/tools/pdf/pdf-table.lib';
+import { downloadService } from '@/services/download';
 import type { Lang } from '@/i18n/config';
 
 const TR: Record<Lang, Record<string, string>> = {
@@ -68,12 +69,7 @@ export default function PdfToExcel({ lang = 'en' }: { lang?: Lang }) {
 
   const download = () => {
     const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = (file ? file.name.replace(/\.pdf$/i, '') : 'table') + '.csv';
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadService.download(blob, (file ? file.name.replace(/\.pdf$/i, '') : 'table') + '.csv');
   };
 
   return (

--- a/src/services/download/browser.ts
+++ b/src/services/download/browser.ts
@@ -26,10 +26,27 @@ export class BrowserDownloadService implements DownloadService {
     const link = document.createElement('a');
     link.href = url;
     link.download = filename;
+    link.rel = 'noopener';
+    link.style.display = 'none';
+    // The anchor MUST be in the document for a synthetic click to trigger a
+    // download on mobile browsers and Firefox — a detached <a>.click() is ignored.
+    document.body.appendChild(link);
     link.click();
 
-    // Clean up
-    setTimeout(() => URL.revokeObjectURL(url), 100);
+    // Keep the object URL alive well past the click. Mobile browsers and large
+    // blobs (e.g. a compressed video) hand off to the download manager
+    // asynchronously; revoking too soon aborts the transfer and the file never
+    // saves. Clean up on a long delay, and on page hide as a backstop.
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      URL.revokeObjectURL(url);
+      link.remove();
+      window.removeEventListener('pagehide', cleanup);
+    };
+    window.addEventListener('pagehide', cleanup);
+    setTimeout(cleanup, 60_000);
   }
 
   async downloadZip(files: BlobFile[], zipName: string): Promise<void> {

--- a/src/tools/pdf/mupdf.client.ts
+++ b/src/tools/pdf/mupdf.client.ts
@@ -23,7 +23,13 @@ function engine(): Remote<MupdfApi> {
 }
 
 async function bytesOf(file: File): Promise<Uint8Array> {
-  return new Uint8Array(await file.arrayBuffer());
+  try {
+    return new Uint8Array(await file.arrayBuffer());
+  } catch {
+    // Reading a very large PDF into one contiguous ArrayBuffer overruns a phone's
+    // tab memory and throws a cryptic NotReadableError — surface a clear one.
+    throw new Error('This PDF is too large to load in your browser — it ran out of memory. Try splitting it or use the desktop app.');
+  }
 }
 
 function toBlob(bytes: Uint8Array): Blob {


### PR DESCRIPTION
browser.ts (the platform-aware path 44 tools incl. VideoCompress actually use) gets the append-to-DOM + delayed-revoke fix — this is what fixes mobile 'processed but won't download'. Converts 9 self-rolled download islands to the shared service. Adds a friendly OOM message to mupdf.client (~20 PDF tools).