### PR TITLE
Fix Sort Text Lines: blank-line ordering + box alignment

### DIFF
--- a/src/islands/dev/SortLines.tsx
+++ b/src/islands/dev/SortLines.tsx
@@ -103,11 +103,13 @@ export default function SortLines({ lang = 'en' }: { lang?: Lang }) {
 
       <div className="grid gap-3 lg:grid-cols-2">
         <div className="space-y-1">
-          <span className="block text-sm font-semibold">{t.input}</span>
+          <div className="flex min-h-9 items-center">
+            <span className="text-sm font-semibold">{t.input}</span>
+          </div>
           <TextArea value={text} onChange={e => setText(e.target.value)} rows={14} placeholder={t.placeholder} />
         </div>
         <div className="space-y-1">
-          <div className="flex items-center justify-between">
+          <div className="flex min-h-9 items-center justify-between">
             <span className="text-sm font-semibold">{t.output} <span className="font-normal text-muted-foreground">· {t.count(outCount)}</span></span>
             <div className="flex gap-2">
               <DownloadTextButton text={output} filename="sorted.txt" />

--- a/src/tools/dev/sort-lines.lib.test.ts
+++ b/src/tools/dev/sort-lines.lib.test.ts
@@ -36,6 +36,10 @@ describe('sortTextLines', () => {
     expect(sortTextLines(input, { byKey: true, caseInsensitive: true, dedupe: true }))
       .toBe('API_KEY=1\napi_key=1\ndb_host=x\nZONE=us');
   });
+  it('parks blank lines at the end so content stays on top', () => {
+    expect(sortTextLines('b\n\na\n\nc')).toBe('a\nb\nc\n\n');
+    expect(sortTextLines('b\n\na', { direction: 'desc' })).toBe('b\na\n');
+  });
   it('returns empty for empty input', () => {
     expect(sortTextLines('', { dropBlanks: true })).toBe('');
   });

--- a/src/tools/dev/sort-lines.lib.ts
+++ b/src/tools/dev/sort-lines.lib.ts
@@ -54,7 +54,12 @@ export function sortTextLines(text: string, opts: SortLinesOptions = {}): string
     sensitivity: caseInsensitive ? 'base' : 'variant',
   });
   const keyOf = byKey ? (l: string) => l.split(/[=:]/, 1)[0] : (l: string) => l;
-  lines.sort((a, b) => collator.compare(keyOf(a), keyOf(b)));
-  if (direction === 'desc') lines.reverse();
-  return lines.join('\n');
+  // Keep blank lines out of the sort and park them at the end — sorting them
+  // inline floats every blank above the real content, so the output looks empty.
+  const blanks: string[] = [];
+  const content: string[] = [];
+  for (const l of lines) (l.trim() === '' ? blanks : content).push(l);
+  content.sort((a, b) => collator.compare(keyOf(a), keyOf(b)));
+  if (direction === 'desc') content.reverse();
+  return [...content, ...blanks].join('\n');
 }


### PR DESCRIPTION
Blank lines now sort to the end (were floating to the top and making the output look empty). Input/output textareas aligned (headers equal height).